### PR TITLE
fix: channels not working searchConfig invalid json

### DIFF
--- a/EMS/core-bundle/src/Entity/Channel.php
+++ b/EMS/core-bundle/src/Entity/Channel.php
@@ -139,7 +139,7 @@ class Channel extends JsonDeserializer implements \JsonSerializable, EntityInter
      */
     public function getOptions(): array
     {
-        return $this->options ?? [];
+        return \array_filter($this->options ?? []);
     }
 
     /**


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

If the searchConfig is '', it's removed from the getOptions return value.
