### PR TITLE
fix: json syntax error with empty string

### DIFF
--- a/EMS/common-bundle/src/Service/ElasticaService.php
+++ b/EMS/common-bundle/src/Service/ElasticaService.php
@@ -454,11 +454,11 @@ class ElasticaService
                 return $value;
             })
             ->setNormalizer('body', function (Options $options, $value) {
+                if (null === $value || '' === $value) {
+                    return [];
+                }
                 if (\is_string($value)) {
                     $value = \json_decode($value, true, 512, JSON_THROW_ON_ERROR);
-                }
-                if (null === $value) {
-                    return [];
                 }
 
                 return $value;


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |Y|
|New feature?   |N|
|BC breaks?     |N|
|Deprecations?  |N|
|Fixed tickets  |N|

rector add JSON_THROW_ON_ERROR on json_decode() 