### PR TITLE
fix(core): Upload asset $status accessed before initialization

### DIFF
--- a/EMS/core-bundle/src/Entity/UploadedAsset.php
+++ b/EMS/core-bundle/src/Entity/UploadedAsset.php
@@ -96,7 +96,7 @@ class UploadedAsset implements EntityInterface
     }
 
     /**
-     * @return array{sha1:string, type:string, available:bool, name:string, size:int, status:string, uploaded:int, user:string}
+     * @return array{sha1:string, type:string, available:bool, name:string, size:int, status: ?string, uploaded:int, user:string}
      */
     public function getResponse(): array
     {
@@ -122,26 +122,14 @@ class UploadedAsset implements EntityInterface
         return $this->id;
     }
 
-    /**
-     * Set status.
-     *
-     * @param string $status
-     *
-     * @return UploadedAsset
-     */
-    public function setStatus($status)
+    public function setStatus(?string $status): self
     {
         $this->status = $status;
 
         return $this;
     }
 
-    /**
-     * Get status.
-     *
-     * @return string
-     */
-    public function getStatus()
+    public function getStatus(): ?string
     {
         return $this->status;
     }

--- a/EMS/core-bundle/src/Entity/UploadedAsset.php
+++ b/EMS/core-bundle/src/Entity/UploadedAsset.php
@@ -26,7 +26,7 @@ class UploadedAsset implements EntityInterface
     /**
      * @ORM\Column(name="status", type="string", length=64, nullable=true)
      */
-    private string $status;
+    private ?string $status = null;
 
     /**
      * @ORM\Column(name="sha1", type="string", length=128)


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

Typed property EMS\CoreBundle\Entity\UploadedAsset::$status must not be accessed before initialization
