### PR TITLE
fix: options can be null

### DIFF
--- a/EMS/core-bundle/src/Entity/FieldType.php
+++ b/EMS/core-bundle/src/Entity/FieldType.php
@@ -67,11 +67,11 @@ class FieldType extends JsonDeserializer implements \JsonSerializable
     protected $description;
 
     /**
-     * @var array<mixed>
+     * @var array<mixed>|null
      *
      * @ORM\Column(name="options", type="json", nullable=true)
      */
-    protected array $options = [];
+    protected array|null $options = [];
 
     /**
      * @var int
@@ -709,7 +709,7 @@ class FieldType extends JsonDeserializer implements \JsonSerializable
     }
 
     /**
-     * @param array<mixed> $options
+     * @param array<mixed>|null $options
      */
     public function setOptions(?array $options): self
     {

--- a/EMS/core-bundle/src/Entity/FieldType.php
+++ b/EMS/core-bundle/src/Entity/FieldType.php
@@ -723,7 +723,7 @@ class FieldType extends JsonDeserializer implements \JsonSerializable
      */
     public function getOptions(): array
     {
-        return $this->options;
+        return $this->options ?? [];
     }
 
     public function jsonSerialize(): JsonClass


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

Error loading entity if options is null in the DB
