### PR TITLE
fix: json_decode can't get null and empty string value

### DIFF
--- a/EMS/core-bundle/src/Form/DataTransformer/ChannelOptionsTransformer.php
+++ b/EMS/core-bundle/src/Form/DataTransformer/ChannelOptionsTransformer.php
@@ -39,10 +39,9 @@ final class ChannelOptionsTransformer implements DataTransformerInterface
     {
         $defaultFormatted = (isset($value[$attribute]) && '' !== $value[$attribute]) ? $value[$attribute] : '{}';
         $formatted = \json_decode($defaultFormatted, true, 512, JSON_THROW_ON_ERROR);
-        if (null === $formatted) {
-            return $defaultFormatted;
-        }
 
-        return \json_encode($formatted, JSON_PRETTY_PRINT);
+        return (null !== $formatted && \json_encode($formatted, JSON_PRETTY_PRINT))
+            ? \json_encode($formatted, JSON_PRETTY_PRINT)
+            : '{}';
     }
 }

--- a/EMS/core-bundle/src/Form/DataTransformer/ChannelOptionsTransformer.php
+++ b/EMS/core-bundle/src/Form/DataTransformer/ChannelOptionsTransformer.php
@@ -37,7 +37,7 @@ final class ChannelOptionsTransformer implements DataTransformerInterface
      */
     private function jsonFormat(array $value, string $attribute): string
     {
-        $defaultFormatted = (isset($value[$attribute]) && $value[$attribute] !== '') ? $value[$attribute] : '{}';
+        $defaultFormatted = (isset($value[$attribute]) && '' !== $value[$attribute]) ? $value[$attribute] : '{}';
         $formatted = \json_decode($defaultFormatted, true, 512, JSON_THROW_ON_ERROR);
         if (null === $formatted) {
             return $defaultFormatted;

--- a/EMS/core-bundle/src/Form/DataTransformer/ChannelOptionsTransformer.php
+++ b/EMS/core-bundle/src/Form/DataTransformer/ChannelOptionsTransformer.php
@@ -37,13 +37,12 @@ final class ChannelOptionsTransformer implements DataTransformerInterface
      */
     private function jsonFormat(array $value, string $attribute): string
     {
-        $formatted = \json_decode($value[$attribute] ?? '', true, 512, JSON_THROW_ON_ERROR);
+        $defaultFormatted = (isset($value[$attribute]) && $value[$attribute] !== '') ? $value[$attribute] : '{}';
+        $formatted = \json_decode($defaultFormatted, true, 512, JSON_THROW_ON_ERROR);
         if (null === $formatted) {
-            $formatted = $value[$attribute] ?? '';
-        } else {
-            $formatted = \json_encode($formatted, JSON_PRETTY_PRINT);
+            return $defaultFormatted;
         }
 
-        return $formatted;
+        return \json_encode($formatted, JSON_PRETTY_PRINT);
     }
 }

--- a/EMS/core-bundle/src/Service/Channel/ChannelRegistrar.php
+++ b/EMS/core-bundle/src/Service/Channel/ChannelRegistrar.php
@@ -56,8 +56,10 @@ final class ChannelRegistrar
         }
 
         $baseUrl = \vsprintf('%s://%s%s', [$request->getScheme(), $request->getHttpHost(), $request->getBasePath()]);
-        $searchConfig = \json_decode($channel->getOptions()['searchConfig'] ?? '{}', true, 512, JSON_THROW_ON_ERROR);
-        $attributes = \json_decode($channel->getOptions()['attributes'] ?? null, true, 512, JSON_THROW_ON_ERROR);
+        $defaultSearchConfigOption = (isset($channel->getOptions()['searchConfig']) && $channel->getOptions()['searchConfig'] !== '') ? $channel->getOptions()['searchConfig'] : '{}';
+        $searchConfig = \json_decode($defaultSearchConfigOption, true, 512, JSON_THROW_ON_ERROR);
+        $defaultAttributesOption = (isset($channel->getOptions()['attributes']) && $channel->getOptions()['attributes'] !== '') ? $channel->getOptions()['attributes'] : '{}';
+        $attributes = \json_decode($defaultAttributesOption, true, 512, JSON_THROW_ON_ERROR);
 
         if (!$this->indexService->hasIndex($alias)) {
             $this->logger->warning('log.channel.alias_not_found', [
@@ -74,7 +76,7 @@ final class ChannelRegistrar
             'search_config' => $searchConfig,
         ];
 
-        if (\is_array($attributes)) {
+        if (\is_array($attributes) && \count($attributes) > 0) {
             $options[Environment::REQUEST_CONFIG] = $attributes;
         }
 

--- a/EMS/core-bundle/src/Service/Channel/ChannelRegistrar.php
+++ b/EMS/core-bundle/src/Service/Channel/ChannelRegistrar.php
@@ -56,9 +56,9 @@ final class ChannelRegistrar
         }
 
         $baseUrl = \vsprintf('%s://%s%s', [$request->getScheme(), $request->getHttpHost(), $request->getBasePath()]);
-        $defaultSearchConfigOption = (isset($channel->getOptions()['searchConfig']) && $channel->getOptions()['searchConfig'] !== '') ? $channel->getOptions()['searchConfig'] : '{}';
+        $defaultSearchConfigOption = (isset($channel->getOptions()['searchConfig']) && '' !== $channel->getOptions()['searchConfig']) ? $channel->getOptions()['searchConfig'] : '{}';
         $searchConfig = \json_decode($defaultSearchConfigOption, true, 512, JSON_THROW_ON_ERROR);
-        $defaultAttributesOption = (isset($channel->getOptions()['attributes']) && $channel->getOptions()['attributes'] !== '') ? $channel->getOptions()['attributes'] : '{}';
+        $defaultAttributesOption = (isset($channel->getOptions()['attributes']) && '' !== $channel->getOptions()['attributes']) ? $channel->getOptions()['attributes'] : '{}';
         $attributes = \json_decode($defaultAttributesOption, true, 512, JSON_THROW_ON_ERROR);
 
         if (!$this->indexService->hasIndex($alias)) {


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |Y|
|New feature?   |N|
|BC breaks?     |N|
|Deprecations?  |N|
|Fixed tickets  |N|

Rektor add JSON_THROW_ON_ERROR flag to json_decode so no null or empty_string value anymore
