### PR TITLE
feat: tasks version

### DIFF
--- a/EMS/core-bundle/src/Command/Revision/TaskCreateCommand.php
+++ b/EMS/core-bundle/src/Command/Revision/TaskCreateCommand.php
@@ -119,7 +119,7 @@ final class TaskCreateCommand extends AbstractCommand
 
     private function createTask(Revision $revision, Document $document): void
     {
-        if (!$revision->isTaskEnabled()) {
+        if (!$revision->giveContentType()->tasksEnabled()) {
             $this->io->warning(\sprintf('Skipping revision %s tasks not enabled', $revision));
 
             return;

--- a/EMS/core-bundle/src/Controller/Revision/TaskController.php
+++ b/EMS/core-bundle/src/Controller/Revision/TaskController.php
@@ -10,6 +10,7 @@ use EMS\CoreBundle\Core\Revision\Task\TaskDTO;
 use EMS\CoreBundle\Core\Revision\Task\TaskManager;
 use EMS\CoreBundle\Core\UI\AjaxModal;
 use EMS\CoreBundle\Core\UI\AjaxService;
+use EMS\CoreBundle\Entity\Task;
 use EMS\CoreBundle\Form\Data\EntityTable;
 use EMS\CoreBundle\Form\Revision\Task\RevisionTaskFiltersType;
 use EMS\CoreBundle\Form\Revision\Task\RevisionTaskType;
@@ -99,7 +100,7 @@ final class TaskController extends AbstractController
         $revision = $tasks->getRevision();
         $ajaxTemplate = $this->getAjaxTemplate();
 
-        if ($revision->hasTaskCurrent() && $this->taskManager->isTaskRequester($revision->getTaskCurrent())) {
+        if ($revision->hasTaskCurrent() && Task::STATUS_PROGRESS !== $revision->getTaskCurrent()->getStatus()) {
             $action = $request->get('action');
             $formValidation = $this->createCommentForm('validation', 'approve' !== $action);
             $formValidation->handleRequest($request);

--- a/EMS/core-bundle/src/Controller/Revision/TaskController.php
+++ b/EMS/core-bundle/src/Controller/Revision/TaskController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace EMS\CoreBundle\Controller\Revision;
 
-use EMS\CoreBundle\Core\ContentType\ContentTypeRoles;
 use EMS\CoreBundle\Core\DataTable\TableExporter;
 use EMS\CoreBundle\Core\Revision\Task\Table\TaskTableFilters;
 use EMS\CoreBundle\Core\Revision\Task\TaskDTO;
@@ -12,13 +11,11 @@ use EMS\CoreBundle\Core\Revision\Task\TaskManager;
 use EMS\CoreBundle\Core\UI\AjaxModal;
 use EMS\CoreBundle\Core\UI\AjaxService;
 use EMS\CoreBundle\Form\Data\EntityTable;
-use EMS\CoreBundle\Form\Field\SelectUserPropertyType;
 use EMS\CoreBundle\Form\Revision\Task\RevisionTaskFiltersType;
 use EMS\CoreBundle\Form\Revision\Task\RevisionTaskType;
 use EMS\CoreBundle\Helper\DataTableRequest;
 use EMS\Helpers\Standard\Json;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
@@ -102,7 +99,7 @@ final class TaskController extends AbstractController
         $revision = $tasks->getRevision();
         $ajaxTemplate = $this->getAjaxTemplate();
 
-        if ($this->taskManager->isTaskOwnerRevision($revision)) {
+        if ($revision->hasTaskCurrent() && $this->taskManager->isTaskRequester($revision->getTaskCurrent())) {
             $action = $request->get('action');
             $formValidation = $this->createCommentForm('validation', 'approve' !== $action);
             $formValidation->handleRequest($request);
@@ -232,50 +229,6 @@ final class TaskController extends AbstractController
         return $this->getAjaxModal()
             ->setFooter('modalFooterClose')
             ->setBody('modalHistoryBody', ['task' => $this->taskManager->getTask($taskId)])
-            ->getResponse();
-    }
-
-    public function ajaxModalChangeOwner(Request $request, int $revisionId): JsonResponse
-    {
-        $revision = $this->taskManager->getRevision($revisionId);
-        $contentType = $revision->giveContentType();
-
-        $ajaxModal = $this->getAjaxModal();
-        $ajaxModal->setTitle('task.change_owner.title', ['%revision%' => $revision->getLabel()]);
-
-        $form = $this->formFactory->createNamed('task_change_owner', FormType::class, [], [
-            'translation_domain' => 'EMSCoreBundle',
-        ]);
-        $form->add('new_owner', SelectUserPropertyType::class, [
-            'constraints' => [new NotBlank()],
-            'user_roles' => [$contentType->role(ContentTypeRoles::OWNER)],
-            'exclude_values' => $revision->hasOwner() ? [$revision->getOwner()] : [],
-            'placeholder' => '',
-            'label' => 'task.change_owner.change',
-            'allow_add' => false,
-            'user_property' => 'username',
-            'label_property' => 'displayName',
-        ]);
-
-        $form->handleRequest($request);
-
-        if ($form->isSubmitted() && $form->isValid()) {
-            try {
-                $this->taskManager->changeOwner($revision, $form->get('new_owner')->getData());
-
-                return $ajaxModal
-                    ->addMessageSuccess('task.change_owner.success')
-                    ->setBodyHtml('')
-                    ->setFooter('modalFooterClose')
-                    ->getResponse();
-            } catch (\Throwable) {
-                $ajaxModal->addMessageError('task.error.ajax');
-            }
-        }
-
-        return $ajaxModal
-            ->setBody('modalChangeOwnerBody', ['revision' => $revision, 'form' => $form->createView()])
-            ->setFooter('modalChangeOwnerFooter')
             ->getResponse();
     }
 

--- a/EMS/core-bundle/src/Core/ContentType/ContentTypeRoles.php
+++ b/EMS/core-bundle/src/Core/ContentType/ContentTypeRoles.php
@@ -21,7 +21,6 @@ class ContentTypeRoles implements \ArrayAccess
     final public const DELETE = 'delete';
     final public const TRASH = 'trash';
     final public const ARCHIVE = 'archive';
-    final public const OWNER = 'owner';
     final public const SHOW_LINK_CREATE = 'show_link_create';
     final public const SHOW_LINK_SEARCH = 'show_link_search';
 
@@ -33,7 +32,6 @@ class ContentTypeRoles implements \ArrayAccess
         self::DELETE,
         self::TRASH,
         self::ARCHIVE,
-        self::OWNER,
         self::SHOW_LINK_CREATE,
         self::SHOW_LINK_SEARCH,
     ];

--- a/EMS/core-bundle/src/Core/ContentType/ContentTypeSettings.php
+++ b/EMS/core-bundle/src/Core/ContentType/ContentTypeSettings.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\Core\ContentType;
+
+/**
+ * @implements \ArrayAccess<string, bool>
+ */
+class ContentTypeSettings implements \ArrayAccess
+{
+    /** @var array<string, bool> */
+    private array $settings = [];
+
+    final public const TASKS_ENABLED = 'tasks_enabled';
+
+    private const SETTINGS = [
+        self::TASKS_ENABLED,
+    ];
+
+    /**
+     * @param array<string, bool> $data
+     */
+    public function __construct(array $data)
+    {
+        foreach (self::SETTINGS as $field) {
+            $this->settings[$field] = $data[$field] ?? false;
+        }
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    public function getSettings(): array
+    {
+        return $this->settings;
+    }
+
+    public function offsetExists($offset): bool
+    {
+        return isset($this->settings[$offset]);
+    }
+
+    public function offsetGet($offset): bool
+    {
+        return $this->settings[$offset];
+    }
+
+    public function offsetSet($offset, $value): void
+    {
+        $this->settings[$offset] = $value;
+    }
+
+    public function offsetUnset($offset): void
+    {
+        unset($this->settings[$offset]);
+    }
+}

--- a/EMS/core-bundle/src/Core/Revision/Task/Table/TaskTableFilters.php
+++ b/EMS/core-bundle/src/Core/Revision/Task/Table/TaskTableFilters.php
@@ -11,7 +11,7 @@ class TaskTableFilters
     /** @var string[] */
     public array $assignee = [];
     /** @var string[] */
-    public array $owner = [];
+    public array $requester = [];
 
     /**
      * @return array<string, string[]>
@@ -21,7 +21,7 @@ class TaskTableFilters
         return \array_filter([
             TaskTableService::COL_STATUS => $this->status,
             TaskTableService::COL_ASSIGNEE => $this->assignee,
-            TaskTableService::COL_OWNER => $this->owner,
+            TaskTableService::COL_REQUESTER => $this->requester,
         ]);
     }
 }

--- a/EMS/core-bundle/src/Core/Revision/Task/Table/TaskTableFilters.php
+++ b/EMS/core-bundle/src/Core/Revision/Task/Table/TaskTableFilters.php
@@ -9,8 +9,6 @@ class TaskTableFilters
     /** @var string[] */
     public array $status = [];
     /** @var string[] */
-    public array $version = [];
-    /** @var string[] */
     public array $assignee = [];
     /** @var string[] */
     public array $owner = [];
@@ -22,7 +20,6 @@ class TaskTableFilters
     {
         return \array_filter([
             TaskTableService::COL_STATUS => $this->status,
-            TaskTableService::COL_DOCUMENT_VERSION => $this->version,
             TaskTableService::COL_ASSIGNEE => $this->assignee,
             TaskTableService::COL_OWNER => $this->owner,
         ]);

--- a/EMS/core-bundle/src/Core/Revision/Task/Table/TaskTableService.php
+++ b/EMS/core-bundle/src/Core/Revision/Task/Table/TaskTableService.php
@@ -16,7 +16,7 @@ final class TaskTableService implements EntityServiceInterface
 {
     private const COL_TITLE = 'title';
     private const COL_DOCUMENT = 'label';
-    public const COL_DOCUMENT_VERSION = 'version';
+    public const COL_VERSION_TAG = 'version_tag';
     public const COL_OWNER = 'owner';
     public const COL_ASSIGNEE = 'assignee';
     public const COL_STATUS = 'status';
@@ -29,13 +29,13 @@ final class TaskTableService implements EntityServiceInterface
     public const COLUMNS = [
         self::COL_TITLE => ['type' => 'block', 'column' => 'taskTitle', 'mapping' => 't.title'],
         self::COL_DOCUMENT => ['column' => 'label', 'mapping' => 'r.labelField'],
-        self::COL_DOCUMENT_VERSION => ['type' => 'block', 'column' => 'versionTag', 'mapping' => 'r.versionTag'],
+        self::COL_VERSION_TAG => ['type' => 'block'],
         self::COL_OWNER => ['type' => 'block', 'column' => 'owner', 'mapping' => 'r.owner'],
         self::COL_ASSIGNEE => ['type' => 'block', 'column' => 'taskAssignee', 'mapping' => 't.assignee'],
         self::COL_STATUS => ['type' => 'block', 'column' => 'taskStatus', 'mapping' => 't.status'],
         self::COL_DEADLINE => ['type' => 'block', 'column' => 'taskDeadline', 'mapping' => 't.deadline'],
         self::COL_MODIFIED => ['type' => 'block', 'column' => 'taskModified', 'mapping' => 't.modified'],
-        self::COL_ACTIONS => ['type' => 'block'],
+        self::COL_ACTIONS => ['type' => 'block', 'label'],
     ];
 
     public function __construct(private readonly TaskRepository $taskRepository)
@@ -47,7 +47,7 @@ final class TaskTableService implements EntityServiceInterface
         /** @var array<string, array{type: ?string, column: ?string, label: string, mapping?: string}> $columns */
         $columns = $this->getColumns($context);
 
-        $disableSorting = [self::COL_ASSIGNEE, self::COL_OWNER, self::COL_DOCUMENT_VERSION, self::COL_ACTIONS];
+        $disableSorting = [self::COL_ASSIGNEE, self::COL_OWNER, self::COL_VERSION_TAG, self::COL_ACTIONS];
 
         foreach ($columns as $name => $options) {
             $orderField = !\in_array($name, $disableSorting) ? $name : null;
@@ -135,7 +135,7 @@ final class TaskTableService implements EntityServiceInterface
             unset($columns[self::COL_OWNER]);
         }
         if (!$context->showVersionTagColumn) {
-            unset($columns[self::COL_DOCUMENT_VERSION]);
+            unset($columns[self::COL_VERSION_TAG]);
         }
 
         foreach ($columns as $name => &$column) {

--- a/EMS/core-bundle/src/Core/Revision/Task/Table/TaskTableService.php
+++ b/EMS/core-bundle/src/Core/Revision/Task/Table/TaskTableService.php
@@ -17,7 +17,7 @@ final class TaskTableService implements EntityServiceInterface
     private const COL_TITLE = 'title';
     private const COL_DOCUMENT = 'label';
     public const COL_VERSION_TAG = 'version_tag';
-    public const COL_OWNER = 'owner';
+    public const COL_REQUESTER = 'requester';
     public const COL_ASSIGNEE = 'assignee';
     public const COL_STATUS = 'status';
     private const COL_DEADLINE = 'deadline';
@@ -30,7 +30,7 @@ final class TaskTableService implements EntityServiceInterface
         self::COL_TITLE => ['type' => 'block', 'column' => 'taskTitle', 'mapping' => 't.title'],
         self::COL_DOCUMENT => ['column' => 'label', 'mapping' => 'r.labelField'],
         self::COL_VERSION_TAG => ['type' => 'block'],
-        self::COL_OWNER => ['type' => 'block', 'column' => 'owner', 'mapping' => 'r.owner'],
+        self::COL_REQUESTER => ['type' => 'block', 'column' => 'requester', 'mapping' => 't.createdBy'],
         self::COL_ASSIGNEE => ['type' => 'block', 'column' => 'taskAssignee', 'mapping' => 't.assignee'],
         self::COL_STATUS => ['type' => 'block', 'column' => 'taskStatus', 'mapping' => 't.status'],
         self::COL_DEADLINE => ['type' => 'block', 'column' => 'taskDeadline', 'mapping' => 't.deadline'],
@@ -47,7 +47,7 @@ final class TaskTableService implements EntityServiceInterface
         /** @var array<string, array{type: ?string, column: ?string, label: string, mapping?: string}> $columns */
         $columns = $this->getColumns($context);
 
-        $disableSorting = [self::COL_ASSIGNEE, self::COL_OWNER, self::COL_VERSION_TAG, self::COL_ACTIONS];
+        $disableSorting = [self::COL_ASSIGNEE, self::COL_VERSION_TAG, self::COL_ACTIONS];
 
         foreach ($columns as $name => $options) {
             $orderField = !\in_array($name, $disableSorting) ? $name : null;
@@ -131,8 +131,8 @@ final class TaskTableService implements EntityServiceInterface
         if (TaskManager::TAB_USER === $context->tab) {
             unset($columns[self::COL_ASSIGNEE]);
         }
-        if (TaskManager::TAB_OWNER === $context->tab) {
-            unset($columns[self::COL_OWNER]);
+        if (TaskManager::TAB_REQUESTER === $context->tab) {
+            unset($columns[self::COL_REQUESTER]);
         }
         if (!$context->showVersionTagColumn) {
             unset($columns[self::COL_VERSION_TAG]);

--- a/EMS/core-bundle/src/Core/Revision/Task/TaskEvent.php
+++ b/EMS/core-bundle/src/Core/Revision/Task/TaskEvent.php
@@ -32,9 +32,9 @@ class TaskEvent extends Event
         return $this->revision->isTaskCurrent($this->task);
     }
 
-    public function isAssigneeIsOwner(): bool
+    public function isAssigneeIsRequester(): bool
     {
-        return $this->revision->hasOwner() && $this->revision->getOwner() === $this->task->getAssignee();
+        return $this->task->getCreatedBy() === $this->task->getAssignee();
     }
 
     public function setComment(?string $comment): void

--- a/EMS/core-bundle/src/Core/Revision/Task/TaskEventSubscriber.php
+++ b/EMS/core-bundle/src/Core/Revision/Task/TaskEventSubscriber.php
@@ -89,8 +89,8 @@ final class TaskEventSubscriber implements EventSubscriberInterface
     {
         $this->updateStatus($event, Task::STATUS_COMPLETED);
 
-        if ($event->isTaskCurrent() && $event->revision->hasOwner()) {
-            $this->sendMail($event, 'completed', $event->revision->getOwner());
+        if ($event->isTaskCurrent()) {
+            $this->sendMail($event, 'completed', $event->task->getCreatedBy());
         }
     }
 
@@ -131,7 +131,7 @@ final class TaskEventSubscriber implements EventSubscriberInterface
 
         if (null === $receiver
             || !$receiver->getEmailNotification()
-            || (Task::STATUS_COMPLETED !== $type && $event->isAssigneeIsOwner())) {
+            || (Task::STATUS_COMPLETED !== $type && $event->isAssigneeIsRequester())) {
             return;
         }
 

--- a/EMS/core-bundle/src/Core/Revision/Task/TaskManager.php
+++ b/EMS/core-bundle/src/Core/Revision/Task/TaskManager.php
@@ -161,7 +161,7 @@ final class TaskManager
 
     public function taskCreateFromRevision(TaskDTO $taskDTO, Revision $revision, string $username): Task
     {
-        $task = Task::createFromDTO($taskDTO);
+        $task = Task::createFromDTO($taskDTO, $username);
         $revision->addTask($task, $username);
 
         $this->dispatchEvent($this->createTaskEvent($task, $revision, $username), TaskEvent::CREATE);

--- a/EMS/core-bundle/src/Core/Revision/Task/TaskManager.php
+++ b/EMS/core-bundle/src/Core/Revision/Task/TaskManager.php
@@ -20,7 +20,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 final class TaskManager
 {
     public const TAB_USER = 'user';
-    public const TAB_OWNER = 'owner';
+    public const TAB_REQUESTER = 'requester';
     public const TAB_MANAGER = 'manager';
 
     public function __construct(private readonly TaskRepository $taskRepository, private readonly TaskTableService $taskTableService, private readonly RevisionRepository $revisionRepository, private readonly DataService $dataService, private readonly UserService $userService, private readonly EventDispatcherInterface $eventDispatcher, private readonly LoggerInterface $logger)
@@ -32,16 +32,6 @@ final class TaskManager
         return $this->taskRepository->countApproved($revision);
     }
 
-    public function changeOwner(Revision $revision, string $newOwner): void
-    {
-        $transaction = $this->revisionTransaction(function (Revision $revision) use ($newOwner) {
-            $revision->setOwner($newOwner);
-            $this->revisionRepository->save($revision);
-        });
-
-        $transaction($revision->getId());
-    }
-
     /**
      * @return string[]
      */
@@ -49,7 +39,7 @@ final class TaskManager
     {
         return \array_filter([
             self::TAB_USER,
-            $this->isTaskOwner() ? self::TAB_OWNER : null,
+            self::TAB_REQUESTER,
             $this->isTaskManager() ? self::TAB_MANAGER : null,
         ]);
     }
@@ -127,18 +117,11 @@ final class TaskManager
         return $task->getAssignee() === $user->getUsername();
     }
 
-    public function isTaskOwner(): bool
+    public function isTaskRequester(Task $task): bool
     {
         $user = $this->userService->getCurrentUser();
 
-        return $this->taskRepository->countForOwner($user) > 0;
-    }
-
-    public function isTaskOwnerRevision(Revision $revision): bool
-    {
-        $user = $this->userService->getCurrentUser();
-
-        return $revision->hasOwner() && $revision->getOwner() === $user->getUsername();
+        return $task->getCreatedBy() === $user->getUsername();
     }
 
     public function isTaskManager(): bool
@@ -162,7 +145,7 @@ final class TaskManager
     public function taskCreateFromRevision(TaskDTO $taskDTO, Revision $revision, string $username): Task
     {
         $task = Task::createFromDTO($taskDTO, $username);
-        $revision->addTask($task, $username);
+        $revision->addTask($task);
 
         $this->dispatchEvent($this->createTaskEvent($task, $revision, $username), TaskEvent::CREATE);
         if ($revision->isTaskCurrent($task)) {
@@ -216,7 +199,7 @@ final class TaskManager
 
             if ($approve) {
                 $this->dispatchEvent($event, TaskEvent::APPROVED);
-                $revision->addTask($task, $revision->getOwner());
+                $revision->addTask($task);
                 $this->setNextPlanned($revision);
             } else {
                 $revision->updateModified();
@@ -254,7 +237,7 @@ final class TaskManager
             $oldCurrentTask = $revision->getTaskCurrent();
             $orderTaskCurrent = $this->getTask($orderCurrentTaskId);
 
-            if ($revision->taskCurrentReplace($orderTaskCurrent, $user->getUsername())) {
+            if ($revision->taskCurrentReplace($orderTaskCurrent)) {
                 $this->dispatchEvent($this->createTaskEvent($oldCurrentTask, $revision), TaskEvent::PLANNED);
                 $this->dispatchEvent($this->createTaskEvent($orderTaskCurrent, $revision), TaskEvent::PROGRESS);
             }

--- a/EMS/core-bundle/src/Entity/ContentType.php
+++ b/EMS/core-bundle/src/Entity/ContentType.php
@@ -7,6 +7,7 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use EMS\CoreBundle\Core\ContentType\ContentTypeFields;
 use EMS\CoreBundle\Core\ContentType\ContentTypeRoles;
+use EMS\CoreBundle\Core\ContentType\ContentTypeSettings;
 use EMS\CoreBundle\Core\ContentType\Version\VersionFields;
 use EMS\CoreBundle\Core\ContentType\Version\VersionOptions;
 use EMS\CoreBundle\Entity\Helper\JsonClass;
@@ -17,8 +18,6 @@ use EMS\Helpers\Standard\DateTime;
 use EMS\Helpers\Standard\Type;
 
 /**
- * ContentType.
- *
  * @ORM\Table(name="content_type")
  * @ORM\Entity(repositoryClass="EMS\CoreBundle\Repository\ContentTypeRepository")
  * @ORM\HasLifecycleCallbacks()
@@ -243,6 +242,13 @@ class ContentType extends JsonDeserializer implements \JsonSerializable, EntityI
      * @ORM\Column(name="fields", type="json", nullable=true)
      */
     protected array $fields = [];
+
+    /**
+     * @var array<string, bool>
+     *
+     * @ORM\Column(name="settings", type="json", nullable=true)
+     */
+    protected ?array $settings = null;
 
     public function __construct()
     {
@@ -1186,5 +1192,20 @@ class ContentType extends JsonDeserializer implements \JsonSerializable, EntityI
     public function setFields(ContentTypeFields $fields): void
     {
         $this->fields = $fields->getFields();
+    }
+
+    public function tasksEnabled(): bool
+    {
+        return $this->getSettings()[ContentTypeSettings::TASKS_ENABLED] ?? false;
+    }
+
+    public function getSettings(): ContentTypeSettings
+    {
+        return new ContentTypeSettings($this->settings ?? []);
+    }
+
+    public function setSettings(ContentTypeSettings $settings): void
+    {
+        $this->settings = $settings->getSettings();
     }
 }

--- a/EMS/core-bundle/src/Entity/Revision.php
+++ b/EMS/core-bundle/src/Entity/Revision.php
@@ -243,7 +243,6 @@ class Revision implements EntityInterface, \Stringable
                 $this->rawData = $ancestor->rawData;
                 $this->circles = $ancestor->circles;
                 $this->dataField = new DataField($ancestor->dataField);
-                $this->owner = $ancestor->owner;
                 $this->taskCurrent = $ancestor->taskCurrent;
                 $this->taskPlannedIds = $ancestor->taskPlannedIds;
                 $this->taskApprovedIds = $ancestor->taskApprovedIds;

--- a/EMS/core-bundle/src/Entity/RevisionTaskTrait.php
+++ b/EMS/core-bundle/src/Entity/RevisionTaskTrait.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace EMS\CoreBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
-use EMS\CoreBundle\Core\ContentType\ContentTypeRoles;
-use EMS\CoreBundle\Roles;
 
 trait RevisionTaskTrait
 {
@@ -30,21 +28,8 @@ trait RevisionTaskTrait
      */
     private ?array $taskApprovedIds = [];
 
-    /**
-     * @ORM\Column(name="owner", type="text", nullable=true)
-     */
-    private ?string $owner = null;
-
-    public function addTask(Task $task, string $username): void
+    public function addTask(Task $task): void
     {
-        if (null === $this->owner) {
-            $this->owner = $username;
-        }
-
-        if ($this->owner !== $username) {
-            throw new \RuntimeException(\sprintf('User %s is the owner!', $this->owner));
-        }
-
         if (null === $this->taskCurrent) {
             $this->taskCurrent = $task;
         } elseif (Task::STATUS_PLANNED === $task->getStatus()) {
@@ -54,13 +39,13 @@ trait RevisionTaskTrait
         }
     }
 
-    public function taskCurrentReplace(Task $newTaskCurrent, string $username): bool
+    public function taskCurrentReplace(Task $newTaskCurrent): bool
     {
         if ($this->hasTaskCurrent() && $newTaskCurrent->getId() === $this->getTaskCurrent()->getId()) {
             return false;
         }
 
-        $this->addTask($this->getTaskCurrent(), $username);
+        $this->addTask($this->getTaskCurrent());
         $this->taskCurrent = $newTaskCurrent;
         $this->deleteTaskPlanned($newTaskCurrent);
 
@@ -134,15 +119,6 @@ trait RevisionTaskTrait
         return $this->getTaskCurrent()->getTitle();
     }
 
-    public function getOwner(): string
-    {
-        if (null === $owner = $this->owner) {
-            throw new \RuntimeException('Revision has no owner');
-        }
-
-        return $owner;
-    }
-
     public function getTaskNextPlannedId(): ?string
     {
         if (!$this->hasTaskPlannedIds()) {
@@ -159,11 +135,6 @@ trait RevisionTaskTrait
     public function hasTasks(bool $includeApproved = true): bool
     {
         return $this->hasTaskCurrent() || $this->hasTaskPlannedIds() || ($includeApproved && $this->hasTaskApprovedIds());
-    }
-
-    public function hasOwner(): bool
-    {
-        return null !== $this->owner;
     }
 
     public function hasTaskCurrent(): bool
@@ -198,12 +169,7 @@ trait RevisionTaskTrait
 
     public function isTaskEnabled(): bool
     {
-        return Roles::NOT_DEFINED !== $this->giveContentType()->role(ContentTypeRoles::OWNER);
-    }
-
-    public function setOwner(string $owner): void
-    {
-        $this->owner = $owner;
+        return true; // @todo option on contentType?
     }
 
     public function setTaskCurrent(?Task $task): void

--- a/EMS/core-bundle/src/Entity/RevisionTaskTrait.php
+++ b/EMS/core-bundle/src/Entity/RevisionTaskTrait.php
@@ -167,11 +167,6 @@ trait RevisionTaskTrait
         return \in_array($task->getId(), $this->getTaskApprovedIds(), true);
     }
 
-    public function isTaskEnabled(): bool
-    {
-        return true; // @todo option on contentType?
-    }
-
     public function setTaskCurrent(?Task $task): void
     {
         $this->taskCurrent = $task;

--- a/EMS/core-bundle/src/Entity/Task.php
+++ b/EMS/core-bundle/src/Entity/Task.php
@@ -54,9 +54,14 @@ class Task implements EntityInterface
     /**
      * @var array<mixed>
      *
-     * @ORM\Column(name="logs", type="json", nullable=false)
+     * @ORM\Column(name="logs", type="json")
      */
     private array $logs;
+
+    /**
+     * @ORM\Column(name="created_by", type="text")
+     */
+    private string $createdBy;
 
     final public const STATUS_PROGRESS = 'progress';
     final public const STATUS_PLANNED = 'planned';
@@ -72,11 +77,12 @@ class Task implements EntityInterface
         self::STATUS_APPROVED => ['icon' => 'fa fa-check', 'bg' => 'green', 'text' => 'success', 'label' => 'success'],
     ];
 
-    public function __construct()
+    public function __construct(string $username)
     {
         $this->id = Uuid::uuid4();
         $this->created = DateTime::create('now');
         $this->modified = DateTime::create('now');
+        $this->createdBy = $username;
     }
 
     public function addLog(TaskLog $taskLog): void
@@ -84,9 +90,9 @@ class Task implements EntityInterface
         $this->logs[] = $taskLog->getData();
     }
 
-    public static function createFromDTO(TaskDTO $dto): Task
+    public static function createFromDTO(TaskDTO $dto, string $username): Task
     {
-        $task = new self();
+        $task = new self($username);
         $task->updateFromDTO($dto);
 
         return $task;
@@ -237,5 +243,15 @@ class Task implements EntityInterface
     public function getName(): string
     {
         return $this->getId();
+    }
+
+    public function getCreatedBy(): string
+    {
+        return $this->createdBy;
+    }
+
+    public function setCreatedBy(string $createdBy): void
+    {
+        $this->createdBy = $createdBy;
     }
 }

--- a/EMS/core-bundle/src/Form/Form/ContentTypeRolesType.php
+++ b/EMS/core-bundle/src/Form/Form/ContentTypeRolesType.php
@@ -28,7 +28,6 @@ class ContentTypeRolesType extends AbstractType
                 ->add(ContentTypeRoles::DELETE, RolePickerType::class)
                 ->add(ContentTypeRoles::TRASH, RolePickerType::class)
                 ->add(ContentTypeRoles::ARCHIVE, RolePickerType::class)
-                ->add(ContentTypeRoles::OWNER, RolePickerType::class)
                 ->add(ContentTypeRoles::SHOW_LINK_CREATE, RolePickerType::class)
             ;
         }

--- a/EMS/core-bundle/src/Form/Form/ContentTypeSettingsType.php
+++ b/EMS/core-bundle/src/Form/Form/ContentTypeSettingsType.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\Form\Form;
+
+use EMS\CoreBundle\Core\ContentType\ContentTypeSettings;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class ContentTypeSettingsType extends AbstractType
+{
+    /**
+     * @param FormBuilderInterface<FormBuilderInterface> $builder
+     * @param array<string, mixed>                       $options
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add(ContentTypeSettings::TASKS_ENABLED, CheckboxType::class, ['required' => false])
+        ;
+    }
+}

--- a/EMS/core-bundle/src/Form/Form/ContentTypeType.php
+++ b/EMS/core-bundle/src/Form/Form/ContentTypeType.php
@@ -147,6 +147,9 @@ class ContentTypeType extends AbstractType
             'managed' => $environment->getManaged(),
             'label' => false,
         ]);
+        $builder->add('settings', ContentTypeSettingsType::class, [
+            'label' => false,
+        ]);
 
         if (null !== $mapping) {
             $builder->add('fields', ContentTypeFieldsType::class, [

--- a/EMS/core-bundle/src/Form/Revision/Task/RevisionTaskFiltersType.php
+++ b/EMS/core-bundle/src/Form/Revision/Task/RevisionTaskFiltersType.php
@@ -43,8 +43,8 @@ class RevisionTaskFiltersType extends AbstractType
                 'label_property' => 'displayName',
             ]);
         }
-        if (TaskManager::TAB_OWNER !== $options['tab']) {
-            $builder->add('owner', SelectUserPropertyType::class, [
+        if (TaskManager::TAB_REQUESTER !== $options['tab']) {
+            $builder->add('requester', SelectUserPropertyType::class, [
                 'required' => false,
                 'allow_add' => false,
                 'multiple' => true,

--- a/EMS/core-bundle/src/Form/Revision/Task/RevisionTaskFiltersType.php
+++ b/EMS/core-bundle/src/Form/Revision/Task/RevisionTaskFiltersType.php
@@ -8,7 +8,6 @@ use EMS\CoreBundle\Core\Revision\Task\Table\TaskTableFilters;
 use EMS\CoreBundle\Core\Revision\Task\TaskManager;
 use EMS\CoreBundle\Entity\Task;
 use EMS\CoreBundle\Form\Field\SelectUserPropertyType;
-use EMS\CoreBundle\Service\ContentTypeService;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -18,10 +17,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class RevisionTaskFiltersType extends AbstractType
 {
     final public const NAME = 'filters';
-
-    public function __construct(private readonly ContentTypeService $contentTypeService)
-    {
-    }
 
     /**
      * @param FormBuilderInterface<FormBuilderInterface> $builder
@@ -38,16 +33,6 @@ class RevisionTaskFiltersType extends AbstractType
                 'Completed' => Task::STATUS_COMPLETED,
             ],
         ]);
-
-        $versionTags = $this->contentTypeService->getAllVersionTags();
-        if (\count($versionTags) > 0) {
-            $builder->add('version', ChoiceType::class, [
-                'required' => false,
-                'multiple' => true,
-                'attr' => ['class' => 'select2'],
-                'choices' => \array_combine($versionTags, $versionTags),
-            ]);
-        }
 
         if (TaskManager::TAB_USER !== $options['tab']) {
             $builder->add('assignee', SelectUserPropertyType::class, [

--- a/EMS/core-bundle/src/Repository/TaskRepository.php
+++ b/EMS/core-bundle/src/Repository/TaskRepository.php
@@ -13,7 +13,6 @@ use EMS\CoreBundle\Core\Revision\Task\TaskManager;
 use EMS\CoreBundle\Entity\ContentType;
 use EMS\CoreBundle\Entity\Revision;
 use EMS\CoreBundle\Entity\Task;
-use EMS\CoreBundle\Entity\UserInterface;
 
 /**
  * @extends ServiceEntityRepository<Task>
@@ -23,34 +22,6 @@ final class TaskRepository extends ServiceEntityRepository
     public function __construct(Registry $registry)
     {
         parent::__construct($registry, Task::class);
-    }
-
-    public function countForOwner(UserInterface $user): int
-    {
-        $qb = $this->_em->createQueryBuilder();
-        $qb
-            ->select('count(r.id)')
-            ->from(Revision::class, 'r')
-            ->where('r.endTime is null')
-            ->andWhere($qb->expr()->eq('r.deleted', ':false'))
-            ->andWhere($qb->expr()->eq('r.owner', ':username'))
-            ->setParameters([
-                'username' => $user->getUsername(),
-                'false' => false,
-            ]);
-
-        return \intval($qb->getQuery()->getSingleScalarResult());
-    }
-
-    public function countForUser(UserInterface $user): int
-    {
-        $qb = $this->createQueryBuilder('t');
-        $qb
-            ->select('count(t.id)')
-            ->andWhere($qb->expr()->eq('t.assignee', ':username'))
-            ->setParameter('username', $user->getUsername());
-
-        return \intval($qb->getQuery()->getSingleScalarResult());
     }
 
     public function countApproved(Revision $revision): int
@@ -106,9 +77,9 @@ final class TaskRepository extends ServiceEntityRepository
                     ->andWhere($qb->expr()->eq('t.assignee', ':username'))
                     ->setParameter('username', $context->user->getUsername());
                 break;
-            case TaskManager::TAB_OWNER:
+            case TaskManager::TAB_REQUESTER:
                 $qb
-                    ->andWhere($qb->expr()->eq('r.owner', ':username'))
+                    ->andWhere($qb->expr()->eq('t.createdBy', ':username'))
                     ->setParameter('username', $context->user->getUsername());
                 break;
         }

--- a/EMS/core-bundle/src/Resources/DoctrineMigrations/pdo_mysql/Version20221219150621.php
+++ b/EMS/core-bundle/src/Resources/DoctrineMigrations/pdo_mysql/Version20221219150621.php
@@ -21,6 +21,7 @@ final class Version20221219150621 extends AbstractMigration
         $this->addSql("update task set task.created_by = JSON_UNQUOTE(JSON_EXTRACT(logs, '$[0].username'))");
         $this->addSql('ALTER TABLE task MODIFY created_by LONGTEXT NOT NULL');
         $this->addSql('ALTER TABLE revision DROP owner');
+        $this->addSql('ALTER TABLE content_type ADD settings LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:json)\'');
     }
 
     public function down(Schema $schema): void
@@ -32,5 +33,6 @@ final class Version20221219150621 extends AbstractMigration
 
         $this->addSql('ALTER TABLE task DROP created_by');
         $this->addSql('ALTER TABLE revision ADD owner LONGTEXT DEFAULT NULL');
+        $this->addSql('ALTER TABLE content_type DROP settings');
     }
 }

--- a/EMS/core-bundle/src/Resources/DoctrineMigrations/pdo_mysql/Version20221219150621.php
+++ b/EMS/core-bundle/src/Resources/DoctrineMigrations/pdo_mysql/Version20221219150621.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20221219150621 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof MySQLPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MySQLPlatform'."
+        );
+
+        $this->addSql('ALTER TABLE task ADD created_by LONGTEXT DEFAULT NULL');
+        $this->addSql("update task set task.created_by = JSON_UNQUOTE(JSON_EXTRACT(logs, '$[0].username'))");
+        $this->addSql('ALTER TABLE task MODIFY created_by LONGTEXT NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof MySQLPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MySQLPlatform'."
+        );
+
+        $this->addSql('ALTER TABLE task DROP created_by');
+    }
+}

--- a/EMS/core-bundle/src/Resources/DoctrineMigrations/pdo_mysql/Version20221219150621.php
+++ b/EMS/core-bundle/src/Resources/DoctrineMigrations/pdo_mysql/Version20221219150621.php
@@ -20,6 +20,7 @@ final class Version20221219150621 extends AbstractMigration
         $this->addSql('ALTER TABLE task ADD created_by LONGTEXT DEFAULT NULL');
         $this->addSql("update task set task.created_by = JSON_UNQUOTE(JSON_EXTRACT(logs, '$[0].username'))");
         $this->addSql('ALTER TABLE task MODIFY created_by LONGTEXT NOT NULL');
+        $this->addSql('ALTER TABLE revision DROP owner');
     }
 
     public function down(Schema $schema): void
@@ -30,5 +31,6 @@ final class Version20221219150621 extends AbstractMigration
         );
 
         $this->addSql('ALTER TABLE task DROP created_by');
+        $this->addSql('ALTER TABLE revision ADD owner LONGTEXT DEFAULT NULL');
     }
 }

--- a/EMS/core-bundle/src/Resources/DoctrineMigrations/pdo_pgsql/Version20221219144622.php
+++ b/EMS/core-bundle/src/Resources/DoctrineMigrations/pdo_pgsql/Version20221219144622.php
@@ -22,6 +22,7 @@ final class Version20221219144622 extends AbstractMigration
         $this->addSql('ALTER TABLE task ALTER created_by SET NOT NULL');
 
         $this->addSql('ALTER TABLE revision DROP owner');
+        $this->addSql('ALTER TABLE content_type ADD settings JSON DEFAULT NULL');
     }
 
     public function down(Schema $schema): void
@@ -33,5 +34,6 @@ final class Version20221219144622 extends AbstractMigration
 
         $this->addSql('ALTER TABLE task DROP created_by');
         $this->addSql('ALTER TABLE revision ADD owner TEXT DEFAULT NULL');
+        $this->addSql('ALTER TABLE content_type DROP settings');
     }
 }

--- a/EMS/core-bundle/src/Resources/DoctrineMigrations/pdo_pgsql/Version20221219144622.php
+++ b/EMS/core-bundle/src/Resources/DoctrineMigrations/pdo_pgsql/Version20221219144622.php
@@ -20,6 +20,8 @@ final class Version20221219144622 extends AbstractMigration
         $this->addSql('ALTER TABLE task ADD created_by TEXT DEFAULT NULL');
         $this->addSql("UPDATE task SET created_by = logs->0->>'username'");
         $this->addSql('ALTER TABLE task ALTER created_by SET NOT NULL');
+
+        $this->addSql('ALTER TABLE revision DROP owner');
     }
 
     public function down(Schema $schema): void
@@ -30,5 +32,6 @@ final class Version20221219144622 extends AbstractMigration
         );
 
         $this->addSql('ALTER TABLE task DROP created_by');
+        $this->addSql('ALTER TABLE revision ADD owner TEXT DEFAULT NULL');
     }
 }

--- a/EMS/core-bundle/src/Resources/DoctrineMigrations/pdo_pgsql/Version20221219144622.php
+++ b/EMS/core-bundle/src/Resources/DoctrineMigrations/pdo_pgsql/Version20221219144622.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20221219144622 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\PostgreSQLPlatform'."
+        );
+
+        $this->addSql('ALTER TABLE task ADD created_by TEXT DEFAULT NULL');
+        $this->addSql("UPDATE task SET created_by = logs->0->>'username'");
+        $this->addSql('ALTER TABLE task ALTER created_by SET NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\PostgreSQLPlatform'."
+        );
+
+        $this->addSql('ALTER TABLE task DROP created_by');
+    }
+}

--- a/EMS/core-bundle/src/Resources/config/form.xml
+++ b/EMS/core-bundle/src/Resources/config/form.xml
@@ -419,7 +419,6 @@
             <tag name="form.type"/>
         </service>
         <service id="ems_core.form_revision_task.filters" class="EMS\CoreBundle\Form\Revision\Task\RevisionTaskFiltersType">
-            <argument type="service" id="ems.service.contenttype" />
             <tag name="form.type"/>
         </service>
     </services>

--- a/EMS/core-bundle/src/Resources/config/form.xml
+++ b/EMS/core-bundle/src/Resources/config/form.xml
@@ -295,6 +295,7 @@
             <argument type="service" id="ems.service.elasticsearch" />
             <argument type="service" id="ems.service.revision" />
             <argument type="service" id="ems.service.environment" />
+            <argument type="service" id="EMS\CoreBundle\Service\ContentTypeService" />
             <tag name="ems.form.datafieldtype" alias="version_tag" />
             <tag name="form.type"/>
         </service>

--- a/EMS/core-bundle/src/Resources/config/routing/task.xml
+++ b/EMS/core-bundle/src/Resources/config/routing/task.xml
@@ -5,17 +5,17 @@
         xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
     <route id="ems_core_task_ajax_datatable" path="/tasks/dashboard/{tab}.json" methods="GET POST">
-        <requirement key="tab">user|owner|manager</requirement>
+        <requirement key="tab">user|requester|manager</requirement>
         <default key="tab">user</default>
         <default key="_controller">EMS\CoreBundle\Controller\Revision\TaskController::ajaxDataTable</default>
     </route>
     <route id="ems_core_task_ajax_datatable_csv" path="/tasks/dashboard/{tab}.csv" methods="GET">
-        <requirement key="tab">user|owner|manager</requirement>
+        <requirement key="tab">user|requester|manager</requirement>
         <default key="tab">user</default>
         <default key="_controller">EMS\CoreBundle\Controller\Revision\TaskController::ajaxDataTableCSV</default>
     </route>
     <route id="ems_core_task_ajax_datatable_excel" path="/tasks/dashboard/{tab}-excel" methods="GET">
-        <requirement key="tab">user|owner|manager</requirement>
+        <requirement key="tab">user|requester|manager</requirement>
         <default key="tab">user</default>
         <default key="_controller">EMS\CoreBundle\Controller\Revision\TaskController::ajaxDataTableExcel</default>
     </route>
@@ -41,9 +41,6 @@
     </route>
     <route id="ems_core_task_ajax_modal_history" path="/data/revisions/{revisionId}/history-modal/{taskId}" methods="GET">
         <default key="_controller">EMS\CoreBundle\Controller\Revision\TaskController::ajaxModalHistory</default>
-    </route>
-    <route id="ems_core_task_ajax_modal_change_owner" path="/data/revisions/{revisionId}/change-owner" methods="GET POST">
-        <default key="_controller">EMS\CoreBundle\Controller\Revision\TaskController::ajaxModalChangeOwner</default>
     </route>
     <route id="ems_core_task_ajax_delete" path="/data/revisions/{revisionId}/delete/{taskId}" methods="POST">
         <default key="_controller">EMS\CoreBundle\Controller\Revision\TaskController::ajaxDelete</default>

--- a/EMS/core-bundle/src/Resources/config/services.xml
+++ b/EMS/core-bundle/src/Resources/config/services.xml
@@ -293,6 +293,7 @@
             <argument type="service" id="security.authorization_checker" />
             <argument type="service" id="EMS\CoreBundle\Repository\RevisionRepository" />
             <argument type="service" id="security.token_storage" />
+            <argument type="service" id="translator" />
             <argument>%ems_core.circles_object%</argument>
             <tag name="emsco.entity.service" />
         </service>

--- a/EMS/core-bundle/src/Resources/config/twig.xml
+++ b/EMS/core-bundle/src/Resources/config/twig.xml
@@ -49,6 +49,11 @@
             <tag name="twig.runtime"/>
         </service>
 
+        <service id="emsco.twig.content_type_runtime" class="EMS\CoreBundle\Twig\ContentTypeRuntime">
+            <argument type="service" id="EMS\CoreBundle\Service\ContentTypeService"/>
+            <tag name="twig.runtime"/>
+        </service>
+
         <service id="emsco.twig.environment_runtime" class="EMS\CoreBundle\Twig\EnvironmentRuntime">
             <argument type="service" id="ems.service.environment"/>
             <tag name="twig.runtime"/>

--- a/EMS/core-bundle/src/Resources/translations/EMSCoreBundle.en.yml
+++ b/EMS/core-bundle/src/Resources/translations/EMSCoreBundle.en.yml
@@ -506,7 +506,7 @@ task.create.title: 'Add a new task'
 task.dashboard.action.change_owner: 'Change owner'
 task.dashboard.action.edit_revision: 'Edit revision'
 task.dashboard.action.go_revision: Revision
-task.dashboard.column.version: Version
+task.dashboard.column.version_tag: 'New version'
 task.dashboard.column.actions: Actions
 task.dashboard.column.assignee: Assignee
 task.dashboard.column.deadline: Deadline
@@ -907,3 +907,6 @@ log.data.revision.added_to_release: 'Document "%label%" has been added to releas
 log.data.revision.can_not_add_draft_in_release: 'Revision in draft mode can not be added to a release'
 log.data.revision.document_already_in_release_but_updated: 'Document "%label%" has been updated with a new revision in release "%release%"'
 log.data.revision.already_in_release: 'This revision of document "%label%" was already in release "%release%"'
+revision.version_tag: 'Yes as %version_tag%'
+revision.version_tag.empty: 'No (Silent publish)'
+

--- a/EMS/core-bundle/src/Resources/translations/EMSCoreBundle.en.yml
+++ b/EMS/core-bundle/src/Resources/translations/EMSCoreBundle.en.yml
@@ -493,17 +493,10 @@ table.index.column.actions: Actions
 table.index.column.loop_count: '#'
 table.index.empty: 'Nothing to show here'
 task.assigned_to: 'Assigned to '
-task.change_owner.change: 'New owner'
-task.change_owner.current: 'The current owner for document "%revision%" is "%owner%"'
-task.change_owner.missing: 'The document "%revision%" has no owner'
-task.change_owner.submit: Change
-task.change_owner.success: 'Successfully changed ownership!'
-task.change_owner.title: 'Change owner for %revision%'
 task.create.button: 'Add a task'
 task.create.submit: 'Create task'
 task.create.success: 'Task "%title%" successfully created.'
 task.create.title: 'Add a new task'
-task.dashboard.action.change_owner: 'Change owner'
 task.dashboard.action.edit_revision: 'Edit revision'
 task.dashboard.action.go_revision: Revision
 task.dashboard.column.version_tag: 'New version'
@@ -512,11 +505,11 @@ task.dashboard.column.assignee: Assignee
 task.dashboard.column.deadline: Deadline
 task.dashboard.column.modified: Last modification
 task.dashboard.column.label: Document
-task.dashboard.column.owner: Owner
+task.dashboard.column.requester: Requester
 task.dashboard.column.status: Status
 task.dashboard.column.title: Task
 task.dashboard.tab.manager: 'All tasks'
-task.dashboard.tab.owner: 'Created tasks'
+task.dashboard.tab.requester: 'Requested tasks'
 task.dashboard.tab.user: 'Assigned to me'
 task.delete.submit: 'Delete task'
 task.delete.success: 'Task "%title%" successfully deleted.'
@@ -569,7 +562,7 @@ task.filters: Filters
 task.filter.status: Statuses
 task.filter.version: Versions
 task.filter.assignee: Assignees
-task.filter.owner: Owners
+task.filter.requester: Requesters
 task.filter.submit: Search
 task.filter.reset: Clear
 uploaded-file.action.download_selected: 'Download selected'

--- a/EMS/core-bundle/src/Resources/translations/emsco-twigs.en.yml
+++ b/EMS/core-bundle/src/Resources/translations/emsco-twigs.en.yml
@@ -82,7 +82,6 @@ views.data.revisions-data-html.status: Status
 views.data.revisions-data-html.draft-in-progress: 'Draft in progress'
 views.data.revisions-data-html.current-revision: 'Current revision'
 views.data.revisions-data-html.previous-revision: 'Previous revision'
-views.data.revisions-data-html.owner: Owner
 views.data.revisions-data-html.finalized-by: 'Finalized by'
 views.data.revisions-data-html.finalized-on: 'Finalized on'
 views.data.revisions-data-html.all-linked-documents: 'All linked documents'

--- a/EMS/core-bundle/src/Resources/views/contenttype/edit.html.twig
+++ b/EMS/core-bundle/src/Resources/views/contenttype/edit.html.twig
@@ -137,6 +137,23 @@
                             {% endif %}
                         </div>
                     </div>
+
+                    <div class="col-md-8">
+                        <table class="table table-hover">
+                            <thead>
+                            <tr>
+                                <th>Settings</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            {% for settingField in form.settings %}
+                                <tr>
+                                    <td>{{ form_widget(settingField) }}</td>
+                                </tr>
+                            {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
                 </div>
                 <!-- /.box-body -->
                 <div class="box-footer">

--- a/EMS/core-bundle/src/Resources/views/data/revisions-data.html.twig
+++ b/EMS/core-bundle/src/Resources/views/data/revisions-data.html.twig
@@ -112,7 +112,7 @@
 
 {% block revisionSidebar %}
 	{% set tabs = [{name: 'tab_about_revision', label: 'views.data.revisions-data-html.revision'|trans}] %}
-	{% if revision.isTaskEnabled %}
+	{% if revision.giveContentType.tasksEnabled %}
 		{% set tabs = tabs|merge([{ name: 'tab_tasks', label: 'task.tab_tasks'|trans }]) %}
 	{% endif %}
 	<div id="revision-tabs" class="nav-tabs-custom">

--- a/EMS/core-bundle/src/Resources/views/data/revisions-data.html.twig
+++ b/EMS/core-bundle/src/Resources/views/data/revisions-data.html.twig
@@ -113,7 +113,11 @@
 {% block revisionSidebar %}
 	{% set tabs = [{name: 'tab_about_revision', label: 'views.data.revisions-data-html.revision'|trans}] %}
 	{% if revision.giveContentType.tasksEnabled %}
-		{% set tabs = tabs|merge([{ name: 'tab_tasks', label: 'task.tab_tasks'|trans }]) %}
+		{% if revision.hasTaskCurrent and revision.taskCurrent.assignee == app.user.userIdentifier %}
+			{% set tabs = tabs|merge([{ name: 'tab_task', label: 'task.tab_task'|trans }]) %}
+		{% else %}
+			{% set tabs = tabs|merge([{ name: 'tab_tasks', label: 'task.tab_tasks'|trans }]) %}
+		{% endif %}
 	{% endif %}
 	<div id="revision-tabs" class="nav-tabs-custom">
 		<ul class="nav nav-tabs">

--- a/EMS/core-bundle/src/Resources/views/data/revisions-data.html.twig
+++ b/EMS/core-bundle/src/Resources/views/data/revisions-data.html.twig
@@ -113,12 +113,7 @@
 {% block revisionSidebar %}
 	{% set tabs = [{name: 'tab_about_revision', label: 'views.data.revisions-data-html.revision'|trans}] %}
 	{% if revision.isTaskEnabled %}
-		{% if (revision.hasOwner and revision.owner == app.user.username) or (revision.hasTasks == false and is_granted(revision.giveContentType.roles.owner) and revision.hasOwner == false) %}
-			{% set tabs = tabs|merge([{ name: 'tab_tasks', label: 'task.tab_tasks'|trans }]) %}
-		{% endif %}
-		{% if revision.hasTaskCurrent and revision.owner != app.user.username %}
-			{% set tabs = tabs|merge([{ name: 'tab_task', label: 'task.tab_task'|trans }]) %}
-		{% endif %}
+		{% set tabs = tabs|merge([{ name: 'tab_tasks', label: 'task.tab_tasks'|trans }]) %}
 	{% endif %}
 	<div id="revision-tabs" class="nav-tabs-custom">
 		<ul class="nav nav-tabs">
@@ -167,12 +162,6 @@
 			{{ 'views.data.revisions-data-html.previous-revision'|trans({'%timestamp%': revision.created|date(date_time_format)}) }}
 		{% endif %}
 	</p>
-
-	{% if revision.hasOwner %}
-		<hr/>
-		<strong><i class="fa fa-user-circle-o margin-r-5"></i> {{ 'views.data.revisions-data-html.owner'|trans }}</strong>
-		<p class="text-muted">{{ revision.owner|displayname }}</p>
-	{% endif %}
 
 	{% if revision.finalizedBy %}
 		<hr>

--- a/EMS/core-bundle/src/Resources/views/macros/data-field-type.html.twig
+++ b/EMS/core-bundle/src/Resources/views/macros/data-field-type.html.twig
@@ -1237,7 +1237,12 @@
 			{% endif %}
 		</dt>
 		<dd>
-			{{ diff_text(dataField.rawData, compare, dataField.fieldType.name, compareRawData)|raw }}
+			{% if dataField.rawData %}
+				{% set translateRaw = 'revision.version_tag'|trans({'%version_tag%': dataField.rawData})  %}
+			{% else %}
+				{% set translateRaw = 'revision.version_tag.empty'|trans %}
+			{% endif %}
+			{{ diff_text(translateRaw, false, dataField.fieldType.name, compareRawData)|raw }}
 		</dd>
 	</dl>
 	{{ _self.messages(dataField) }}

--- a/EMS/core-bundle/src/Resources/views/revision/task/ajax.twig
+++ b/EMS/core-bundle/src/Resources/views/revision/task/ajax.twig
@@ -123,13 +123,6 @@
             <a class="btn btn-sm btn-default" href="{{ path('revision.new-draft', { 'type': contentType.name, 'ouuid': ouuid }) }}">
                 <i class="fa fa-pencil-square-o" aria-hidden="true"></i> {{ 'task.dashboard.action.edit_revision'|trans }}
             </a>
-            {% if isManager %}
-                <a href="#task-change-owner" class="btn btn-sm btn-default btn-task-change-owner-modal"
-                    data-url="{{ path('ems_core_task_ajax_modal_change_owner', { 'revisionId': revisionId }) }}"
-                    data-title="{{ 'task.dashboard.action.change_owner'|trans }}">
-                    <i class="fa fa-user-circle-o" aria-hidden="true"></i> {{ 'task.dashboard.action.change_owner'|trans }}
-                </a>
-            {% endif %}
         </div>
     </div>
 {% endblock %}
@@ -215,23 +208,6 @@
 {% endblock %}
 
 {% block modalHistoryBody %}{{ block('renderHistoryTimeline') }}{% endblock %}
-
-{% block modalChangeOwnerBody %}
-    {%- if revision.hasOwner -%}
-        {% set info = 'task.change_owner.current'|trans({'%revision%': revision.label, '%owner%': revision.owner|displayname }) %}
-    {%- else -%}
-        {% set info = 'task.change_owner.missing'|trans({'%revision%': revision}) %}
-    {%- endif -%}
-    <div class="alert alert-info" role="alert">{{ info }}</div>
-    {{ form(form) }}
-{% endblock %}
-
-{% block modalChangeOwnerFooter %}
-    <div class="pull-left">
-        <button id="ajax-modal-submit" class="btn btn-sm btn-primary">{{ 'task.change_owner.submit'|trans }}</button>
-        <button type="button" class="btn btn-sm btn-default" data-dismiss="modal">Close</button>
-    </div>
-{% endblock %}
 
 {% block taskForm %}
     {{ form_start(form) }}

--- a/EMS/core-bundle/src/Resources/views/revision/task/columns.twig
+++ b/EMS/core-bundle/src/Resources/views/revision/task/columns.twig
@@ -9,7 +9,11 @@
 {%- endblock -%}
 
 {%- block version_tag -%}
-    {{ data.versionTagField }}
+    {%- if data.versionTagField -%}
+        {{- 'revision.version_tag'|trans({'%version_tag%': data.versionTagField}) -}}
+    {%- else -%}
+        {{- 'revision.version_tag.empty'|trans -}}
+    {%- endif -%}
 {%- endblock -%}
 {%- block owner -%}{{- data.owner|displayname -}}{%- endblock -%}
 {%- block assignee -%}{{- data.taskCurrent.assignee|displayname -}}{%- endblock -%}

--- a/EMS/core-bundle/src/Resources/views/revision/task/columns.twig
+++ b/EMS/core-bundle/src/Resources/views/revision/task/columns.twig
@@ -8,7 +8,9 @@
     </a>
 {%- endblock -%}
 
-{%- block version -%}{{- data.versionTag -}}{%- endblock -%}
+{%- block version_tag -%}
+    {{ data.versionTagField }}
+{%- endblock -%}
 {%- block owner -%}{{- data.owner|displayname -}}{%- endblock -%}
 {%- block assignee -%}{{- data.taskCurrent.assignee|displayname -}}{%- endblock -%}
 

--- a/EMS/core-bundle/src/Resources/views/revision/task/columns.twig
+++ b/EMS/core-bundle/src/Resources/views/revision/task/columns.twig
@@ -15,7 +15,7 @@
         {{- 'revision.version_tag.empty'|trans -}}
     {%- endif -%}
 {%- endblock -%}
-{%- block owner -%}{{- data.owner|displayname -}}{%- endblock -%}
+{%- block requester -%}{{- data.taskCurrent.createdBy|displayname -}}{%- endblock -%}
 {%- block assignee -%}{{- data.taskCurrent.assignee|displayname -}}{%- endblock -%}
 
 {% block status %}
@@ -46,12 +46,5 @@
         <a class="btn btn-sm btn-default" href="{{ path('revision.new-draft', { 'type': data.giveContentType.name, 'ouuid': data.ouuid }) }}">
             <i class="fa fa-pencil-square-o" aria-hidden="true"></i> {{ 'task.dashboard.action.edit_revision'|trans }}
         </a>
-        {% if table.context.tab|default('') == 'manager' %}
-            <a href="#task-change-owner" class="btn btn-sm btn-default btn-task-change-owner-modal"
-               data-url="{{ path('ems_core_task_ajax_modal_change_owner', { 'revisionId': data.id }) }}"
-               data-title="{{ 'task.dashboard.action.change_owner'|trans }}">
-                <i class="fa fa-user-circle-o" aria-hidden="true"></i> {{ 'task.dashboard.action.change_owner'|trans }}
-            </a>
-        {% endif %}
     </div>
 {%- endblock -%}

--- a/EMS/core-bundle/src/Resources/views/revision/task/dashboard.html.twig
+++ b/EMS/core-bundle/src/Resources/views/revision/task/dashboard.html.twig
@@ -69,8 +69,8 @@
                     {% if filterForm.assignee is defined %}
                         {{ form_row(filterForm.assignee, {'row_attr': { 'class': 'col-md-3' }, 'label': 'task.filter.assignee'|trans  }) }}
                     {% endif %}
-                    {% if filterForm.owner is defined %}
-                        {{ form_row(filterForm.owner, {'row_attr': { 'class': 'col-md-3' }, 'label': 'task.filter.owner'|trans  }) }}
+                    {% if filterForm.requester is defined %}
+                        {{ form_row(filterForm.requester, {'row_attr': { 'class': 'col-md-3' }, 'label': 'task.filter.requester'|trans  }) }}
                     {% endif %}
                     <div class="col-md-12">
                         <input type="hidden" name="tab" value="{{ currentTab }}" />

--- a/EMS/core-bundle/src/Resources/views/revision/task/mail.twig
+++ b/EMS/core-bundle/src/Resources/views/revision/task/mail.twig
@@ -72,7 +72,6 @@
     {% set path = path('data.revisions', { 'type': revision.giveContentType.name, 'ouuid': revision.ouuid })  %}
     <p>
         In {{ revision.giveContentType.singularName }} : <a href="{{ backendUrl|default('') }}{{ path }}" target="_blank"><strong>{{ revision.label }}</strong></a><br/>
-        {% if revision.hasOwner %}Owned by {{ revision.owner|displayname  }}{% endif %}
     </p>
 {% endblock %}
 
@@ -80,6 +79,7 @@
     <p>
         <strong>title:&nbsp;</strong>{{ task.title }}<br/>
         {% if task.assignee != receiver.username %}<strong>assignee:&nbsp;</strong>{{ task.assignee|displayname }}<br/>{% endif %}
+        {% if task.createdBy != receiver.username %}<strong>requester:&nbsp;</strong>{{ task.createdBy|displayname }}<br/>{% endif %}
         {% if task.hasDeadline %}<strong>deadline:&nbsp;</strong>{{ task.deadline.format(date_format) }}<br/>{% endif %}
         {% if task.hasDescription %}
             <strong>description:&nbsp;</strong><br/>

--- a/EMS/core-bundle/src/Service/ContentTypeService.php
+++ b/EMS/core-bundle/src/Service/ContentTypeService.php
@@ -723,21 +723,6 @@ class ContentTypeService implements EntityServiceInterface
         return [$emptyLabel => null] + \array_combine($versionTagsLabels, $versionTags);
     }
 
-    /**
-     * @return string[]
-     */
-    public function getAllVersionTags(): array
-    {
-        $versionTags = [];
-        foreach ($this->getAll() as $contentType) {
-            if ($contentType->isActive()) {
-                $versionTags = \array_merge($versionTags, $contentType->getVersionTags());
-            }
-        }
-
-        return \array_unique($versionTags);
-    }
-
     public function deleteByItemName(string $name): string
     {
         $contentTypeRepository = $this->getContentTypeRepository();

--- a/EMS/core-bundle/src/Service/ContentTypeService.php
+++ b/EMS/core-bundle/src/Service/ContentTypeService.php
@@ -12,6 +12,7 @@ use EMS\CommonBundle\Service\ElasticaService;
 use EMS\CoreBundle\Core\ContentType\ContentTypeRoles;
 use EMS\CoreBundle\Core\UI\Menu;
 use EMS\CoreBundle\Core\UI\MenuEntry;
+use EMS\CoreBundle\EMSCoreBundle;
 use EMS\CoreBundle\Entity\ContentType;
 use EMS\CoreBundle\Entity\Environment;
 use EMS\CoreBundle\Entity\FieldType;
@@ -30,6 +31,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ContentTypeService implements EntityServiceInterface
 {
@@ -39,7 +41,17 @@ class ContentTypeService implements EntityServiceInterface
     /** @var ContentType[] */
     protected array $contentTypeArrayByName = [];
 
-    public function __construct(protected Registry $doctrine, protected LoggerInterface $logger, private readonly Mapping $mappingService, private readonly ElasticaService $elasticaService, private readonly EnvironmentService $environmentService, private readonly AuthorizationCheckerInterface $authorizationChecker, private readonly RevisionRepository $revisionRepository, private readonly TokenStorageInterface $tokenStorage, private readonly ?string $circleContentTypeName)
+    public function __construct(
+        protected Registry $doctrine,
+        protected LoggerInterface $logger,
+        private readonly Mapping $mappingService,
+        private readonly ElasticaService $elasticaService,
+        private readonly EnvironmentService $environmentService,
+        private readonly AuthorizationCheckerInterface $authorizationChecker,
+        private readonly RevisionRepository $revisionRepository,
+        private readonly TokenStorageInterface $tokenStorage,
+        private readonly TranslatorInterface $translator,
+        private readonly ?string $circleContentTypeName)
     {
     }
 
@@ -666,6 +678,49 @@ class ContentTypeService implements EntityServiceInterface
         }
 
         return $contentTypeRepository;
+    }
+
+    /**
+     * @return array<string, ?string>
+     */
+    public function getVersionDefault(ContentType $contentType): array
+    {
+        if (!$contentType->hasVersionTags()) {
+            return [];
+        }
+
+        $versionTags = $contentType->getVersionTags();
+        $defaultVersion = \array_shift($versionTags);
+        $defaultVersionLabel = $this->translator->trans(
+            'revision.version_tag',
+            ['%version_tag%' => $defaultVersion],
+            EMSCoreBundle::TRANS_DOMAIN
+        );
+
+        return [$defaultVersionLabel => $defaultVersion];
+    }
+
+    /**
+     * @return array<string, ?string>
+     */
+    public function getVersionTags(ContentType $contentType): array
+    {
+        if (!$contentType->hasVersionTags()) {
+            return [];
+        }
+
+        $versionTags = $contentType->getVersionTags();
+        $versionTagsLabels = \array_map(function (string $versionTag) {
+            return $this->translator->trans(
+                'revision.version_tag',
+                ['%version_tag%' => $versionTag],
+                EMSCoreBundle::TRANS_DOMAIN
+            );
+        }, $versionTags);
+
+        $emptyLabel = $this->translator->trans('revision.version_tag.empty', [], EMSCoreBundle::TRANS_DOMAIN);
+
+        return [$emptyLabel => null] + \array_combine($versionTagsLabels, $versionTags);
     }
 
     /**

--- a/EMS/core-bundle/src/Service/DataService.php
+++ b/EMS/core-bundle/src/Service/DataService.php
@@ -1013,11 +1013,6 @@ class DataService
         $revision->setLockBy($username);
         $revision->setLockUntil(new \DateTime($this->lockTime));
 
-        if (null !== $currentUser
-            && $this->userService->isGrantedRole($contentType->role(ContentTypeRoles::OWNER))) {
-            $revision->setOwner($currentUser->getUsername());
-        }
-
         if (null !== $currentUser && $contentType->getCirclesField()) {
             if (isset($revision->getRawData()[$contentType->getCirclesField()])) {
                 if (\is_array($revision->getRawData()[$contentType->getCirclesField()])) {

--- a/EMS/core-bundle/src/Twig/AppExtension.php
+++ b/EMS/core-bundle/src/Twig/AppExtension.php
@@ -55,8 +55,24 @@ class AppExtension extends AbstractExtension
     /**
      * @param array<mixed> $assetConfig
      */
-    public function __construct(private readonly Registry $doctrine, private readonly AuthorizationCheckerInterface $authorizationChecker, private readonly UserService $userService, private readonly ContentTypeService $contentTypeService, private readonly RouterInterface $router, private readonly TwigEnvironment $twig, private readonly ObjectChoiceListFactory $objectChoiceListFactory, private readonly LoggerInterface $logger, protected FormFactory $formFactory, protected FileService $fileService, protected RequestRuntime $commonRequestRuntime, private readonly MailerService $mailer, private readonly ElasticaService $elasticaService, private readonly SearchService $searchService, private readonly AssetRuntime $assetRuntime, protected array $assetConfig)
-    {
+    public function __construct(
+        private readonly Registry $doctrine,
+        private readonly AuthorizationCheckerInterface $authorizationChecker,
+        private readonly UserService $userService,
+        private readonly ContentTypeService $contentTypeService,
+        private readonly RouterInterface $router,
+        private readonly TwigEnvironment $twig,
+        private readonly ObjectChoiceListFactory $objectChoiceListFactory,
+        private readonly LoggerInterface $logger,
+        protected FormFactory $formFactory,
+        protected FileService $fileService,
+        protected RequestRuntime $commonRequestRuntime,
+        private readonly MailerService $mailer,
+        private readonly ElasticaService $elasticaService,
+        private readonly SearchService $searchService,
+        private readonly AssetRuntime $assetRuntime,
+        protected array $assetConfig
+    ) {
     }
 
     /**
@@ -65,7 +81,6 @@ class AppExtension extends AbstractExtension
     public function getFunctions(): array
     {
         return [
-            new TwigFunction('get_content_types', $this->getContentTypes(...)),
             new TwigFunction('cant_be_finalized', $this->cantBeFinalized(...)),
             new TwigFunction('sequence', $this->getSequenceNextValue(...)),
             new TwigFunction('diff_text', $this->diffText(...), ['is_safe' => ['html']]),
@@ -99,8 +114,11 @@ class AppExtension extends AbstractExtension
             new TwigFunction('emsco_get_environments', [EnvironmentRuntime::class, 'getEnvironments']),
             new TwigFunction('emsco_get_environments_revision', [EnvironmentRuntime::class, 'getEnvironmentsRevision']),
             new TwigFunction('emsco_get_default_environment_names', [EnvironmentRuntime::class, 'getDefaultEnvironmentNames']),
+            new TwigFunction('emsco_get_content_types', [ContentTypeRuntime::class, 'getContentTypes']),
+            new TwigFunction('emsco_get_content_type_version_tags', [ContentTypeRuntime::class, 'getContentTypeVersionTags']),
             // deprecated
             new TwigFunction('get_default_environments', [EnvironmentRuntime::class, 'getDefaultEnvironmentNames'], ['deprecated' => true, 'alternative' => 'emsco_get_default_environment_names']),
+            new TwigFunction('get_content_types', [ContentTypeRuntime::class, 'getContentTypes'], ['deprecated' => true, 'alternative' => 'emsco_get_content_types']),
         ];
     }
 
@@ -126,7 +144,6 @@ class AppExtension extends AbstractExtension
             new TwigFilter('in_my_circles', $this->inMyCircles(...)),
             new TwigFilter('data_link', $this->dataLink(...), ['is_safe' => ['html']]),
             new TwigFilter('data_label', $this->dataLabel(...), ['is_safe' => ['html']]),
-            new TwigFilter('get_content_type', $this->getContentType(...)),
             new TwigFilter('emsco_get_environment', [EnvironmentRuntime::class, 'getEnvironment']),
             new TwigFilter('generate_from_template', $this->generateFromTemplate(...)),
             new TwigFilter('objectChoiceLoader', $this->objectChoiceLoader(...)),
@@ -156,10 +173,12 @@ class AppExtension extends AbstractExtension
             new TwigFilter('emsco_log_error', [CoreRuntime::class, 'logError']),
             new TwigFilter('emsco_guess_locale', [DataExtractorRuntime::class, 'guessLocale']),
             new TwigFilter('emsco_asset_meta', [DataExtractorRuntime::class, 'assetMeta']),
+            new TwigFilter('emsco_get_content_type', [ContentTypeRuntime::class, 'getContentType']),
             // deprecated
             new TwigFilter('url_generator', Encoder::webalize(...), ['deprecated' => true, 'alternative' => 'ems_webalize']),
             new TwigFilter('emsco_webalize', Encoder::webalize(...), ['deprecated' => true, 'alternative' => 'ems_webalize']),
             new TwigFilter('get_environment', [EnvironmentRuntime::class, 'getEnvironment'], ['deprecated' => true, 'alternative' => 'emsco_get_environment']),
+            new TwigFilter('get_content_type', [ContentTypeRuntime::class, 'getContentType'], ['deprecated' => true, 'alternative' => 'emsco_get_contentType']),
         ];
     }
 
@@ -1064,24 +1083,6 @@ class AppExtension extends AbstractExtension
     public function firstInArray(mixed $needle, array $haystack): bool
     {
         return 0 === \array_search($needle, $haystack);
-    }
-
-    public function getContentType(string $name): ?ContentType
-    {
-        $contentType = $this->contentTypeService->getByName($name);
-        if (false !== $contentType) {
-            return $contentType;
-        }
-
-        return null;
-    }
-
-    /**
-     * @return ContentType[]
-     */
-    public function getContentTypes(): array
-    {
-        return $this->contentTypeService->getAll();
     }
 
     /**

--- a/EMS/core-bundle/src/Twig/ContentTypeRuntime.php
+++ b/EMS/core-bundle/src/Twig/ContentTypeRuntime.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\Twig;
+
+use EMS\CoreBundle\Entity\ContentType;
+use EMS\CoreBundle\Service\ContentTypeService;
+use Twig\Extension\RuntimeExtensionInterface;
+
+class ContentTypeRuntime implements RuntimeExtensionInterface
+{
+    public function __construct(private readonly ContentTypeService $contentTypeService)
+    {
+    }
+
+    public function getContentType(string $name): ?ContentType
+    {
+        $contentType = $this->contentTypeService->getByName($name);
+
+        return $contentType ?: null;
+    }
+
+    /**
+     * @return ContentType[]
+     */
+    public function getContentTypes(): array
+    {
+        return $this->contentTypeService->getAll();
+    }
+
+    /**
+     * @return array<string, ?string>
+     */
+    public function getContentTypeVersionTags(string $contentTypeName): array
+    {
+        $contentType = $this->contentTypeService->giveByName($contentTypeName);
+
+        return $this->contentTypeService->getVersionTags($contentType);
+    }
+}


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |n|
|New feature?   |y|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

Refactor version and tasks.

* Translate the version tags and null value.
* Add new emsco_get_content_type_version_tags function
* Deprecated get_content_types  -> emsco_get_content_types
* Deprecated get_content_type -> emsco_get_content_type
* Add created_by on task table used for building requester views/logic
* Owner becomes requester
* Remove `owner` field from revision
* Added contentType settings json, now only for enabling tasks

