### PR TITLE
fix: double ems.command.admin.get

### DIFF
--- a/EMS/common-bundle/src/Resources/config/commands.xml
+++ b/EMS/common-bundle/src/Resources/config/commands.xml
@@ -32,7 +32,7 @@
             <argument type="string">%kernel.project_dir%</argument>
             <tag name="console.command" command="ems:admin:get"/>
         </service>
-        <service id="ems.command.admin.get" class="EMS\CommonBundle\Command\Admin\BackupCommand">
+        <service id="ems.command.admin.backup" class="EMS\CommonBundle\Command\Admin\BackupCommand">
             <argument type="service" id="ems.helper.admin_api"/>
             <argument type="string">%kernel.project_dir%</argument>
             <tag name="console.command" command="ems:admin:backup"/>


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

"EMS\CommonBundle\Command\Admin\GetCommand" is not registered because the new backup command uses the same id.
