### PR TITLE
fix(tasks): planned ids array_values

### DIFF
--- a/EMS/core-bundle/src/Entity/RevisionTaskTrait.php
+++ b/EMS/core-bundle/src/Entity/RevisionTaskTrait.php
@@ -177,6 +177,6 @@ trait RevisionTaskTrait
      */
     public function setTaskPlanned(array $taskPlanned): void
     {
-        $this->taskPlannedIds = \array_map(fn (Task $task) => $task->getId(), $taskPlanned);
+        $this->taskPlannedIds = \array_values(\array_map(fn (Task $task) => $task->getId(), $taskPlanned));
     }
 }

--- a/EMS/core-bundle/src/Resources/DoctrineMigrations/pdo_mysql/Version20221222131342.php
+++ b/EMS/core-bundle/src/Resources/DoctrineMigrations/pdo_mysql/Version20221222131342.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20221222131342 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof MySQLPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MySQLPlatform'."
+        );
+
+        $query = <<<QUERY
+            select id, task_planned_ids from revision 
+            where task_planned_ids is not null and task_planned_ids != '[]'
+QUERY;
+
+        $rows = $this->connection->executeQuery($query)->iterateAssociative();
+
+        foreach ($rows as $row) {
+            $wrongJson = \json_decode($row['task_planned_ids'], true);
+            $correctJson = \json_encode(\array_values($wrongJson));
+
+            $this->connection->update('revision', ['task_planned_ids' => $correctJson], ['id' => $row['id']]);
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+    }
+}

--- a/EMS/core-bundle/src/Resources/DoctrineMigrations/pdo_pgsql/Version20221222130227.php
+++ b/EMS/core-bundle/src/Resources/DoctrineMigrations/pdo_pgsql/Version20221222130227.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20221222130227 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\PostgreSQLPlatform'."
+        );
+
+        $query = <<<QUERY
+            select id, task_planned_ids from revision 
+            where task_planned_ids is not null and task_planned_ids::text != '[]'
+QUERY;
+
+        $rows = $this->connection->executeQuery($query)->iterateAssociative();
+
+        foreach ($rows as $row) {
+            $wrongJson = \json_decode($row['task_planned_ids'], true);
+            $correctJson = \json_encode(\array_values($wrongJson));
+
+            $this->connection->update('revision', ['task_planned_ids' => $correctJson], ['id' => $row['id']]);
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

The revision task planned ids are not correctly saved to the database when **changing the order**.
This way we can not do Postgres json queries, because task planned ids is not allways a valid json array.

Expected
```json
["764e891a-05e9-499a-9aee-ecbec8fa7566", "3b0cc12d-70b0-4bd1-a835-b70496308376"]
````

Actual
```json
{"764e891a-05e9-499a-9aee-ecbec8fa7566":"764e891a-05e9-499a-9aee-ecbec8fa7566", "3b0cc12d-70b0-4bd1-a835-b70496308376":"3b0cc12d-70b0-4bd1-a835-b70496308376"}
````
