### PR TITLE
fix(api/admin): logging

### DIFF
--- a/EMS/common-bundle/src/Command/Admin/BackupCommand.php
+++ b/EMS/common-bundle/src/Command/Admin/BackupCommand.php
@@ -13,6 +13,7 @@ use EMS\CommonBundle\Contracts\CoreApi\CoreApiInterface;
 use EMS\CommonBundle\Search\Search;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class BackupCommand extends AbstractCommand
@@ -36,6 +37,7 @@ class BackupCommand extends AbstractCommand
     public function initialize(InputInterface $input, OutputInterface $output): void
     {
         parent::initialize($input, $output);
+        $this->adminHelper->setLogger(new ConsoleLogger($output));
         $this->export = $this->getOptionBool(self::EXPORT);
         $exportFolder = $this->getOptionStringNull(self::EXPORT_FOLDER);
         if (null !== $exportFolder) {

--- a/EMS/common-bundle/src/Command/Admin/CreateCommand.php
+++ b/EMS/common-bundle/src/Command/Admin/CreateCommand.php
@@ -11,6 +11,7 @@ use EMS\Helpers\Standard\Json;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class CreateCommand extends AbstractCommand
@@ -31,6 +32,7 @@ class CreateCommand extends AbstractCommand
     public function initialize(InputInterface $input, OutputInterface $output): void
     {
         parent::initialize($input, $output);
+        $this->adminHelper->setLogger(new ConsoleLogger($output));
         $this->configType = $this->getArgumentString(self::CONFIG_TYPE);
         $this->jsonPath = $this->getArgumentString(self::JSON_PATH);
         $folder = $this->getOptionStringNull(self::FOLDER);

--- a/EMS/common-bundle/src/Command/Admin/DeleteCommand.php
+++ b/EMS/common-bundle/src/Command/Admin/DeleteCommand.php
@@ -8,6 +8,7 @@ use EMS\CommonBundle\Common\Admin\AdminHelper;
 use EMS\CommonBundle\Common\Command\AbstractCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class DeleteCommand extends AbstractCommand
@@ -25,6 +26,7 @@ class DeleteCommand extends AbstractCommand
     public function initialize(InputInterface $input, OutputInterface $output): void
     {
         parent::initialize($input, $output);
+        $this->adminHelper->setLogger(new ConsoleLogger($output));
         $this->configType = $this->getArgumentString(self::CONFIG_TYPE);
         $this->entityName = $this->getArgumentString(self::ENTITY_NAME);
     }

--- a/EMS/common-bundle/src/Command/Admin/GetCommand.php
+++ b/EMS/common-bundle/src/Command/Admin/GetCommand.php
@@ -11,6 +11,7 @@ use EMS\CommonBundle\Contracts\CoreApi\CoreApiInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class GetCommand extends AbstractCommand
@@ -32,6 +33,7 @@ class GetCommand extends AbstractCommand
     public function initialize(InputInterface $input, OutputInterface $output): void
     {
         parent::initialize($input, $output);
+        $this->adminHelper->setLogger(new ConsoleLogger($output));
         $this->configType = $this->getArgumentString(self::CONFIG_TYPE);
         $this->export = $this->getOptionBool(self::EXPORT);
         $folder = $this->getOptionStringNull(self::FOLDER);

--- a/EMS/common-bundle/src/Command/Admin/JobCommand.php
+++ b/EMS/common-bundle/src/Command/Admin/JobCommand.php
@@ -11,6 +11,7 @@ use EMS\CommonBundle\Contracts\CoreApi\CoreApiInterface;
 use EMS\Helpers\Standard\Json;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class JobCommand extends AbstractCommand
@@ -29,6 +30,7 @@ class JobCommand extends AbstractCommand
     public function initialize(InputInterface $input, OutputInterface $output): void
     {
         parent::initialize($input, $output);
+        $this->adminHelper->setLogger(new ConsoleLogger($output));
         $this->jobIdOrJsonFile = $this->getArgumentString(self::JOB_ID);
     }
 

--- a/EMS/common-bundle/src/Command/Admin/LoginCommand.php
+++ b/EMS/common-bundle/src/Command/Admin/LoginCommand.php
@@ -10,6 +10,7 @@ use EMS\CommonBundle\Contracts\CoreApi\Exception\NotAuthenticatedExceptionInterf
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 
@@ -54,6 +55,7 @@ class LoginCommand extends AbstractCommand
     public function initialize(InputInterface $input, OutputInterface $output): void
     {
         parent::initialize($input, $output);
+        $this->adminHelper->setLogger(new ConsoleLogger($output));
         $baseUrl = $this->getArgumentStringNull(self::ARG_BASE_URL);
         if (null !== $baseUrl) {
             $this->backendUrl = $baseUrl;

--- a/EMS/common-bundle/src/Command/Admin/UpdateCommand.php
+++ b/EMS/common-bundle/src/Command/Admin/UpdateCommand.php
@@ -11,6 +11,7 @@ use EMS\Helpers\Standard\Json;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class UpdateCommand extends AbstractCommand
@@ -33,6 +34,7 @@ class UpdateCommand extends AbstractCommand
     public function initialize(InputInterface $input, OutputInterface $output): void
     {
         parent::initialize($input, $output);
+        $this->adminHelper->setLogger(new ConsoleLogger($output));
         $this->configType = $this->getArgumentString(self::CONFIG_TYPE);
         $this->entityName = $this->getArgumentString(self::ENTITY_NAME);
         $this->jsonPath = $this->getArgumentStringNull(self::JSON_PATH);

--- a/EMS/common-bundle/src/Command/Document/DownloadCommand.php
+++ b/EMS/common-bundle/src/Command/Document/DownloadCommand.php
@@ -11,6 +11,7 @@ use EMS\Helpers\Standard\Json;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class DownloadCommand extends AbstractCommand
@@ -30,6 +31,7 @@ class DownloadCommand extends AbstractCommand
     public function initialize(InputInterface $input, OutputInterface $output): void
     {
         parent::initialize($input, $output);
+        $this->adminHelper->setLogger(new ConsoleLogger($output));
         $this->contentType = $this->getArgumentString(self::CONTENT_TYPE);
         $folder = $this->getOptionStringNull(self::FOLDER);
         if (null !== $folder) {

--- a/EMS/common-bundle/src/Command/Document/UpdateCommand.php
+++ b/EMS/common-bundle/src/Command/Document/UpdateCommand.php
@@ -10,6 +10,7 @@ use EMS\Helpers\Standard\Json;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
@@ -31,6 +32,7 @@ class UpdateCommand extends AbstractCommand
     public function initialize(InputInterface $input, OutputInterface $output): void
     {
         parent::initialize($input, $output);
+        $this->adminHelper->setLogger(new ConsoleLogger($output));
         $this->contentType = $this->getArgumentString(self::CONTENT_TYPE);
         $folder = $this->getOptionStringNull(self::FOLDER);
         if (null !== $folder) {

--- a/EMS/common-bundle/src/Common/Admin/AdminHelper.php
+++ b/EMS/common-bundle/src/Common/Admin/AdminHelper.php
@@ -13,15 +13,24 @@ class AdminHelper
 {
     private ?CoreApiInterface $coreApi = null;
 
-    public function __construct(private readonly CoreApiFactoryInterface $coreApiFactory, private readonly CacheItemPoolInterface $cache, private readonly LoggerInterface $logger)
+    public function __construct(
+        private readonly CoreApiFactoryInterface $coreApiFactory,
+        private readonly CacheItemPoolInterface $cache,
+        private LoggerInterface $logger
+    )
     {
+    }
+
+    public function setLogger(LoggerInterface $logger): void
+    {
+        $this->logger = $logger;
     }
 
     public function login(string $baseUrl, string $username, string $password): CoreApiInterface
     {
         $this->coreApi = $this->coreApiFactory->create($baseUrl);
-        $this->coreApi->authenticate($username, $password);
         $this->coreApi->setLogger($this->logger);
+        $this->coreApi->authenticate($username, $password);
         $this->cache->save($this->apiCacheBaseUrl()->set($this->coreApi->getBaseUrl()));
         $this->cache->save($this->apiCacheToken($this->coreApi)->set($this->coreApi->getToken()));
 

--- a/EMS/common-bundle/src/Common/Admin/AdminHelper.php
+++ b/EMS/common-bundle/src/Common/Admin/AdminHelper.php
@@ -17,8 +17,7 @@ class AdminHelper
         private readonly CoreApiFactoryInterface $coreApiFactory,
         private readonly CacheItemPoolInterface $cache,
         private LoggerInterface $logger
-    )
-    {
+    ) {
     }
 
     public function setLogger(LoggerInterface $logger): void


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

Using the adminHelper inside a command we should use the consoleLogger.
Running a command with `-vvv` will still show the response/request logs.
