### PR TITLE
fix(contenttype): ems:contenttype:export walkRecursive

### DIFF
--- a/EMS/core-bundle/src/Service/DataService.php
+++ b/EMS/core-bundle/src/Service/DataService.php
@@ -357,11 +357,8 @@ class DataService
 
     /**
      * @param FormInterface<FormInterface> $form
-     * @param array<mixed>                 $rawData
-     *
-     * @return mixed
      */
-    public function walkRecursive(FormInterface $form, array $rawData, callable $callback)
+    private function walkRecursive(FormInterface $form, mixed $rawData, callable $callback): mixed
     {
         /** @var DataFieldType $dataFieldType */
         $dataFieldType = $form->getConfig()->getType()->getInnerType();


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

The walkRecurvise function is broken during removing phpstan baseline in version 4.
Also refactored the function from public -> private, only used inside the dataService

EMS\CoreBundle\Service\DataService::walkRecursive(): Argument #2 ($rawData) must be of type array, string given, called in core-bundle/src/Service/DataService.php on line 397
