### PR TITLE
fix: target path redirect not working

### DIFF
--- a/EMS/core-bundle/src/Resources/config/services.xml
+++ b/EMS/core-bundle/src/Resources/config/services.xml
@@ -9,6 +9,7 @@
         <!-- event listeners -->
         <service id="emsco.event_listener.access_denied_listener" class="EMS\CoreBundle\EventListener\AccessDeniedListener">
             <argument type="service" id="router"/>
+            <argument>%ems_core.security.firewall.core%</argument>
             <tag name="kernel.event_subscriber" />
         </service>
         <service id="ems_core.event_listener.login_listener" class="EMS\CoreBundle\EventListener\LoginListener">

--- a/EMS/core-bundle/src/Resources/views/user/login.html.twig
+++ b/EMS/core-bundle/src/Resources/views/user/login.html.twig
@@ -53,10 +53,6 @@
                     </div>
                 </div>
                 <div class="col-xs-4">
-                    {% set target = app.request.get('_target_path')|default(null) %}
-                    {% if target %}
-                        <input type="hidden" name="_target_path" value="{{ target }}" />
-                    {% endif %}
                     <input type="submit" id="_submit" name="_submit" value="{{ 'user.login.submit'|trans }}"  class="btn btn-primary btn-block btn-flat"/>
                 </div>
             </div>


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

Correctly save the targetPath in the session using the symfony targetPathTrait.
Url parameter `_target_path` not needed.

We created a requestListener for handeling the accessDenied exception on channels.
https://github.com/ems-project/EMSCoreBundle/pull/844/files

Channels public and private tested. Going to a private channel unauthenticated will redirect to login page. 

Normal access denied exceptions will also redirect to login page by default, and redirect after successful authentication

https://symfony.com/doc/3.1/security/target_path.html
> By default, the Security component retains the information of the last request URI in a **session** variable named _security.main.target_path (with main being the name of the firewall, defined in security.yml). Upon a successful login, the user is redirected to this path, as to help them continue from the last known page they visited.

