### PR TITLE
fix(unpublish): count all environments (include default)

### DIFF
--- a/EMS/core-bundle/src/Service/PublishService.php
+++ b/EMS/core-bundle/src/Service/PublishService.php
@@ -161,7 +161,7 @@ class PublishService
             throw new \LogicException('Unpublish failed: is default environment');
         }
 
-        if (1 === $this->environmentService->getPublishedForRevision($revision, true)->count()) {
+        if (1 === $this->environmentService->getPublishedForRevision($revision)->count()) {
             throw new \LogicException('Unpublish failed: requires 1 environment');
         }
 


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

Regression bug, we check that we are not unpublishing from default environment and also that at least 1 publish environment remains.

Second parameter `true` means, exclude default environment. Removing it counts all environments including default.

Why should we do this check? We can archive a revision, then it's unpublished from the default environment. Unpublishing it from the other environment can result in a revision not published anywhere.
