### PR TITLE
build(release): add changelog 5.x

### DIFF
--- a/CHANGELOG-5.x.md
+++ b/CHANGELOG-5.x.md
@@ -1,0 +1,42 @@
+# Changelog 5.x
+
+## 5.0.1 (2022-12-21)
+### Bug Fixes
+* fix: cache missed or hit in the emsco flashbag by @theus77 in https://github.com/ems-project/elasticms/pull/197
+* fix: double ems.command.admin.get by @Davidmattei in https://github.com/ems-project/elasticms/pull/199
+* fix: noinit options by @theus77 in https://github.com/ems-project/elasticms/pull/196
+
+## 5.0.0 (2022-12-20)
+### Features
+* feat(media-library): add media library component by @Davidmattei in https://github.com/ems-project/elasticms/pull/161
+* feat(web-migration): array to json object by @IsaMic in https://github.com/ems-project/elasticms/pull/168
+* feat: already connected by @theus77 in https://github.com/ems-project/elasticms/pull/180
+* feat: audit description by @theus77 in https://github.com/ems-project/elasticms/pull/152
+* feat: audit referer label by @theus77 in https://github.com/ems-project/elasticms/pull/163
+* feat: backup from CLI by @theus77 in https://github.com/ems-project/elasticms/pull/181
+* feat: elk8 by @theus77 in https://github.com/ems-project/elasticms/pull/187
+* feat: get version command by @theus77 in https://github.com/ems-project/elasticms/pull/184
+* feat: new copywriter role by @theus77 in https://github.com/ems-project/elasticms/pull/170
+* feat: switch default env command by @theus77 in https://github.com/ems-project/elasticms/pull/146
+* feat: tasks version by @Davidmattei in https://github.com/ems-project/elasticms/pull/185
+### Bug Fixes
+* fix: $emptyExtractor by @theus77 in https://github.com/ems-project/elasticms/pull/148
+* fix: int translation's key => string by @theus77 in https://github.com/ems-project/elasticms/pull/189
+* fix: label key might be an integer by @theus77 in https://github.com/ems-project/elasticms/pull/166
+* fix: options can be null by @theus77 in https://github.com/ems-project/elasticms/pull/165
+* fix: protected attached indexes by @theus77 in https://github.com/ems-project/elasticms/pull/153
+### Code Refactoring
+* refactor(file-upload): remove bootstrap-fileinput by @Davidmattei in https://github.com/ems-project/elasticms/pull/160
+* refactor: demo by @theus77 in https://github.com/ems-project/elasticms/pull/169
+* refactor: json by @theus77 in https://github.com/ems-project/elasticms/pull/183
+### Builds
+* build: enable splitter for demo by @Davidmattei in https://github.com/ems-project/elasticms/pull/172
+* build: release improvements by @Davidmattei in https://github.com/ems-project/elasticms/pull/191
+### Chores
+* chore: add CODEOWNERS file by @Davidmattei in https://github.com/ems-project/elasticms/pull/177
+* chore: add autolabeler config by @Davidmattei in https://github.com/ems-project/elasticms/pull/173
+* chore: composer validation by @Davidmattei in https://github.com/ems-project/elasticms/pull/190
+* chore: documentation repositories by @Davidmattei in https://github.com/ems-project/elasticms/pull/171
+* chore: moved to doc project by @theus77 in https://github.com/ems-project/elasticms/pull/182
+* chore: no pull requests for demo (readonly) by @Davidmattei in https://github.com/ems-project/elasticms/pull/176
+* chore: php 8.1 by @Davidmattei in https://github.com/ems-project/elasticms/pull/149

--- a/release/Command/GithubChangeLogCommand.php
+++ b/release/Command/GithubChangeLogCommand.php
@@ -101,7 +101,7 @@ class GithubChangeLogCommand extends AbstractGithubCommand
             }
         }
 
-        if (!$content = \file_get_contents($this->file)) {
+        if (false === $content = \file_get_contents($this->file)) {
             throw new \Exception(\sprintf('Could not read %s', $this->file));
         }
 


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |n|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

Small bug in the create if the changelog does not exist yet.
Then ran the following for creating the changelog

```bash
php release/run github:changelog 5.0.0 785d66e681b47ca3bfcf2d5103b967d71353525e --date=2022-12-20 --write
php release/run github:changelog 5.0.1 c403a76ca68d48e648a3e77903e577c23a2b39ba --date=2022-12-21 --write
````

Follow up pr of https://github.com/ems-project/elasticms/pull/198

