### PR TITLE
refactor(controller): remove argument for setContainer

### DIFF
--- a/EMS/client-helper-bundle/src/Resources/config/services.xml
+++ b/EMS/client-helper-bundle/src/Resources/config/services.xml
@@ -123,18 +123,14 @@
             <argument type="service" id="emsch.manager.client_request" />
             <argument type="service" id="emsch.helper_cache"/>
             <argument type="service" id="twig" />
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="controller.service_arguments"/>
             <tag name="container.service_subscriber"/>
         </service>
         <service id="EMS\ClientHelperBundle\Controller\AssetController" public="true">
             <argument type="service" id="EMS\CommonBundle\Twig\AssetRuntime"/>
             <argument type="string">%kernel.project_dir%</argument>
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="controller.service_arguments"/>
             <tag name="container.service_subscriber"/>
         </service>

--- a/EMS/common-bundle/src/Resources/config/metric.xml
+++ b/EMS/common-bundle/src/Resources/config/metric.xml
@@ -24,9 +24,7 @@
         <service id="ems.controller.metric" class="EMS\CommonBundle\Controller\MetricController">
             <argument type="service" id="ems.metric.collector" />
             <argument>%ems.metric.port%</argument>
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="controller.service_arguments"/>
             <tag name="container.service_subscriber"/>
         </service>

--- a/EMS/common-bundle/src/Resources/config/storage.xml
+++ b/EMS/common-bundle/src/Resources/config/storage.xml
@@ -17,9 +17,7 @@
         <service id="EMS\CommonBundle\Controller\FileController">
             <argument type="service" id="ems_common.storage.processor"/>
             <argument type="service" id="ems_common.twig.runtime.request"/>
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="controller.service_arguments"/>
             <tag name="container.service_subscriber"/>
         </service>

--- a/EMS/core-bundle/src/Resources/config/controllers.xml
+++ b/EMS/core-bundle/src/Resources/config/controllers.xml
@@ -26,18 +26,14 @@
         <service id="EMS\CoreBundle\Controller\Api\Form\SubmissionController" public="true">
             <argument type="service" id="ems.form_submission" />
             <argument type="service" id="logger" />
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
         <service id="EMS\CoreBundle\Controller\Api\Form\VerificationController" public="true">
             <argument type="service" id="ems.form_verification" />
             <argument type="service" id="logger" />
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
@@ -65,18 +61,14 @@
         <service id="EMS\CoreBundle\Controller\ContentManagement\ActionController" public="true">
             <argument type="service" id="logger" />
             <argument type="service" id="ems.service.action" />
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
         <service id="EMS\CoreBundle\Controller\ContentManagement\AnalyzerController" public="true">
             <argument type="service" id="emsco.logger" />
             <argument type="service" id="ems.service.helper" />
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
@@ -84,9 +76,7 @@
             <argument type="service" id="ems_common.storage.processor" />
             <argument type="service" id="ems.repository.channel" />
             <argument>%ems_core.asset_config%</argument>
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
@@ -95,9 +85,7 @@
             <argument type="service" id="ems.service.contenttype" />
             <argument type="service" id="ems.service.mapping" />
             <argument type="service" id="form.registry" />
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
@@ -106,9 +94,7 @@
             <argument type="service" id="ems.service.user" />
             <argument type="service" id="ems.service.data" />
             <argument type="service" id="ems.service.contenttype" />
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
         </service>
         <service id="EMS\CoreBundle\Controller\ContentManagement\DataController" public="true">
@@ -123,9 +109,7 @@
             <argument type="service" id="twig" />
             <argument type="service" id="ems_common.pdf.printer.dom" />
             <argument type="service" id="ems.service.job" />
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
@@ -133,9 +117,7 @@
             <argument type="service" id="ems.service.datatable" />
             <argument type="service" id="ems_core.core_data_table.table_renderer" />
             <argument type="service" id="ems_core.core_data_table.table_exporter" />
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
@@ -153,34 +135,26 @@
             <argument>%ems_core.paging_size%</argument>
             <argument>%ems_core.instance_id%</argument>
             <argument>%ems_core.circles_object%</argument>
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
         </service>
         <service id="EMS\CoreBundle\Controller\ContentManagement\FileController" public="true">
             <argument type="service" id="ems.service.file" />
             <argument type="service" id="ems.service.asset_extractor" />
             <argument type="service" id="emsco.logger" />
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
         </service>
         <service id="EMS\CoreBundle\Controller\ContentManagement\FilterController" public="true">
             <argument type="service" id="emsco.logger" />
             <argument type="service" id="ems.service.helper" />
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
         <service id="EMS\CoreBundle\Controller\ContentManagement\IndexController" public="true">
             <argument type="service" id="ems.service.index" />
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
         </service>
         <service id="EMS\CoreBundle\Controller\ContentManagement\JobController" public="true">
@@ -188,9 +162,7 @@
             <argument type="service" id="ems.service.job" />
             <argument>%ems_core.paging_size%</argument>
             <argument>%ems_core.trigger_job_from_web%</argument>
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
@@ -198,9 +170,7 @@
             <argument type="service" id="emsco.logger" />
             <argument type="service" id="ems.service.alias" />
             <argument>%ems_core.instance_id%</argument>
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
@@ -211,9 +181,7 @@
             <argument type="service" id="ems.service.contenttype" />
             <argument type="service" id="ems.service.search" />
             <argument type="service" id="ems_common.service.elastica" />
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
@@ -221,9 +189,7 @@
             <argument type="service" id="logger" />
             <argument type="service" id="ems.service.release" />
             <argument type="service" id="ems.service.release_revision" />
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
@@ -231,9 +197,7 @@
             <argument type="service" id="ems.service.contenttype" />
             <argument type="service" id="ems.view.manager" />
             <argument type="service" id="logger"/>
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
@@ -242,9 +206,7 @@
         <service id="EMS\CoreBundle\Controller\Dashboard\DashboardController" public="true">
             <argument type="service" id="logger"/>
             <argument type="service" id="ems.dashboard.manager" />
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
@@ -253,9 +215,7 @@
         <service id="EMS\CoreBundle\Controller\Form\SubmissionController" public="true">
             <argument type="service" id="ems.form_submission" />
             <argument type="service" id="logger" />
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
@@ -264,9 +224,7 @@
         <service id="EMS\CoreBundle\Controller\Job\ScheduleController" public="true">
             <argument type="service" id="ems.schedule.manager" />
             <argument type="service" id="logger"/>
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
@@ -275,9 +233,7 @@
         <service id="EMS\CoreBundle\Controller\Log\LogController" public="true">
             <argument type="service" id="ems.log.manager" />
             <argument type="service" id="logger" />
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
@@ -292,9 +248,7 @@
             <argument type="service" id="ems.service.search" />
             <argument type="service" id="ems.log.manager"/>
             <argument type="service" id="logger" />
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
@@ -305,9 +259,7 @@
             <argument type="service" id="ems.service.publish" />
             <argument type="service" id="ems.service.revision" />
             <argument type="service" id="translator" />
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
@@ -317,9 +269,7 @@
             <argument type="service" id="ems.service.revision" />
             <argument type="service" id="ems.service.data" />
             <argument type="service" id="ems.service.user" />
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
@@ -328,9 +278,7 @@
             <argument type="service" id="ems_core.core_ui.ajax_service" />
             <argument type="service" id="form.factory" />
             <argument type="service" id="ems_core.core_data_table.table_exporter" />
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
@@ -340,9 +288,7 @@
             <argument type="service" id="ems.service.query_search" />
             <argument type="service" id="EMS\CoreBundle\Controller\ElasticsearchController" />
             <argument type="service" id="ems_core.core_document.data_links_factory" />
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
@@ -355,18 +301,14 @@
         <service id="EMS\CoreBundle\Controller\User\ProfileController" public="true">
             <argument type="service" id="emsco.manager.user" />
             <argument type="service" id="emsco.logger" />
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
         </service>
         <service id="EMS\CoreBundle\Controller\User\ResettingController" public="true">
             <argument type="service" id="emsco.manager.user" />
             <argument type="service" id="ems_core.security.authenticator" />
             <argument type="service" id="emsco.logger" />
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
         </service>
 
@@ -376,9 +318,7 @@
             <argument type="service" id="ems_common.service.elastica" />
             <argument type="service" id="ems.service.data" />
             <argument type="service" id="ems.service.search" />
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
@@ -390,18 +330,14 @@
             <argument type="service" id="ems.form.factories.objectChoiceListFactory" />
             <argument type="service" id="security.authorization_checker" />
             <argument type="service" id="form.registry" />
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
         <service id="EMS\CoreBundle\Controller\Views\HierarchicalController" public="true">
             <argument type="service" id="ems.service.contenttype" />
             <argument type="service" id="ems.service.search" />
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
@@ -409,9 +345,7 @@
         <!-- Wysiwyg -->
         <service id="EMS\CoreBundle\Controller\Wysiwyg\StylesetController" public="true">
             <argument type="service" id="ems.service.wysiwyg_styles_set" />
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
@@ -420,25 +354,19 @@
         <service id="EMS\CoreBundle\Controller\ChannelController" public="true">
             <argument type="service" id="logger" />
             <argument type="service" id="ems.service.channel" />
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
         <service id="EMS\CoreBundle\Controller\DashboardController" public="true">
             <argument type="service" id="ems.dashboard.manager" />
             <argument type="service" id="ems_core.dashboard.dashboards" />
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
         <service id="EMS\CoreBundle\Controller\DefaultController" public="true">
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
         </service>
         <service id="EMS\CoreBundle\Controller\ElasticsearchController" public="true">
@@ -458,18 +386,14 @@
             <argument>%ems_core.paging_size%</argument>
             <argument>%ems_core.health_check_allow_origin%</argument>
             <argument>%ems_core.elasticsearch_cluster%</argument>
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
         <service id="EMS\CoreBundle\Controller\I18nController" public="true">
             <argument type="service" id="ems.service.i18n" />
             <argument>%ems_core.paging_size%</argument>
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
@@ -481,18 +405,14 @@
             <argument type="service" id="ems.service.notification"/>
             <argument type="service" id="ems.dashboard.manager"/>
             <argument>%ems_core.paging_size%</argument>
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
         <service id="EMS\CoreBundle\Controller\QuerySearchController" public="true">
             <argument type="service" id="logger" />
             <argument type="service" id="ems.service.query_search" />
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
@@ -501,9 +421,7 @@
             <argument type="service" id="ems.service.aggregate_option" />
             <argument type="service" id="ems.service.search_field_option" />
             <argument type="service" id="translator" />
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
@@ -514,27 +432,21 @@
             <argument type="service" id="ems.service.job"/>
             <argument type="service" id="ems.dashboard.manager"/>
             <argument type="service" id="ems.service.contenttype"/>
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
         <service id="EMS\CoreBundle\Controller\UploadedFileController" public="true">
             <argument type="service" id="emsco.logger" />
             <argument type="service" id="ems.service.file" />
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
         </service>
         <service id="EMS\CoreBundle\Controller\UploadedFileWysiwygController" public="true">
             <argument type="service" id="ems.service.file" />
             <argument type="service" id="ems_core.core_ui.ajax_service" />
             <argument type="service" id="router" />
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
@@ -544,9 +456,7 @@
             <argument type="service" id="ems.service.user" />
             <argument type="service" id="emsco.manager.user" />
             <argument type="service" id="EMS\CommonBundle\Contracts\SpreadsheetGeneratorServiceInterface"/>
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
@@ -554,9 +464,7 @@
             <argument type="service" id="ems.service.wysiwyg_profile" />
             <argument type="service" id="ems.service.wysiwyg_styles_set" />
             <argument type="service" id="translator" />
-            <call method="setContainer">
-                <argument type="service" id="Psr\Container\ContainerInterface"/>
-            </call>
+            <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |n|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

We got an invalid argument, but we do not need to pass the argument because our controllers are tagged with ``container.service_subscriber`

https://github.com/symfony/symfony/discussions/44628
