### PR TITLE
fix(notification): treat notification not refreshing

### DIFF
--- a/EMS/core-bundle/src/Form/Form/TreatNotificationsType.php
+++ b/EMS/core-bundle/src/Form/Form/TreatNotificationsType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EMS\CoreBundle\Form\Form;
 
 use EMS\CoreBundle\Form\Field\EnvironmentPickerType;
@@ -19,49 +21,32 @@ class TreatNotificationsType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        $notifications = $options['notifications'];
-
-        $builder->add('notifications', CollectionType::class, [
+        $builder
+            ->add('notifications', CollectionType::class, [
                 'entry_type' => CheckboxType::class,
                 'allow_add' => true,
                 'required' => false,
-                'entry_options' => [
-                    'label' => null,
-                    'required' => false,
-                ],
+                'entry_options' => ['label' => null, 'required' => false],
             ])
             ->add('publishTo', EnvironmentPickerType::class, [
-                    'multiple' => false,
-                    'required' => false,
+                'multiple' => false,
+                'required' => false,
             ])
-//             ->add('unpublishFrom', EnvironmentPickerType::class, [
-//                     'multiple' => false,
-//                     'required' => false,
-//             ] )
             ->add('response', TextareaType::class, [
-                    'attr' => [
-                            'class' => 'ckeditor',
-                    ],
+                'attr' => ['class' => 'ckeditor'],
             ])
             ->add('accept', SubmitEmsType::class, [
-                    'attr' => [
-                            'class' => 'btn btn-success btn-md',
-                    ],
-                    'disabled' => true,
-                    'icon' => 'fa fa-check',
+                'attr' => ['class' => 'btn btn-success btn-md'],
+                'icon' => 'fa fa-check',
             ])
             ->add('reject', SubmitEmsType::class, [
-                    'attr' => [
-                            'class' => 'btn btn-danger btn-md',
-                    ],
-                    'icon' => 'fa fa-ban',
+                'attr' => ['class' => 'btn btn-danger btn-md'],
+                'icon' => 'fa fa-ban',
             ]);
     }
 
     public function configureOptions(OptionsResolver $resolver): void
     {
-        $resolver->setDefaults([
-            'notifications' => [],
-        ]);
+        $resolver->setDefaults(['notifications' => []]);
     }
 }

--- a/EMS/core-bundle/src/Resources/views/notification/inboxToTreat.html.twig
+++ b/EMS/core-bundle/src/Resources/views/notification/inboxToTreat.html.twig
@@ -100,7 +100,7 @@
 	      <div class="modal-footer">
 	      
 			<div class="btn-group">
-              	{{ form_widget(treatform.accept) }}		
+              	{{ form_widget(treatform.accept, { 'attr': { 'disabled': true } }) }}
               	{{ form_widget(treatform.reject) }}
 			</div>
 	      </div>

--- a/EMS/core-bundle/src/Service/NotificationService.php
+++ b/EMS/core-bundle/src/Service/NotificationService.php
@@ -436,6 +436,7 @@ class NotificationService
             EmsFields::LOG_REVISION_ID_FIELD => $notification->getRevision()->getId(),
             EmsFields::LOG_ENVIRONMENT_FIELD => $notification->getEnvironment()->getName(),
             'status' => $notification->getStatus(),
+            'label' => $notification->getRevision()->getLabel(),
         ]);
     }
 


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

In the controller we check if the accept button isClicked, because we are disabling it through the symfony form it is always returning false.

Fix is disabling the button in Twig. This way symfony form will return true if it was clicked

Bug comes from this PR: https://github.com/ems-project/EMSCoreBundle/pull/1220

