### PR TITLE
fix(cli): define all timeouts in cache manager

### DIFF
--- a/elasticms-cli/src/Client/HttpClient/CacheManager.php
+++ b/elasticms-cli/src/Client/HttpClient/CacheManager.php
@@ -39,6 +39,8 @@ class CacheManager
             'handler' => $stack,
             RequestOptions::ALLOW_REDIRECTS => $allowRedirect,
             RequestOptions::CONNECT_TIMEOUT => 10,
+            RequestOptions::TIMEOUT => 10,
+            RequestOptions::READ_TIMEOUT => 10,
         ]);
     }
 


### PR DESCRIPTION
for website like tiktok or linkedin that doesn't support standards

|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|


