### PR TITLE
feat(cli): save audit

### DIFF
--- a/elasticms-cli/src/Command/Web/AuditCommand.php
+++ b/elasticms-cli/src/Command/Web/AuditCommand.php
@@ -231,8 +231,12 @@ class AuditCommand extends AbstractCommand
         }
         $this->auditCache->progressFinish($output, $counter);
 
-        if (!$this->auditCache->hasNext()) {
-            $this->deleteNonUpdated();
+        if (!$this->auditCache->hasNext() && !$this->dryRun) {
+            try {
+                $this->deleteNonUpdated();
+            } catch (\Throwable $e) {
+                $this->io->warning(\sprintf('The command was not able to delete old documents: %s', $e->getMessage()));
+            }
         }
 
         $this->io->section('Save cache and report');


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |n|
|New feature?   |y|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

Save audit documents as JSON in order to reupload them in another ems
