### PR TITLE
fix(jsonMenuNested): copy all broken

### DIFF
--- a/EMS/core-bundle/assets/js/module/jsonMenuNested.js
+++ b/EMS/core-bundle/assets/js/module/jsonMenuNested.js
@@ -190,7 +190,7 @@ export default class JsonMenuNested {
 
             let json = JSON.parse(localStorage.getItem(this.copyName));
 
-            return loopJson(json, (key, value) => key === 'id' && value !== 'root' ? uuidv4() : value);
+            return loopJson(json, (key, value) => key === 'id' && value !== '_root' ? uuidv4() : value);
         }
 
         return false;
@@ -302,9 +302,9 @@ export default class JsonMenuNested {
         btnCopyAll.onclick = (e) => {
             e.preventDefault();
             this._setCopy({
-                id: 'root',
-                label: 'root',
-                type: 'root',
+                id: '_root',
+                label: '_root',
+                type: '_root',
                 children: JSON.parse(this.getStructureJson())
             });
         }
@@ -348,7 +348,8 @@ export default class JsonMenuNested {
             btnPaste.onclick = (e) => {
                 e.preventDefault();
 
-                let copied = this._getCopy(true);
+                let copied = this._getCopy();
+
                 if (false === copied) {
                     return;
                 }

--- a/EMS/core-bundle/src/Resources/views/revision/json/json_menu_nested.html.twig
+++ b/EMS/core-bundle/src/Resources/views/revision/json/json_menu_nested.html.twig
@@ -206,7 +206,7 @@
                         <button class="btn-json-menu-nested-paste"
                                 data-item-id="{{ item.id }}"
                                 data-node-id="{{ node.id }}"
-                                {%- if 'root' == position %}data-allow="root"{% endif -%}>
+                                {%- if 'root' == position %}data-allow="_root"{% endif -%}>
                             <span class="fa fa-paste"></span>&nbsp;{{ 'field_type.json_menu_editor.paste'|trans }}
                         </button>
                     </li>


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

Broken because we changed the type from 'root' to '_root', and did not update the javascript code for copy.
https://github.com/ems-project/EMSCommonBundle/pull/442/files

