### PR TITLE
fix(rebuild): publishing multiple revisions in default env

### DIFF
--- a/EMS/core-bundle/src/Command/RecomputeCommand.php
+++ b/EMS/core-bundle/src/Command/RecomputeCommand.php
@@ -200,8 +200,6 @@ final class RecomputeCommand extends Command
                 $this->em->persist($revision);
                 $this->em->persist($newRevision);
                 $this->em->flush();
-                $this->em->detach($revision);
-                $this->em->detach($newRevision);
 
                 $this->indexService->indexRevision($newRevision);
 
@@ -225,6 +223,7 @@ final class RecomputeCommand extends Command
             if ($transactionActive) {
                 $this->em->commit();
             }
+            $this->em->clear();
 
             $paginator = $this->revisionRepository->findAllLockedRevisions($this->contentType, self::LOCK_BY, $page, $limit);
             $iterator = $paginator->getIterator();

--- a/EMS/core-bundle/src/Command/ReindexCommand.php
+++ b/EMS/core-bundle/src/Command/ReindexCommand.php
@@ -175,9 +175,6 @@ class ReindexCommand extends EmsCommand
 
                 $em->flush();
                 $em->clear();
-                foreach ($paginator as $revision) {
-                    $em->detach($revision);
-                }
 
                 ++$page;
                 $paginator = $revRepo->getRevisionsPaginatorPerEnvironmentAndContentType($environment, $contentType, $page);


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

This was not correct, we should just clear().
https://github.com/ems-project/elasticms/pull/143

Original issue: https://github.com/ems-project/EMSCoreBundle/pull/1174

Recompute and reindex trigger from job also still completes the job.
