### PR TITLE
fix(recompute): deep recompute skip deleted fields

### DIFF
--- a/EMS/core-bundle/src/Command/RecomputeCommand.php
+++ b/EMS/core-bundle/src/Command/RecomputeCommand.php
@@ -180,6 +180,7 @@ final class RecomputeCommand extends Command
                 $revisionType->setData($newRevision); // bind new revision on form
 
                 if ($this->optionDeep) {
+                    $newRevision->setRawData([]);
                     $viewData = $this->dataService->getSubmitData($revisionType->get('data')); // get view data of new revision
                     $revisionType->submit(['data' => $viewData]); // submit new revision (reverse model transformers called
                 }


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

We were not cleaning the rawData, this way deleted fields stay indexed.
