### PR TITLE
fix(core-twig): in_my_circles ($circles) must be of type array|string

### DIFF
--- a/EMS/core-bundle/src/Repository/EnvironmentRepository.php
+++ b/EMS/core-bundle/src/Repository/EnvironmentRepository.php
@@ -150,7 +150,7 @@ class EnvironmentRepository extends EntityRepository
                 'alias' => $record['alias'],
                 'managed' => $record['managed'],
                 'baseUrl' => $record['baseUrl'],
-                'circles' => $record['circles'],
+                'circles' => $record['circles'] ?? [],
             ];
         }
 


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

environment.circles|in_my_circles but the environment is an array and circles is nullable. 
Now if circles is null we pass an empty array.
