### PR TITLE
fix(docker): expose cluster

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -27,6 +27,8 @@ services:
     extends:
       file: ../demo/docker-${ELK_VERSION-elk7}.yml
       service: es01
+    ports:
+      - "9201:9200"
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.es.rule=Host(`es.localhost`)"
@@ -37,6 +39,8 @@ services:
     extends:
       file: ../demo/docker-${ELK_VERSION-elk7}.yml
       service: es02
+    ports:
+      - "9202:9200"
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.es.rule=Host(`es.localhost`)"
@@ -47,6 +51,8 @@ services:
     extends:
       file: ../demo/docker-${ELK_VERSION-elk7}.yml
       service: es03
+    ports:
+      - "9203:9200"
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.es.rule=Host(`es.localhost`)"


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

For supporting:

EMS_ELASTICSEARCH_HOSTS='["http://localhost:9201","http://localhost:9202","http://localhost:9203"]'
