### PR TITLE
fix(jsonMenuNested): label not working

### DIFF
--- a/EMS/common-bundle/src/Json/JsonMenuNested.php
+++ b/EMS/common-bundle/src/Json/JsonMenuNested.php
@@ -31,7 +31,7 @@ final class JsonMenuNested implements \IteratorAggregate, \Countable, \Stringabl
     {
         $this->id = $data['id'];
         $this->type = $data['type'];
-        $this->label = \strval($data['label']) ?: '';
+        $this->label = \strval($data['label'] ?? '');
         $this->object = $data['object'] ?? [];
 
         $children = $data['children'] ?? [];


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

Target 5.2 for this pr https://github.com/ems-project/elasticms/pull/313/files
