### PR TITLE
fix(admin): doctrine migrations in dev mode

### DIFF
--- a/elasticms-admin/bin/console
+++ b/elasticms-admin/bin/console
@@ -8,6 +8,7 @@ file_exists(dirname(__DIR__).'/vendor/autoload_runtime.php') ?
     require_once dirname(__DIR__).'/vendor/autoload_runtime.php' :
     require_once dirname(__DIR__).'/../vendor/autoload_runtime.php';
 
+$_SERVER['ELASTICMS_PATH'] = file_exists(dirname(__DIR__).'/vendor/elasticms') ?: dirname(__DIR__).'/../EMS';
 $_SERVER['APP_RUNTIME_OPTIONS'] = [
     'disable_dotenv' => ('true' === ($_SERVER['APP_DISABLE_DOTENV'] ?? false)),
     'prod_envs' => ['prod', 'redis'],

--- a/elasticms-admin/bin/console
+++ b/elasticms-admin/bin/console
@@ -8,7 +8,10 @@ file_exists(dirname(__DIR__).'/vendor/autoload_runtime.php') ?
     require_once dirname(__DIR__).'/vendor/autoload_runtime.php' :
     require_once dirname(__DIR__).'/../vendor/autoload_runtime.php';
 
-$_SERVER['ELASTICMS_PATH'] = file_exists(dirname(__DIR__).'/vendor/elasticms') ? dirname(__DIR__).'/vendor/elasticms' : dirname(__DIR__).'/../EMS';
+$_SERVER['ELASTICMS_PATH'] = file_exists(dirname(__DIR__).'/vendor/elasticms') ?
+    dirname(__DIR__).'/vendor/elasticms' :
+    dirname(__DIR__).'/../EMS';
+
 $_SERVER['APP_RUNTIME_OPTIONS'] = [
     'disable_dotenv' => ('true' === ($_SERVER['APP_DISABLE_DOTENV'] ?? false)),
     'prod_envs' => ['prod', 'redis'],

--- a/elasticms-admin/bin/console
+++ b/elasticms-admin/bin/console
@@ -8,7 +8,7 @@ file_exists(dirname(__DIR__).'/vendor/autoload_runtime.php') ?
     require_once dirname(__DIR__).'/vendor/autoload_runtime.php' :
     require_once dirname(__DIR__).'/../vendor/autoload_runtime.php';
 
-$_SERVER['ELASTICMS_PATH'] = file_exists(dirname(__DIR__).'/vendor/elasticms') ?: dirname(__DIR__).'/../EMS';
+$_SERVER['ELASTICMS_PATH'] = file_exists(dirname(__DIR__).'/vendor/elasticms') ? dirname(__DIR__).'/vendor/elasticms' : dirname(__DIR__).'/../EMS';
 $_SERVER['APP_RUNTIME_OPTIONS'] = [
     'disable_dotenv' => ('true' === ($_SERVER['APP_DISABLE_DOTENV'] ?? false)),
     'prod_envs' => ['prod', 'redis'],

--- a/elasticms-admin/config/packages/doctrine_migrations.yaml
+++ b/elasticms-admin/config/packages/doctrine_migrations.yaml
@@ -1,6 +1,6 @@
 doctrine_migrations:
     migrations_paths:
-        Application\Migrations: '%kernel.project_dir%/vendor/elasticms/core-bundle/src/Resources/DoctrineMigrations/pdo_%env(resolve:DB_DRIVER)%'
+        Application\Migrations: '%env(string:ELASTICMS_PATH)%/core-bundle/src/Resources/DoctrineMigrations/pdo_%env(resolve:DB_DRIVER)%'
     storage:
         table_storage:
             table_name: 'migration_versions'
@@ -11,4 +11,4 @@ doctrine_migrations:
 when@dev:
   doctrine_migrations:
     migrations_paths:
-      Application\Migrations: '%kernel.project_dir%/../EMS/core-bundle/src/Resources/DoctrineMigrations/pdo_%env(resolve:DB_DRIVER)%'
+      Application\Migrations: '%env(string:ELASTICMS_PATH)%/core-bundle/src/Resources/DoctrineMigrations/pdo_%env(resolve:DB_DRIVER)%'

--- a/elasticms-admin/config/packages/framework.yaml
+++ b/elasticms-admin/config/packages/framework.yaml
@@ -1,5 +1,6 @@
 parameters:
     env(DEFAULT_LOCAL): 'en'
+    env(ELASTICMS_PATH): '%kernel.project_dir%/vendor/elasticms'
 
 framework:
     secret: '%env(APP_SECRET)%'


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |n|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

In `dev` mode the demo was not searching for the migrations in the correct path.
Added a new `ELASTICMS_PATH` variable for defining the location of Elasticms (packages/bundles)

This PR targets 5.2
