### PR TITLE
fix(emsch/search): query_search replace request values

### DIFF
--- a/EMS/client-helper-bundle/src/Helper/Search/QueryBuilder.php
+++ b/EMS/client-helper-bundle/src/Helper/Search/QueryBuilder.php
@@ -83,10 +83,13 @@ final class QueryBuilder
             }
 
             $textMust = new BoolQuery();
-            $textMust->addMust(\array_values(\array_map(fn (TextValue $textValue) => $textValue->makeShould(), $textValues)));
+            foreach ($textValues as $textValue) {
+                $textMust->addMust($textValue->makeShould());
+            }
 
-            $queryFields->setMinimumShouldMatch(1)->addShould($textMust);
+            $query->setMinimumShouldMatch(1)->addShould($textMust);
         }
+
         if ($queryFields->count() > 0) {
             $query->addMust($queryFields);
         }

--- a/EMS/client-helper-bundle/src/Helper/Search/Search.php
+++ b/EMS/client-helper-bundle/src/Helper/Search/Search.php
@@ -160,9 +160,12 @@ final class Search
             return null;
         }
 
-        $stringQuerySearch = u(Json::encode($this->querySearch))->replace('%query%', $queryString)->toString();
+        $jsonQueryString = Json::encode($this->querySearch);
 
-        return Json::decode($stringQuerySearch);
+        $queryString = u($jsonQueryString)->replace('%query%', $queryString)->toString();
+        $queryString = RequestHelper::replace($this->request, $queryString);
+
+        return Json::decode($queryString);
     }
 
     public function getAnalyzer(): string


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

Support %_locale% and other request parameters replacement in query_search option for search_config.
