### PR TITLE
fix(notifications): outbox table not showing results

### DIFF
--- a/EMS/core-bundle/src/Controller/NotificationController.php
+++ b/EMS/core-bundle/src/Controller/NotificationController.php
@@ -175,7 +175,7 @@ class NotificationController extends AbstractController
 
         $rejectedNotifications = [];
         if ('sent' == $folder) {
-            $notifications = $this->notificationService->listSentNotifications(($page - 1) * $paging_size, $paging_size, $filters);
+            $notifications = $this->notificationService->listSentNotifications(($page - 1) * $paging_size, $paging_size, $notificationFilter);
             $lastPage = \ceil($countSent / $paging_size);
         } else {
             $notifications = $this->notificationService->listInboxNotifications(($page - 1) * $paging_size, $paging_size, $filters);

--- a/EMS/core-bundle/src/Entity/Form/NotificationFilter.php
+++ b/EMS/core-bundle/src/Entity/Form/NotificationFilter.php
@@ -4,50 +4,25 @@ declare(strict_types=1);
 
 namespace EMS\CoreBundle\Entity\Form;
 
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use EMS\CoreBundle\Entity\ContentType;
 use EMS\CoreBundle\Entity\Environment;
 use EMS\CoreBundle\Entity\Template;
 
 class NotificationFilter
 {
-    private ?Template $template = null;
-    private ?Environment $environment = null;
+    /** @var Collection<int, Template> */
+    public Collection $template;
+    /** @var Environment[] */
+    public array $environment;
+    /** @var Collection<int, ContentType> */
+    public Collection $contentType;
 
-    private ?ContentType $contentType = null;
-
-    public function setTemplate(?Template $template): NotificationFilter
+    public function __construct()
     {
-        $this->template = $template;
-
-        return $this;
-    }
-
-    public function getTemplate(): ?Template
-    {
-        return $this->template;
-    }
-
-    public function setEnvironment(?Environment $environment): NotificationFilter
-    {
-        $this->environment = $environment;
-
-        return $this;
-    }
-
-    public function getEnvironment(): ?Environment
-    {
-        return $this->environment;
-    }
-
-    public function setContentType(?ContentType $contentType): NotificationFilter
-    {
-        $this->contentType = $contentType;
-
-        return $this;
-    }
-
-    public function getContentType(): ?ContentType
-    {
-        return $this->contentType;
+        $this->template = new ArrayCollection();
+        $this->contentType = new ArrayCollection();
+        $this->environment = [];
     }
 }

--- a/EMS/core-bundle/src/Form/Form/NotificationFormType.php
+++ b/EMS/core-bundle/src/Form/Form/NotificationFormType.php
@@ -34,16 +34,7 @@ class NotificationFormType extends AbstractType
 '<i class="'.$value->getContentType()->getIcon().' text-'.$value->getContentType()->getColor().'"></i>&nbsp;&nbsp;'.$value->getName().' for '.$value->getContentType()->getSingularName(),
             'multiple' => true,
             'required' => false,
-            'choice_value' => function ($value) {
-                if (null != $value) {
-                    return $value->getId();
-                }
-
-                return $value;
-            },
-            'attr' => [
-                    'class' => 'select2',
-            ],
+            'attr' => ['class' => 'select2'],
         ])
         ->add('environment', ChoiceType::class, [
                 'attr' => [
@@ -74,23 +65,12 @@ class NotificationFormType extends AbstractType
                 'choice_label' => fn ($value, $key, $index) => '<i class="'.$value->getIcon().' text-'.$value->getColor().'"></i>&nbsp;&nbsp;'.$value->getSingularName(),
                 'multiple' => true,
                 'required' => false,
-                'choice_value' => function ($value) {
-                    if (null != $value) {
-                        return $value->getId();
-                    }
-
-                    return $value;
-                },
-                'attr' => [
-                        'class' => 'select2',
-                ],
+                'attr' => ['class' => 'select2'],
         ])
 
         ->add('filter', SubmitEmsType::class, [
                 'translation_domain' => EMSCoreBundle::TRANS_DOMAIN,
-                'attr' => [
-                        'class' => 'btn-primary btn-md',
-                ],
+                'attr' => ['class' => 'btn btn-primary btn-sm'],
                 'icon' => 'fa fa-columns',
         ]);
     }

--- a/EMS/core-bundle/src/Repository/TemplateRepository.php
+++ b/EMS/core-bundle/src/Repository/TemplateRepository.php
@@ -22,19 +22,19 @@ class TemplateRepository extends ServiceEntityRepository
     }
 
     /**
-     * @param int[] $contentTypeIds
+     * @param ?ContentType[] $contentTypes
      *
      * @return Template[]
      */
-    public function findByRenderOptionAndContentType(string $option, ?array $contentTypeIds = null): array
+    public function findByRenderOptionAndContentType(string $option, ?array $contentTypes = null): array
     {
         $qb = $this->createQueryBuilder('t')
         ->select('t')
         ->where('t.renderOption = :option');
 
-        if (null != $contentTypeIds) {
+        if (null != $contentTypes) {
             $qb->andWhere('t.contentType IN (:cts)')
-            ->setParameters(['option' => $option, 'cts' => $contentTypeIds]);
+            ->setParameters(['option' => $option, 'cts' => $contentTypes]);
         } else {
             $qb->setParameter('option', $option);
         }

--- a/EMS/core-bundle/src/Service/NotificationService.php
+++ b/EMS/core-bundle/src/Service/NotificationService.php
@@ -6,6 +6,7 @@ use Doctrine\Bundle\DoctrineBundle\Registry;
 use EMS\CommonBundle\Helper\EmsFields;
 use EMS\CoreBundle\Core\Mail\MailerService;
 use EMS\CoreBundle\Entity\Environment;
+use EMS\CoreBundle\Entity\Form\NotificationFilter;
 use EMS\CoreBundle\Entity\Form\TreatNotifications;
 use EMS\CoreBundle\Entity\Notification;
 use EMS\CoreBundle\Entity\Revision;
@@ -385,39 +386,15 @@ class NotificationService
     }
 
     /**
-     * @param ?array<mixed> $filters
-     *
      * @return Notification[]
      */
-    public function listSentNotifications(int $from, int $limit, array $filters = null): array
+    public function listSentNotifications(int $from, int $limit, NotificationFilter $notificationFilter): array
     {
-        $contentTypes = null;
-        $environments = null;
-        $templates = null;
-
-        if (null != $filters) {
-            if (isset($filters['contentType'])) {
-                $contentTypes = $filters['contentType'];
-            } elseif (isset($filters['environment'])) {
-                $environments = $filters['environment'];
-            } elseif (isset($filters['template'])) {
-                $templates = $filters['template'];
-            }
-        }
-
         $em = $this->doctrine->getManager();
         /** @var NotificationRepository $repository */
         $repository = $em->getRepository(Notification::class);
-        $notifications = $repository->findByPendingAndRoleAndCircleForUserSent($this->userService->getCurrentUser(), $from, $limit, $contentTypes, $environments, $templates);
 
-//         /**@var Notification $notification*/
-//         foreach ($notifications as $notification) {
-//             $result = $repository->countNotificationByUuidAndContentType($notification->getRevision()->getOuuid(), $notification->getRevision()->getContentType());
-
-//             $notification->setCounter($result);
-//         }
-
-        return $notifications;
+        return $repository->findByPendingAndRoleAndCircleForUserSent($this->userService->getCurrentUser(), $from, $limit, $notificationFilter);
     }
 
     private function response(Notification $notification, TreatNotifications $treatNotifications, string $status): void


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

If the action had no environments defined, the notification sent was not showing.

Refactor some code:
* NotificationFilter -> is a simple DTO object for the forms, instead of getting the arrays of the object. Pass the object with public properties.
* NotificationFormType -> filtering was not working, remove `choice_value` fixed
* Updated  paramters not passing int[] but entity objects
* countForSent & findByPendingAndRoleAndCircleForUserSent use same queryBuilder

