### PR TITLE
feat(emsch/routing): search one and http exceptions

### DIFF
--- a/EMS/client-helper-bundle/src/Helper/Elasticsearch/ClientRequestRuntime.php
+++ b/EMS/client-helper-bundle/src/Helper/Elasticsearch/ClientRequestRuntime.php
@@ -11,6 +11,7 @@ use EMS\CommonBundle\Common\EMSLink;
 use EMS\CommonBundle\Elasticsearch\Response\Response;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Twig\Extension\RuntimeExtensionInterface;
 
@@ -40,8 +41,6 @@ final class ClientRequestRuntime implements RuntimeExtensionInterface
     /**
      * @param string|string[]|null $type
      * @param array<mixed>         $body
-     *
-     * @return array<mixed>
      */
     public function searchOne(null|string|array $type, array $body, ?string $indexRegex = null): Document
     {
@@ -54,6 +53,14 @@ final class ClientRequestRuntime implements RuntimeExtensionInterface
         }
 
         return $document;
+    }
+
+    /**
+     * @param mixed[] $headers
+     */
+    public function httpException(int $statusCode, ?string $message = '', array $headers = [], ?int $code = 0): never
+    {
+        throw new HttpException($statusCode, $message, null, $headers, $code);
     }
 
     public function searchConfig(): Search

--- a/EMS/client-helper-bundle/src/Twig/HelperExtension.php
+++ b/EMS/client-helper-bundle/src/Twig/HelperExtension.php
@@ -32,6 +32,7 @@ final class HelperExtension extends AbstractExtension
             new TwigFunction('emsch_search_one', [ClientRequestRuntime::class, 'searchOne']),
             new TwigFunction('emsch_add_environment', [ClientRequestRuntime::class, 'addEnvironment']),
             new TwigFunction('emsch_search_config', [ClientRequestRuntime::class, 'searchConfig']),
+            new TwigFunction('emsch_http_error', [ClientRequestRuntime::class, 'httpException']),
             new TwigFunction('emsch_asset', [AssetHelperRuntime::class, 'asset'], ['is_safe' => ['html']]),
             new TwigFunction('emsch_assets', [AssetHelperRuntime::class, 'assets']),
             new TwigFunction('emsch_assets_version', [AssetHelperRuntime::class, 'setVersion']),

--- a/EMS/client-helper-bundle/src/Twig/HelperExtension.php
+++ b/EMS/client-helper-bundle/src/Twig/HelperExtension.php
@@ -29,6 +29,7 @@ final class HelperExtension extends AbstractExtension
             new TwigFunction('emsch_admin_menu', [AdminMenuRuntime::class, 'showAdminMenu'], ['is_safe' => ['html']]),
             new TwigFunction('emsch_route', [RoutingRuntime::class, 'createUrl']),
             new TwigFunction('emsch_search', [ClientRequestRuntime::class, 'search']),
+            new TwigFunction('emsch_search_one', [ClientRequestRuntime::class, 'searchOne']),
             new TwigFunction('emsch_add_environment', [ClientRequestRuntime::class, 'addEnvironment']),
             new TwigFunction('emsch_search_config', [ClientRequestRuntime::class, 'searchConfig']),
             new TwigFunction('emsch_asset', [AssetHelperRuntime::class, 'asset'], ['is_safe' => ['html']]),


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |n|
|New feature?   |y|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

Even if it's a new feature, at a platform level, not being able to throw a 404 when we are not able the find a target page form a structure route can be see has a bug
