### PR TITLE
fix(emsco): recompute deep (revert #366)

### DIFF
--- a/EMS/core-bundle/src/Command/RecomputeCommand.php
+++ b/EMS/core-bundle/src/Command/RecomputeCommand.php
@@ -243,7 +243,7 @@ final class RecomputeCommand extends Command
             }
 
             if ($transactionActive) {
-                //  $this->em->commit();
+                $this->em->commit();
             }
             $this->em->clear();
 

--- a/EMS/core-bundle/src/Command/RecomputeCommand.php
+++ b/EMS/core-bundle/src/Command/RecomputeCommand.php
@@ -15,6 +15,7 @@ use EMS\CoreBundle\Repository\ContentTypeRepository;
 use EMS\CoreBundle\Repository\RevisionRepository;
 use EMS\CoreBundle\Service\ContentTypeService;
 use EMS\CoreBundle\Service\DataService;
+use EMS\CoreBundle\Service\IndexService;
 use EMS\CoreBundle\Service\PublishService;
 use EMS\CoreBundle\Service\SearchService;
 use Psr\Log\LoggerInterface;
@@ -59,6 +60,7 @@ final class RecomputeCommand extends Command
         private readonly ContentTypeService $contentTypeService,
         private readonly ContentTypeRepository $contentTypeRepository,
         private readonly RevisionRepository $revisionRepository,
+        private readonly IndexService $indexService,
         private readonly SearchService $searchService
     ) {
         parent::__construct();
@@ -198,7 +200,20 @@ final class RecomputeCommand extends Command
 
                 $this->dataService->propagateDataToComputedField($revisionType->get('data'), $objectArray, $this->contentType, $this->contentType->getName(), $newRevision->getOuuid(), true);
                 $newRevision->setRawData($objectArray);
-                $this->dataService->finalizeDraft($newRevision, $revisionType, self::LOCK_BY);
+
+                $revision->close(new \DateTime('now'));
+                $newRevision->setDraft(false);
+                $newRevision->setFinalizedBy(self::LOCK_BY);
+                $newRevision->setRawDataFinalizedBy(self::LOCK_BY);
+
+                $this->dataService->sign($revision);
+                $this->dataService->sign($newRevision);
+
+                $this->em->persist($revision);
+                $this->em->persist($newRevision);
+                $this->em->flush();
+
+                $this->indexService->indexRevision($newRevision);
 
                 foreach ($notifications as $notification) {
                     if (Notification::IN_TRANSIT !== $notification->getStatus()) {
@@ -228,7 +243,7 @@ final class RecomputeCommand extends Command
             }
 
             if ($transactionActive) {
-                $this->em->commit();
+                //  $this->em->commit();
             }
             $this->em->clear();
 

--- a/EMS/core-bundle/src/Resources/config/command.xml
+++ b/EMS/core-bundle/src/Resources/config/command.xml
@@ -213,6 +213,7 @@
             <argument type="service" id="ems.service.contenttype"/>
             <argument type="service" id="EMS\CoreBundle\Repository\ContentTypeRepository"/>
             <argument type="service" id="EMS\CoreBundle\Repository\RevisionRepository"/>
+            <argument type="service" id="ems.service.index"/>
             <argument type="service" id="ems.service.search"/>
             <tag name="console.command"/>
         </service>

--- a/EMS/core-bundle/src/Service/Revision/PostProcessingService.php
+++ b/EMS/core-bundle/src/Service/Revision/PostProcessingService.php
@@ -100,6 +100,7 @@ final class PostProcessingService
                         $found = true;
                     } else {
                         $this->logger->warning('service.data.json_parse_post_processing_error', [
+                            '_id' => $context['_id'] ?? null,
                             'field_name' => $dataField->giveFieldType()->getName(),
                             EmsFields::LOG_ERROR_MESSAGE_FIELD => $out,
                         ]);
@@ -110,6 +111,7 @@ final class PostProcessingService
                     if (!$migration) {
                         $form->addError(new FormError($e->getPrevious()->getMessage()));
                         $this->logger->warning('service.data.cant_finalize_field', [
+                            '_id' => $context['_id'] ?? null,
                             'field_name' => $dataField->giveFieldType()->getName(),
                             'field_display' => isset($fieldType->getDisplayOptions()['label']) && !empty($fieldType->getDisplayOptions()['label']) ? $fieldType->getDisplayOptions()['label'] : $fieldType->getName(),
                             EmsFields::LOG_ERROR_MESSAGE_FIELD => $e->getPrevious()->getMessage(),
@@ -117,6 +119,7 @@ final class PostProcessingService
                     }
                 } else {
                     $this->logger->warning('service.data.json_parse_post_processing_error', [
+                        '_id' => $context['_id'] ?? null,
                         'field_name' => $fieldType->getName(),
                         EmsFields::LOG_ERROR_MESSAGE_FIELD => $e->getMessage(),
                         EmsFields::LOG_EXCEPTION_FIELD => $e,
@@ -148,6 +151,7 @@ final class PostProcessingService
                     }
 
                     $this->logger->warning('service.data.template_parse_error', [
+                        '_id' => $context['_id'] ?? null,
                         EmsFields::LOG_ERROR_MESSAGE_FIELD => $e->getMessage(),
                         EmsFields::LOG_EXCEPTION_FIELD => $e,
                         'computed_field_name' => $fieldType->getName(),


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

PR #366 broke the recompute deep and cause side effects. 
Better to set the finalization fields inside the command

