### PR TITLE
fix(emsco/user): profile remove update simplified UI

### DIFF
--- a/EMS/core-bundle/src/Form/Form/UserOptionsType.php
+++ b/EMS/core-bundle/src/Form/Form/UserOptionsType.php
@@ -20,6 +20,9 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 class UserOptionsType extends AbstractType
 {
+    public const CONTEXT_PROFILE = 'user_profile';
+    public const CONTEXT_USER_MANAGEMENT = 'user_management';
+
     public function __construct(
         private readonly FormManager $formManager,
         protected FormRegistryInterface $formRegistry,
@@ -34,15 +37,20 @@ class UserOptionsType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        $builder
-            ->add(UserOptions::ALLOWED_CONFIGURE_WYSIWYG, CheckboxType::class, [
-                'required' => false,
-                'label' => 'user.option.allowed_configure_wysiwyg',
-            ])
-            ->add(UserOptions::SIMPLIFIED_UI, CheckboxType::class, [
-                'required' => false,
-                'label' => 'user.option.simplified_ui',
-            ]);
+        $context = $options['context'];
+
+        if (self::CONTEXT_USER_MANAGEMENT === $context) {
+            $builder
+                ->add(UserOptions::ALLOWED_CONFIGURE_WYSIWYG, CheckboxType::class, [
+                    'required' => false,
+                    'label' => 'user.option.allowed_configure_wysiwyg',
+                ])
+                ->add(UserOptions::SIMPLIFIED_UI, CheckboxType::class, [
+                    'required' => false,
+                    'label' => 'user.option.simplified_ui',
+                ]);
+        }
+
         if (null !== $this->customUserOptionsForm) {
             $form = $this->formManager->getByName($this->customUserOptionsForm);
             $builder->add(UserOptions::CUSTOM_OPTIONS, $form->getFieldType()->getType(), [
@@ -61,7 +69,10 @@ class UserOptionsType extends AbstractType
 
     public function configureOptions(OptionsResolver $resolver): void
     {
-        $resolver->setDefaults(['translation_domain' => 'emsco-user']);
+        $resolver
+            ->setDefaults(['translation_domain' => 'emsco-user'])
+            ->setRequired(['context'])
+            ->setAllowedValues('context', [self::CONTEXT_PROFILE, self::CONTEXT_USER_MANAGEMENT]);
     }
 
     /**

--- a/EMS/core-bundle/src/Form/Form/UserType.php
+++ b/EMS/core-bundle/src/Form/Form/UserType.php
@@ -108,7 +108,10 @@ final class UserType extends AbstractType
                 'choices' => \array_flip(Locales::getNames()),
                 'choice_translation_domain' => false,
             ])
-            ->add('userOptions', UserOptionsType::class, ['label' => 'user.option.title'])
+            ->add('userOptions', UserOptionsType::class, [
+                'label' => 'user.option.title',
+                'context' => UserOptionsType::CONTEXT_USER_MANAGEMENT,
+            ])
         ;
 
         if ($this->circleObject) {

--- a/EMS/core-bundle/src/Form/User/UserProfileType.php
+++ b/EMS/core-bundle/src/Form/User/UserProfileType.php
@@ -56,7 +56,10 @@ class UserProfileType extends AbstractType
             ->add('layoutBoxed', null, ['label' => 'user.layout_boxed'])
             ->add('sidebarMini', null, ['label' => 'user.sidebar_mini'])
             ->add('sidebarCollapse', null, ['label' => 'user.sidebar_collapse'])
-            ->add('userOptions', UserOptionsType::class, ['label' => 'user.option.title'])
+            ->add('userOptions', UserOptionsType::class, [
+                'label' => 'user.option.title',
+                'context' => UserOptionsType::CONTEXT_PROFILE,
+            ])
             ->add('locale', ChoiceType::class, [
                 'label' => 'user.locale',
                 'translation_domain' => EMSCoreBundle::TRANS_FORM_DOMAIN,

--- a/EMS/core-bundle/src/Resources/views/user/profile/edit.html.twig
+++ b/EMS/core-bundle/src/Resources/views/user/profile/edit.html.twig
@@ -23,7 +23,11 @@
                     {{ form_row(form.sidebarMini) }}
                     {{ form_row(form.sidebarCollapse) }}
 
-                    {{ form_row(form.userOptions) }}
+                    {% if form.userOptions.children|length > 0 %}
+                        {{ form_row(form.userOptions) }}
+                    {% else %}
+                        {{ form_widget(form.userOptions) }}
+                    {% endif %}
 
                     {{ form_row(form.locale) }}
                     {{ form_row(form.localePreferred) }}


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

Also removed the option to update `allowed_configure_wysiwyg` on the profile page.

On the profile update page, for now, only custom user option form is visible (if defined)
