### PR TITLE
fix(emsco/revision): finalization version broken

### DIFF
--- a/EMS/core-bundle/src/Service/DataService.php
+++ b/EMS/core-bundle/src/Service/DataService.php
@@ -790,7 +790,7 @@ class DataService
                 if ($item) {
                     $this->lockRevision($item, null, false, $username);
                     $previousObjectArray = $item->getRawData();
-                    $item->close(new \DateTime('now'));
+                    $item->removeEnvironment($revision->giveContentType()->giveEnvironment());
                     $em->persist($item);
                     $this->unlockRevision($item, $username);
                 }


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

On publishing a new version (Major/Minor), the revision was closed and now current revision.

In bad PR : https://github.com/ems-project/elasticms/pull/366 this bug was introduced. Already reverted in https://github.com/ems-project/elasticms/pull/383 but forgot this.

Tested finalization of documents and versioned documents.
And also the recompute command
