### PR TITLE
feat(core/user): add the WYSIWYG profile in the datatable view

### DIFF
--- a/EMS/core-bundle/src/Controller/UserController.php
+++ b/EMS/core-bundle/src/Controller/UserController.php
@@ -275,6 +275,7 @@ class UserController extends AbstractController
         $table->addColumn('user.index.column.email', 'email');
         $table->addColumn('user.index.column.locale_ui', 'locale');
         $table->addColumn('user.index.column.locale_preferred', 'localePreferred');
+        $table->addColumn('user.index.column.wysiwyg_profile', 'wysiwygProfile');
         if ($this->circleObject) {
             $table->addColumnDefinition(new DataLinksTableColumn('user.index.column.circles', 'circles'));
         }

--- a/EMS/core-bundle/src/Entity/WysiwygProfile.php
+++ b/EMS/core-bundle/src/Entity/WysiwygProfile.php
@@ -131,4 +131,9 @@ class WysiwygProfile extends JsonDeserializer implements \JsonSerializable, Enti
 
         return $profile;
     }
+
+    public function __toString(): string
+    {
+        return $this->getName();
+    }
 }

--- a/EMS/core-bundle/src/Resources/translations/EMSCoreBundle.en.yml
+++ b/EMS/core-bundle/src/Resources/translations/EMSCoreBundle.en.yml
@@ -867,6 +867,7 @@ user:
             roles: Roles
             username: Username
             locale_preferred: 'Locale preferred'
+            wysiwyg_profile: 'WYSIWYG profile'
             locale_ui: UI
     add:
         button: 'Add user'


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |n|
|New feature?   |y|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

in order to simplify the review of the WYSIWYG profile by the webmasters
