### PR TITLE
fix: image not found by dompdf

### DIFF
--- a/EMS/common-bundle/src/Service/Pdf/PdfPrintOptions.php
+++ b/EMS/common-bundle/src/Service/Pdf/PdfPrintOptions.php
@@ -36,7 +36,7 @@ class PdfPrintOptions
         $this->isPhpEnabled = $options[self::PHP_ENABLED] ?? false;
         $this->orientation = $options[self::ORIENTATION] ?? 'portrait';
         $this->size = $options[self::SIZE] ?? 'a4';
-        $this->chroot = $options[self::CHROOT] ?? null;
+        $this->chroot = $options[self::CHROOT] ?? \sys_get_temp_dir();
     }
 
     public function getFilename(): string


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

by default src_path images are generated in the system folder. So the system temp folder must be the default DOMPDF chroot folder.
