### PR TITLE
fix: old revision might not have hash

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,7 @@
 *.inc text eol=lf
 *.twig text eol=lf
 *.env text eol=lf
+*.sh text eol=lf
 
 # Denote all files that are truly binary and should not be modified.
 *.png binary

--- a/EMS/core-bundle/src/Common/DocumentInfo.php
+++ b/EMS/core-bundle/src/Common/DocumentInfo.php
@@ -46,9 +46,13 @@ final class DocumentInfo
             return true;
         }
 
-        $defaultRevision = $this->getRevision($defaultEnvironment->getName());
+        foreach ($revision->getEnvironments() as $environment) {
+            if ($environment === $defaultEnvironment) {
+                return true;
+            }
+        }
 
-        return $defaultRevision && $defaultRevision->getHash() === $revision->getHash();
+        return false;
     }
 
     public function isPublished(string $environmentName): bool

--- a/EMS/core-bundle/src/Entity/Revision.php
+++ b/EMS/core-bundle/src/Entity/Revision.php
@@ -683,6 +683,11 @@ class Revision implements EntityInterface, \Stringable
         return $hash;
     }
 
+    public function hasHash(): bool
+    {
+        return \is_string($this->rawData[Mapping::HASH_FIELD] ?? null);
+    }
+
     /**
      * @return array<int|string, mixed>
      */

--- a/EMS/core-bundle/src/Service/DataService.php
+++ b/EMS/core-bundle/src/Service/DataService.php
@@ -1486,7 +1486,11 @@ class DataService
 
     public function reloadData(Revision $revision, bool $flush = true): int
     {
-        $revisionHash = $revision->getHash();
+        if ($revision->hasHash()) {
+            $revisionHash = $revision->getHash();
+        } else {
+            $revisionHash = null;
+        }
         $reloadRevision = clone $revision;
 
         $finalizedBy = false;

--- a/EMS/core-bundle/src/Service/DocumentService.php
+++ b/EMS/core-bundle/src/Service/DocumentService.php
@@ -92,7 +92,7 @@ class DocumentService
             $currentRevision->setLockBy($documentImportContext->getLockUser());
             $currentRevision->setLockUntil((new \DateTime('now'))->add(new \DateInterval('PT5M')));
 
-            if ($documentImportContext->shouldOnlyChanged() && $currentRevision->getHash() === $newRevision->getHash()) {
+            if ($documentImportContext->shouldOnlyChanged() && $currentRevision->hasHash() && $currentRevision->getHash() === $newRevision->getHash()) {
                 $this->getEntityManager()->persist($currentRevision); // updateModified
                 $this->getEntityManager()->flush();
 


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

Old revision in databases migth not have hash
