### PR TITLE
refactor(elasticm-cli): mediaFile() return

### DIFF
--- a/elasticms-cli/src/Client/WebToElasticms/Config/ConfigManager.php
+++ b/elasticms-cli/src/Client/WebToElasticms/Config/ConfigManager.php
@@ -603,6 +603,20 @@ class ConfigManager
         }
     }
 
+    public function mediaFileLink(Url $url, Rapport $rapport, string $attribute): ?string
+    {
+        $emslink = $this->mediaFile($url, $rapport, $attribute);
+        if (null == $emslink) {
+            return null;
+        }
+
+        if ('href' === $attribute) {
+            return \sprintf('ems://object:%s', $emslink);
+        }
+
+        return \sprintf('ems://file:%s', $emslink);
+    }
+
     public function mediaFile(Url $url, Rapport $rapport, string $attribute): ?string
     {
         foreach ($this->htmlAsset2Document as $config) {
@@ -676,10 +690,6 @@ class ConfigManager
             }
         }
 
-        if ('href' === $attribute) {
-            return \sprintf('ems://object:%s:%s', $config['content_type'], $ouuid);
-        }
-
-        return \sprintf('ems://file:%s:%s', $config['content_type'], $ouuid);
+        return \sprintf('%s:%s', $config['content_type'], $ouuid);
     }
 }

--- a/elasticms-cli/src/Client/WebToElasticms/Filter/Attr/LinkMediaFile.php
+++ b/elasticms-cli/src/Client/WebToElasticms/Filter/Attr/LinkMediaFile.php
@@ -24,9 +24,6 @@ class LinkMediaFile
             return '';
         }
 
-        $explode = \explode(':', $path);
-        $path = \implode(':', \array_slice($explode, -2));
-
         return $path;
     }
 }

--- a/elasticms-cli/src/Client/WebToElasticms/Filter/Html/InternalLink.php
+++ b/elasticms-cli/src/Client/WebToElasticms/Filter/Html/InternalLink.php
@@ -56,7 +56,7 @@ class InternalLink implements HtmlInterface
                 continue;
             }
 
-            $path = $this->config->mediaFile($url, $this->rapport, $attribute);
+            $path = $this->config->mediaFileLink($url, $this->rapport, $attribute);
             if (null !== $path) {
                 $item->setAttribute($attribute, $path);
                 continue;


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |n|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

Refactor mediaFile function to return only a ${type}:{id} and add mediaFileLink for ems://object:${mediafile} or ems://file:${mediafile}