### PR TITLE
feat(search): filter's clause config and search minimum_should_match config

### DIFF
--- a/EMS/client-helper-bundle/src/Helper/Search/Filter.php
+++ b/EMS/client-helper-bundle/src/Helper/Search/Filter.php
@@ -61,6 +61,7 @@ final class Filter
         self::TYPE_DATE_TIME_RANGE,
         self::TYPE_DATE_VERSION,
     ];
+    private string $clause;
 
     /**
      * @param array<mixed> $options
@@ -74,6 +75,7 @@ final class Filter
         $this->field = $options['field'] ?? $name;
         $this->secondaryField = $options['secondary_field'] ?? null;
         $this->nestedPath = $options['nested_path'] ?? null;
+        $this->clause = $options['clause'] ?? 'must';
 
         $this->public = (bool) ($options['public'] ?? true);
         $this->active = (bool) ($options['active'] ?? true);
@@ -251,6 +253,11 @@ final class Filter
     public function isReversedNested(): bool
     {
         return $this->reversedNested;
+    }
+
+    public function getClause(): string
+    {
+        return $this->clause;
     }
 
     private function setQuery(mixed $value): void

--- a/EMS/client-helper-bundle/src/Helper/Search/Search.php
+++ b/EMS/client-helper-bundle/src/Helper/Search/Search.php
@@ -49,6 +49,7 @@ final class Search
     private ?string $sortBy = null;
     private string $analyzer;
     private string $sortOrder = 'asc';
+    private string $minimumShouldMatch;
 
     public function __construct(private readonly Request $request, ClientRequest $clientRequest)
     {
@@ -67,6 +68,7 @@ final class Search
         $this->querySearch = $options['query_search'] ?? null;
         $this->facets = $options['facets'] ?? [];
         $this->sizes = $options['sizes'] ?? [];
+        $this->minimumShouldMatch = $options['minimum_should_match'] ?? '1';
         $this->defaultSorts = $this->parseSorts($options['default_sorts'] ?? []);
         $this->sorts = $this->parseSorts($options['sorts'] ?? []);
 
@@ -296,6 +298,11 @@ final class Search
     public function getHighlight(): array
     {
         return $this->highlight;
+    }
+
+    public function getMinimumShouldMatch(): string
+    {
+        return $this->minimumShouldMatch;
     }
 
     /**


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |n|
|New feature?   |y|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

New clause config that specifies if a filter as to be added as must, must_not or should to the bool query
