### PR TITLE
feat(common): s3 multipart upload

### DIFF
--- a/EMS/common-bundle/src/DependencyInjection/Configuration.php
+++ b/EMS/common-bundle/src/DependencyInjection/Configuration.php
@@ -51,7 +51,7 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('cache')
                     ->addDefaultsIfNotSet()
                     ->children()
-                        ->scalarNode('type')->defaultValue('filesystem')->end()
+                        ->scalarNode('type')->defaultValue('file_system')->end()
                         ->scalarNode('prefix')->defaultValue('ems_cache')->end()
                         ->arrayNode('redis')
                             ->addDefaultsIfNotSet()

--- a/EMS/common-bundle/src/Resources/config/storage.xml
+++ b/EMS/common-bundle/src/Resources/config/storage.xml
@@ -49,6 +49,7 @@
 
         <service id="ems_common.storage.factory.s3" class="EMS\CommonBundle\Storage\Factory\S3Factory">
             <argument type="service" id="logger" />
+            <argument type="service" id="ems.common.cache" />
             <tag name="ems_common.storage.factory" alias="s3"/>
         </service>
 

--- a/EMS/common-bundle/src/Storage/Factory/S3Factory.php
+++ b/EMS/common-bundle/src/Storage/Factory/S3Factory.php
@@ -33,8 +33,11 @@ class S3Factory extends AbstractFactory implements StorageFactoryInterface
 
             return null;
         }
+        if (null !== $config[self::STORAGE_CONFIG_UPLOAD_FOLDER]) {
+            @\trigger_error('The upload-folder S3 config is deprecated', \E_USER_DEPRECATED);
+        }
 
-        return new S3Storage($this->logger, $this->cache, $credentials, $bucket, $config[self::STORAGE_CONFIG_USAGE], $config[self::STORAGE_CONFIG_HOT_SYNCHRONIZE_LIMIT], $config[self::STORAGE_CONFIG_UPLOAD_FOLDER], $config[self::STORAGE_CONFIG_MULTIPART_UPLOAD]);
+        return new S3Storage($this->logger, $this->cache, $credentials, $bucket, $config[self::STORAGE_CONFIG_USAGE], $config[self::STORAGE_CONFIG_HOT_SYNCHRONIZE_LIMIT], $config[self::STORAGE_CONFIG_MULTIPART_UPLOAD]);
     }
 
     public function getStorageType(): string

--- a/EMS/common-bundle/src/Storage/Factory/S3Factory.php
+++ b/EMS/common-bundle/src/Storage/Factory/S3Factory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EMS\CommonBundle\Storage\Factory;
 
+use EMS\CommonBundle\Common\Cache\Cache;
 use EMS\CommonBundle\Storage\Service\S3Storage;
 use EMS\CommonBundle\Storage\Service\StorageInterface;
 use Psr\Log\LoggerInterface;
@@ -14,8 +15,9 @@ class S3Factory extends AbstractFactory implements StorageFactoryInterface
     final public const STORAGE_CONFIG_CREDENTIALS = 'credentials';
     final public const STORAGE_CONFIG_BUCKET = 'bucket';
     final public const STORAGE_CONFIG_UPLOAD_FOLDER = 'upload-folder';
+    final public const STORAGE_CONFIG_MULTIPART_UPLOAD = 'multipart-upload';
 
-    public function __construct(private readonly LoggerInterface $logger)
+    public function __construct(private readonly LoggerInterface $logger, private readonly Cache $cache)
     {
     }
 
@@ -32,7 +34,7 @@ class S3Factory extends AbstractFactory implements StorageFactoryInterface
             return null;
         }
 
-        return new S3Storage($this->logger, $credentials, $bucket, $config[self::STORAGE_CONFIG_USAGE], $config[self::STORAGE_CONFIG_HOT_SYNCHRONIZE_LIMIT], $config[self::STORAGE_CONFIG_UPLOAD_FOLDER]);
+        return new S3Storage($this->logger, $this->cache, $credentials, $bucket, $config[self::STORAGE_CONFIG_USAGE], $config[self::STORAGE_CONFIG_HOT_SYNCHRONIZE_LIMIT], $config[self::STORAGE_CONFIG_UPLOAD_FOLDER], $config[self::STORAGE_CONFIG_MULTIPART_UPLOAD]);
     }
 
     public function getStorageType(): string
@@ -43,7 +45,7 @@ class S3Factory extends AbstractFactory implements StorageFactoryInterface
     /**
      * @param array<string, mixed> $parameters
      *
-     * @return array{type: string, credentials: array<mixed>|null, bucket: string|null, usage: int, hot-synchronize-limit: int, upload-folder: string|null}
+     * @return array{type: string, credentials: array<mixed>|null, bucket: string|null, usage: int, hot-synchronize-limit: int, upload-folder: string|null, multipart-upload: bool}
      */
     private function resolveParameters(array $parameters): array
     {
@@ -54,13 +56,15 @@ class S3Factory extends AbstractFactory implements StorageFactoryInterface
                 self::STORAGE_CONFIG_CREDENTIALS => null,
                 self::STORAGE_CONFIG_BUCKET => null,
                 self::STORAGE_CONFIG_UPLOAD_FOLDER => null,
+                self::STORAGE_CONFIG_MULTIPART_UPLOAD => false,
             ])
             ->setAllowedTypes(self::STORAGE_CONFIG_CREDENTIALS, ['null', 'array'])
             ->setAllowedTypes(self::STORAGE_CONFIG_BUCKET, ['null', 'string'])
             ->setAllowedTypes(self::STORAGE_CONFIG_UPLOAD_FOLDER, ['null', 'string'])
+            ->setAllowedTypes(self::STORAGE_CONFIG_MULTIPART_UPLOAD, ['bool'])
             ->setAllowedValues(self::STORAGE_CONFIG_TYPE, [self::STORAGE_TYPE])
         ;
-        /** @var array{type: string, credentials: array<mixed>|null, bucket: string|null, usage: int, hot-synchronize-limit: int, upload-folder: string|null} $resolvedParameter */
+        /** @var array{type: string, credentials: array<mixed>|null, bucket: string|null, usage: int, hot-synchronize-limit: int, upload-folder: string|null, multipart-upload: bool} $resolvedParameter */
         $resolvedParameter = $resolver->resolve($parameters);
 
         return $resolvedParameter;

--- a/EMS/common-bundle/src/Storage/Factory/S3Factory.php
+++ b/EMS/common-bundle/src/Storage/Factory/S3Factory.php
@@ -59,7 +59,7 @@ class S3Factory extends AbstractFactory implements StorageFactoryInterface
                 self::STORAGE_CONFIG_CREDENTIALS => null,
                 self::STORAGE_CONFIG_BUCKET => null,
                 self::STORAGE_CONFIG_UPLOAD_FOLDER => null,
-                self::STORAGE_CONFIG_MULTIPART_UPLOAD => false,
+                self::STORAGE_CONFIG_MULTIPART_UPLOAD => true,
             ])
             ->setAllowedTypes(self::STORAGE_CONFIG_CREDENTIALS, ['null', 'array'])
             ->setAllowedTypes(self::STORAGE_CONFIG_BUCKET, ['null', 'string'])

--- a/EMS/common-bundle/src/Storage/Service/AbstractUrlStorage.php
+++ b/EMS/common-bundle/src/Storage/Service/AbstractUrlStorage.php
@@ -207,6 +207,10 @@ abstract class AbstractUrlStorage implements StorageInterface, \Stringable
         }
     }
 
+    public function initFinalize(string $hash): void
+    {
+    }
+
     /**
      * @return resource|null
      */

--- a/EMS/common-bundle/src/Storage/Service/EntityStorage.php
+++ b/EMS/common-bundle/src/Storage/Service/EntityStorage.php
@@ -205,4 +205,8 @@ class EntityStorage implements StorageInterface, \Stringable
 
         return $usageRequested <= $this->usage;
     }
+
+    public function initFinalize(string $hash): void
+    {
+    }
 }

--- a/EMS/common-bundle/src/Storage/Service/S3Storage.php
+++ b/EMS/common-bundle/src/Storage/Service/S3Storage.php
@@ -6,6 +6,7 @@ namespace EMS\CommonBundle\Storage\Service;
 
 use Aws\S3\S3Client;
 use EMS\CommonBundle\Common\Cache\Cache;
+use EMS\Helpers\Standard\Base64;
 use Psr\Http\Message\StreamInterface;
 use Psr\Log\LoggerInterface;
 
@@ -37,7 +38,7 @@ class S3Storage extends AbstractUrlStorage
     {
         $s3 = $this->getS3Client();
 
-        $base64Hash = \base64_encode(\sha1($chunk, true));
+        $base64Hash = Base64::encode(\sha1($chunk, true));
         if ($this->multipartUpload) {
             $cache = $this->cache->getItem($this->uploadKey($hash));
             $args = $cache->get();

--- a/EMS/common-bundle/src/Storage/Service/StorageInterface.php
+++ b/EMS/common-bundle/src/Storage/Service/StorageInterface.php
@@ -63,4 +63,6 @@ interface StorageInterface
     public function getHotSynchronizeLimit(): int;
 
     public function removeUpload(string $hash): void;
+
+    public function initFinalize(string $hash): void;
 }

--- a/EMS/common-bundle/src/Storage/StorageManager.php
+++ b/EMS/common-bundle/src/Storage/StorageManager.php
@@ -281,6 +281,7 @@ class StorageManager
             }
 
             try {
+                $adapter->initFinalize($hash);
                 $handler = $adapter->read($hash, false);
             } catch (\Throwable) {
                 continue;


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |n|
|New feature?   |y|
|BC breaks?     |n|
|Deprecations?  |y|
|Fixed tickets  |n|

The S3 upload-folder option was causing high memory usage and timeouts ==> Deprecated

A new multipart-upload option as been introduced if we don't want to use S3 multipart API (and it's chunk by chunk checksum)

See: https://github.com/ems-project/ems-project.github.io/pull/66
