### PR TITLE
fix(cli): don't audit same urls with different parameters more than once

### DIFF
--- a/EMS/common-bundle/src/Common/CoreApi/Endpoint/File/File.php
+++ b/EMS/common-bundle/src/Common/CoreApi/Endpoint/File/File.php
@@ -109,6 +109,11 @@ final class File implements FileInterface
         return $this->storageManager->computeFileHash($filename);
     }
 
+    public function downloadLink(string $hash): string
+    {
+        return \sprintf('%s/data/file/%s', $this->client->getBaseUrl(), $hash);
+    }
+
     public function hashStream(StreamInterface $stream): string
     {
         return $this->storageManager->computeStreamHash($stream);

--- a/elasticms-cli/src/Client/Audit/AuditManager.php
+++ b/elasticms-cli/src/Client/Audit/AuditManager.php
@@ -34,7 +34,7 @@ class AuditManager
         }
     }
 
-    public function analyze(Url $url, HttpResult $result, Report $report): AuditResult
+    public function analyze(Url $url, HttpResult $result, Report $report, bool $alreadyAudited): AuditResult
     {
         $this->logger->notice($url->getUrl());
         $audit = new AuditResult($url);
@@ -43,6 +43,10 @@ class AuditManager
             return $audit;
         }
         $this->addHtmlAudit($audit, $result, $report);
+        if ($alreadyAudited) {
+            return $audit;
+        }
+
         if ($result->isHtml() && ($this->all || $this->pa11y)) {
             $this->startPa11yAudit($audit, $result);
         }

--- a/elasticms-cli/src/Client/Audit/Cache.php
+++ b/elasticms-cli/src/Client/Audit/Cache.php
@@ -139,7 +139,7 @@ class Cache
 
     public function addUrl(Url $url): void
     {
-        $hash = $this->getUrlHash($url);
+        $hash = $this->getUrlHash($url, true);
         if (isset($this->urls[$hash])) {
             return;
         }
@@ -149,9 +149,9 @@ class Cache
         $this->urls[$hash] = $url;
     }
 
-    public function getUrlHash(Url $url): string
+    public function getUrlHash(Url $url, bool $withQuery = false): string
     {
-        return \sha1(\join('$', [self::HASH_SEED, $url->getUrl(null, false, false)]));
+        return \sha1(\join('$', [self::HASH_SEED, $url->getUrl(null, false, false, $withQuery)]));
     }
 
     public function progress(OutputInterface $output): void

--- a/elasticms-cli/src/Client/Audit/Report.php
+++ b/elasticms-cli/src/Client/Audit/Report.php
@@ -29,9 +29,8 @@ class Report
         $this->spreadsheetGeneratorService = new SpreadsheetGeneratorService();
     }
 
-    public function save(string $folder, string $host): void
+    public function generateXslxReport(): string
     {
-        $filename = $folder.DIRECTORY_SEPARATOR.\sprintf('Audit-%s-%s.xlsx', $host, \date('Ymd-His'));
         $config = [
             SpreadsheetGeneratorServiceInterface::CONTENT_DISPOSITION => HeaderUtils::DISPOSITION_ATTACHMENT,
             SpreadsheetGeneratorServiceInterface::WRITER => SpreadsheetGeneratorServiceInterface::XLSX_WRITER,
@@ -59,7 +58,13 @@ class Report
                 ],
             ],
         ];
-        $this->spreadsheetGeneratorService->generateSpreadsheetFile($config, $filename);
+        $tmpFilename = \tempnam(\sys_get_temp_dir(), 'WebReport');
+        if (!\is_string($tmpFilename)) {
+            throw new \RuntimeException('Not able to generate a temporary filename');
+        }
+        $this->spreadsheetGeneratorService->generateSpreadsheetFile($config, $tmpFilename);
+
+        return $tmpFilename;
     }
 
     public function addAccessibilityError(string $url, int $errorCount, ?float $score): void

--- a/elasticms-cli/src/Client/WebToElasticms/Helper/Url.php
+++ b/elasticms-cli/src/Client/WebToElasticms/Helper/Url.php
@@ -147,7 +147,7 @@ class Url
         return $this->cleanPath($path);
     }
 
-    public function getUrl(string $path = null, bool $withFragment = false, bool $withPassword = true): string
+    public function getUrl(string $path = null, bool $withFragment = false, bool $withPassword = true, bool $withQuery = true): string
     {
         if (null !== $path) {
             return (new Url($path, $this->getUrl()))->getUrl(null, $withFragment);
@@ -164,7 +164,7 @@ class Url
         } else {
             $url = \sprintf('%s%s', $url, $this->path);
         }
-        if (null !== $this->query) {
+        if ($withQuery && null !== $this->query) {
             $url = \sprintf('%s?%s', $url, $this->query);
         }
         if ($withFragment && null !== $this->fragment) {


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

- It's useless to audit all search result page (once is enough) but we still need to crawl them (looking for new urls)
- As the audit is working in a (stateless) CLI, the xslx report is not accessible without volume mount, with this PR the xslx is uploaded to the admin
 