### PR TITLE
refactor(core/dataTable): create dataTable types

### DIFF
--- a/EMS/core-bundle/src/Controller/ContentManagement/DatatableController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/DatatableController.php
@@ -34,7 +34,7 @@ final class DatatableController extends AbstractController
         $dataTableRequest = DataTableRequest::fromRequest($request);
         $table->resetIterator($dataTableRequest);
 
-        return $this->render('@EMSCore/datatable/ajax.html.twig', [
+        return $this->render('@EMSCore/datatable/ajax.json.twig', [
             'dataTableRequest' => $dataTableRequest,
             'table' => $table,
         ], new JsonResponse());

--- a/EMS/core-bundle/src/Controller/ContentManagement/DatatableController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/DatatableController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EMS\CoreBundle\Controller\ContentManagement;
 
+use EMS\CoreBundle\Core\DataTable\DataTableFactory;
 use EMS\CoreBundle\Core\DataTable\TableExporter;
 use EMS\CoreBundle\Core\DataTable\TableRenderer;
 use EMS\CoreBundle\Form\Data\ElasticaTable;
@@ -18,8 +19,25 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 
 final class DatatableController extends AbstractController
 {
-    public function __construct(private readonly DatatableService $datatableService, private readonly TableRenderer $tableRenderer, private readonly TableExporter $tableExporter, private readonly TokenStorageInterface $tokenStorage)
+    public function __construct(
+        private readonly DatatableService $datatableService,
+        private readonly DataTableFactory $dataTableFactory,
+        private readonly TableRenderer $tableRenderer,
+        private readonly TableExporter $tableExporter,
+        private readonly TokenStorageInterface $tokenStorage
+    ) {
+    }
+
+    public function ajaxData(Request $request, string $cacheKey): Response
     {
+        $table = $this->dataTableFactory->createFromCache($cacheKey);
+        $dataTableRequest = DataTableRequest::fromRequest($request);
+        $table->resetIterator($dataTableRequest);
+
+        return $this->render('@EMSCore/datatable/ajax.html.twig', [
+            'dataTableRequest' => $dataTableRequest,
+            'table' => $table,
+        ], new JsonResponse());
     }
 
     public function ajaxElastica(Request $request, string $hashConfig): Response

--- a/EMS/core-bundle/src/Core/DataTable/DataTableFactory.php
+++ b/EMS/core-bundle/src/Core/DataTable/DataTableFactory.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\Core\DataTable;
+
+use EMS\CoreBundle\Core\DataTable\Type\AbstractEntityTableType;
+use EMS\CoreBundle\Core\DataTable\Type\DataTableTypeCollection;
+use EMS\CoreBundle\Form\Data\EntityTable;
+use EMS\CoreBundle\Form\Data\TableAbstract;
+use EMS\CoreBundle\Routes;
+use EMS\Helpers\Standard\Base64;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+class DataTableFactory
+{
+    public function __construct(
+        private readonly DataTableTypeCollection $typeCollection,
+        private readonly CacheItemPoolInterface $cache,
+        private readonly UrlGeneratorInterface $urlGenerator
+    ) {
+    }
+
+    public function create(string $class): TableAbstract
+    {
+        $type = $this->typeCollection->getByClass($class);
+
+        $cacheKey = $this->cacheSave($class);
+        $ajaxUrl = $this->generateAjaxUrl($cacheKey);
+
+        return match (true) {
+            $type instanceof AbstractEntityTableType => $this->buildEntityTable($type, $ajaxUrl),
+            default => throw new \RuntimeException('Unknown dataTableType')
+        };
+    }
+
+    public function createFromCache(string $cacheKey): TableAbstract
+    {
+        $item = $this->cache->getItem($cacheKey);
+        if (!$item->isHit()) {
+            throw new \RuntimeException('Invalid cache');
+        }
+
+        $data = $item->get();
+
+        return $this->create($data['class']);
+    }
+
+    private function buildEntityTable(AbstractEntityTableType $type, string $ajaxUrl): EntityTable
+    {
+        $table = new EntityTable($type->getEntityService(), $ajaxUrl);
+        $type->build($table);
+
+        return $table;
+    }
+
+    private function generateAjaxUrl(string $cacheKey): string
+    {
+        return $this->urlGenerator->generate(Routes::DATA_TABLE_AJAX_TABLE, [
+            'cacheKey' => $cacheKey,
+        ]);
+    }
+
+    private function cacheSave(string $class): string
+    {
+        $key = Base64::encode($class);
+        $item = $this->cache->getItem($key)->set(['class' => $class]);
+
+        $this->cache->save($item);
+
+        return $key;
+    }
+}

--- a/EMS/core-bundle/src/Core/DataTable/Type/AbstractEntityTableType.php
+++ b/EMS/core-bundle/src/Core/DataTable/Type/AbstractEntityTableType.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\Core\DataTable\Type;
+
+use EMS\CoreBundle\Form\Data\EntityTable;
+use EMS\CoreBundle\Service\EntityServiceInterface;
+
+abstract class AbstractEntityTableType implements DataTableTypeInterface
+{
+    public function __construct(
+        private readonly EntityServiceInterface $entityService
+    ) {
+    }
+
+    public function build(EntityTable $table): void
+    {
+    }
+
+    public function getEntityService(): EntityServiceInterface
+    {
+        return $this->entityService;
+    }
+}

--- a/EMS/core-bundle/src/Core/DataTable/Type/AbstractEntityTableType.php
+++ b/EMS/core-bundle/src/Core/DataTable/Type/AbstractEntityTableType.php
@@ -7,7 +7,7 @@ namespace EMS\CoreBundle\Core\DataTable\Type;
 use EMS\CoreBundle\Form\Data\EntityTable;
 use EMS\CoreBundle\Service\EntityServiceInterface;
 
-abstract class AbstractEntityTableType implements DataTableTypeInterface
+abstract class AbstractEntityTableType extends AbstractTableType
 {
     public function __construct(
         private readonly EntityServiceInterface $entityService

--- a/EMS/core-bundle/src/Core/DataTable/Type/AbstractTableType.php
+++ b/EMS/core-bundle/src/Core/DataTable/Type/AbstractTableType.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\Core\DataTable\Type;
+
+abstract class AbstractTableType implements DataTableTypeInterface
+{
+    /**
+     * @return string[]
+     */
+    abstract public function getRoles(): array;
+}

--- a/EMS/core-bundle/src/Core/DataTable/Type/DataTableTypeCollection.php
+++ b/EMS/core-bundle/src/Core/DataTable/Type/DataTableTypeCollection.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\Core\DataTable\Type;
+
+class DataTableTypeCollection
+{
+    /**
+     * @param iterable<DataTableTypeInterface> $types
+     */
+    public function __construct(private readonly iterable $types)
+    {
+    }
+
+    public function getByClass(string $class): DataTableTypeInterface
+    {
+        foreach ($this->types as $type) {
+            if ($type instanceof $class) {
+                return $type;
+            }
+        }
+
+        throw new \RuntimeException(\sprintf('Could not find dataTable type "%s"', $class));
+    }
+}

--- a/EMS/core-bundle/src/Core/DataTable/Type/DataTableTypeInterface.php
+++ b/EMS/core-bundle/src/Core/DataTable/Type/DataTableTypeInterface.php
@@ -4,4 +4,8 @@ namespace EMS\CoreBundle\Core\DataTable\Type;
 
 interface DataTableTypeInterface
 {
+    /**
+     * @return string[]
+     */
+    public function getRoles(): array;
 }

--- a/EMS/core-bundle/src/Core/DataTable/Type/DataTableTypeInterface.php
+++ b/EMS/core-bundle/src/Core/DataTable/Type/DataTableTypeInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace EMS\CoreBundle\Core\DataTable\Type;
+
+interface DataTableTypeInterface
+{
+}

--- a/EMS/core-bundle/src/Resources/config/controllers.xml
+++ b/EMS/core-bundle/src/Resources/config/controllers.xml
@@ -113,6 +113,7 @@
         </service>
         <service id="EMS\CoreBundle\Controller\ContentManagement\DatatableController" public="true">
             <argument type="service" id="ems.service.datatable" />
+            <argument type="service" id="emsco.data_table.factory" />
             <argument type="service" id="ems_core.core_data_table.table_renderer" />
             <argument type="service" id="ems_core.core_data_table.table_exporter" />
             <argument type="service" id="security.token_storage" />

--- a/EMS/core-bundle/src/Resources/config/routing/datatable.xml
+++ b/EMS/core-bundle/src/Resources/config/routing/datatable.xml
@@ -4,6 +4,10 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://symfony.com/schema/routing https://symfony.com/schema/routing/routing-1.0.xsd">
 
+    <route id="emsco_datatable_ajax_table" path="/ajax/table/{cacheKey}"
+           controller="EMS\CoreBundle\Controller\ContentManagement\DatatableController::ajaxData"
+           methods="GET"/>
+
     <route id="ems_core_datatable_ajax_elastica" path="/ajax/{hashConfig}.json"
            controller="EMS\CoreBundle\Controller\ContentManagement\DatatableController::ajaxElastica"
            methods="GET|HEAD"/>

--- a/EMS/core-bundle/src/Resources/config/services.xml
+++ b/EMS/core-bundle/src/Resources/config/services.xml
@@ -65,6 +65,7 @@
             <argument type="service" id="emsco.data_table.type.collection" />
             <argument type="service" id="Psr\Cache\CacheItemPoolInterface" />
             <argument type="service" id="router" />
+            <argument type="service" id="security.helper" />
         </service>
         <service id="ems.service.datatable" alias="EMS\CoreBundle\Service\DatatableService"/>
         <service id="EMS\CoreBundle\Service\DatatableService">

--- a/EMS/core-bundle/src/Resources/config/services.xml
+++ b/EMS/core-bundle/src/Resources/config/services.xml
@@ -58,6 +58,14 @@
             <argument type="service" id="ems.service.index"/>
             <argument>%ems_core.security.firewall.core%</argument>
         </service>
+        <service id="emsco.data_table.type.collection" class="EMS\CoreBundle\Core\DataTable\Type\DataTableTypeCollection">
+            <argument type="tagged_iterator" tag="emsco.datatable" />
+        </service>
+        <service id="emsco.data_table.factory" class="EMS\CoreBundle\Core\DataTable\DataTableFactory">
+            <argument type="service" id="emsco.data_table.type.collection" />
+            <argument type="service" id="Psr\Cache\CacheItemPoolInterface" />
+            <argument type="service" id="router" />
+        </service>
         <service id="ems.service.datatable" alias="EMS\CoreBundle\Service\DatatableService"/>
         <service id="EMS\CoreBundle\Service\DatatableService">
             <argument type="service" id="logger"/>

--- a/EMS/core-bundle/src/Routes.php
+++ b/EMS/core-bundle/src/Routes.php
@@ -13,6 +13,7 @@ class Routes
     final public const DISCARD_DRAFT = 'emsco_discard_draft';
     final public const DRAFT_IN_PROGRESS = 'emsco_draft_in_progress';
     final public const DRAFT_IN_PROGRESS_AJAX = 'emsco_draft_in_progress_ajax';
+    final public const DATA_TABLE_AJAX_TABLE = 'emsco_datatable_ajax_table';
     final public const DASHBOARD_ADMIN_INDEX = 'emsco_dashboard_admin_index';
     final public const DASHBOARD_ADMIN_INDEX_AJAX = 'emsco_dashboard_admin_index_ajax';
     final public const DASHBOARD_ADMIN_ADD = 'emsco_dashboard_admin_add';


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |n|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

Building core datatables is too much code and for every dataTable we create a new ajax route.

Implementation on seperate pr: https://github.com/ems-project/elasticms/pull/493
