### PR TITLE
fix(admin): security /admin routes

### DIFF
--- a/elasticms-admin/config/packages/security.yaml
+++ b/elasticms-admin/config/packages/security.yaml
@@ -74,6 +74,7 @@ security:
         - { path: ^/bundles, role: PUBLIC_ACCESS }
         - { path: ^/api, roles: ROLE_API }
         - { path: ^/api/admin, roles: ROLE_ADMIN }
+        - { path: ^/admin, roles: ROLE_ADMIN }
         - { path: ^/i18n-type, roles: ROLE_ADMIN }
         - { path: ^/action, roles: ROLE_ADMIN }
         - { path: ^/wysiwyg-profile, roles: ROLE_ADMIN }


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

Routes starting with `/admin` should be only granted to ROLE_ADMIN
