### PR TITLE
fix(common): storageManager initFinalize before finalize

### DIFF
--- a/EMS/common-bundle/src/Storage/StorageManager.php
+++ b/EMS/common-bundle/src/Storage/StorageManager.php
@@ -154,6 +154,8 @@ class StorageManager
                 continue;
             }
 
+            $adapter->initFinalize($hash);
+
             if ($adapter->finalizeUpload($hash)) {
                 ++$count;
             }
@@ -434,6 +436,7 @@ class StorageManager
             }
 
             foreach ($filteredAdapters as $adapter) {
+                $adapter->initFinalize($hash);
                 $adapter->finalizeUpload($hash);
             }
         } catch (\Throwable $e) {


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

InitFinalize should be called before finalizeUpload
