### PR TITLE
feat(elasticms-web/admin): common probe routes (_readiness, _liveness)

### DIFF
--- a/EMS/common-bundle/src/Controller/ProbeController.php
+++ b/EMS/common-bundle/src/Controller/ProbeController.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CommonBundle\Controller;
+
+use EMS\CommonBundle\Service\ElasticaService;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ProbeController
+{
+    public function __construct(private readonly ElasticaService $elasticaService)
+    {
+    }
+
+    public function readiness(): Response
+    {
+        $version = $this->elasticaService->getVersion();
+
+        return new JsonResponse([
+            'cluster_version' => $version,
+        ]);
+    }
+
+    public function liveness(): Response
+    {
+        return new JsonResponse([
+            'live' => true,
+        ]);
+    }
+}

--- a/EMS/common-bundle/src/Resources/config/routing/probe.xml
+++ b/EMS/common-bundle/src/Resources/config/routing/probe.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<routes xmlns="http://symfony.com/schema/routing"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/routing https://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <route id="ems_probe_readiness" path="/_readiness"
+           controller="ems_common.controller.probe::readiness"
+           host="probe.localhost"
+           methods="GET">
+    </route>
+
+    <route id="ems_probe_liveness" path="/_liveness"
+           controller="ems_common.controller.probe::liveness"
+           host="probe.localhost"
+           methods="GET">
+    </route>
+
+</routes>

--- a/EMS/common-bundle/src/Resources/config/services.xml
+++ b/EMS/common-bundle/src/Resources/config/services.xml
@@ -124,5 +124,10 @@
             <argument type="service" id="kernel"/>
             <argument type="service" id="ems.helper.admin_api"/>
         </service>
+
+        <service id="ems_common.controller.probe" class="EMS\CommonBundle\Controller\ProbeController">
+            <argument type="service" id="ems_common.service.elastica"/>
+            <tag name="controller.service_arguments"/>
+        </service>
     </services>
 </container>

--- a/demo/configs/elasticms-admin/ems-demo.env
+++ b/demo/configs/elasticms-admin/ems-demo.env
@@ -1,6 +1,6 @@
 ###> Apache ###
 SERVER_NAME=local.ems-demo-admin.localhost
-SERVER_ALIASES='local.ems-demo-admin admin-local'
+SERVER_ALIASES='local.ems-demo-admin admin-local probe.localhost'
 ALIAS='/ems'
 JOBS_ENABLED=true
 ###< Apache ###

--- a/elasticms-admin/config/packages/security.yaml
+++ b/elasticms-admin/config/packages/security.yaml
@@ -58,6 +58,8 @@ security:
     access_control:
         - { path: ^/$, role: PUBLIC_ACCESS }
         - { path: ^/metrics$, role: PUBLIC_ACCESS }
+        - { path: ^/_readiness$, role: PUBLIC_ACCESS }
+        - { path: ^/_liveness$, role: PUBLIC_ACCESS }
         - { path: ^/public/, role: PUBLIC_ACCESS }
         - { path: ^/health_check(\.json)?$, role: PUBLIC_ACCESS }
         - { path: ^/login$, role: PUBLIC_ACCESS }

--- a/elasticms-admin/config/routes.yaml
+++ b/elasticms-admin/config/routes.yaml
@@ -1,6 +1,9 @@
 emsco:
     resource: '@EMSCoreBundle/Resources/config/routing/all.xml'
 
+probe:
+  resource: '@EMSCommonBundle/Resources/config/routing/probe.xml'
+
 ems_common:
     resource: 'ems_common.route.loader::load'
     type: service

--- a/elasticms-web/config/routes.yaml
+++ b/elasticms-web/config/routes.yaml
@@ -1,6 +1,9 @@
 files:
   resource: '@EMSCommonBundle/Resources/config/routing/file.xml'
 
+probe:
+  resource: '@EMSCommonBundle/Resources/config/routing/probe.xml'
+
 forms:
   resource: '@EMSFormBundle/Resources/config/routing/form.xml'
 


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |n|
|New feature?   |y|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

Add probe routes (readiness and liveness) for platform tests
