### PR TITLE
chore: cleanup bundles (composer scripts and .gitignore

### DIFF
--- a/EMS/client-helper-bundle/.gitignore
+++ b/EMS/client-helper-bundle/.gitignore
@@ -1,3 +1,2 @@
 /vendor
-/.php-cs-fixer.cache
 /.phpunit.result.cache

--- a/EMS/client-helper-bundle/composer.json
+++ b/EMS/client-helper-bundle/composer.json
@@ -45,9 +45,6 @@
 		"sort-packages": true
 	},
 	"scripts": {
-		"phpcs": "php-cs-fixer fix",
-		"phpstan": "phpstan analyse --memory-limit 1G",
-		"phpunit":  "phpunit",
-		"phpall": "php-cs-fixer fix && phpunit && phpstan analyse --memory-limit 1G"
+		"phpunit": "phpunit"
 	}
 }

--- a/EMS/common-bundle/.gitignore
+++ b/EMS/common-bundle/.gitignore
@@ -1,3 +1,2 @@
 /vendor
-/.php-cs-fixer.cache
 /.phpunit.result.cache

--- a/EMS/common-bundle/composer.json
+++ b/EMS/common-bundle/composer.json
@@ -79,9 +79,6 @@
 		"sort-packages": true
 	},
 	"scripts": {
-		"phpcs": "php-cs-fixer fix",
-		"phpstan": "phpstan analyse --memory-limit 1G",
-		"phpunit":  "phpunit",
-		"phpall": "php-cs-fixer fix && phpunit && phpstan analyse --memory-limit 1G"
+		"phpunit": "phpunit"
 	}
 }

--- a/EMS/core-bundle/.gitignore
+++ b/EMS/core-bundle/.gitignore
@@ -1,4 +1,3 @@
 /node_modules/
 /vendor
-/.php-cs-fixer.cache
 /.phpunit.result.cache

--- a/EMS/core-bundle/composer.json
+++ b/EMS/core-bundle/composer.json
@@ -62,9 +62,6 @@
 		"sort-packages": true
 	},
 	"scripts": {
-		"phpcs": "php-cs-fixer fix",
-		"phpstan": "phpstan analyse --memory-limit 1G",
-		"phpunit": "phpunit",
-		"phpall": "php-cs-fixer fix && phpunit && phpstan analyse --memory-limit 1G"
+		"phpunit": "phpunit"
 	}
 }

--- a/EMS/form-bundle/.gitignore
+++ b/EMS/form-bundle/.gitignore
@@ -1,4 +1,3 @@
 /vendor
 /node_modules
 /.phpunit.result.cache
-/.php-cs-fixer.cache

--- a/EMS/form-bundle/composer.json
+++ b/EMS/form-bundle/composer.json
@@ -40,9 +40,6 @@
 		"sort-packages": true
 	},
 	"scripts": {
-		"phpcs": "php-cs-fixer fix",
-		"phpstan": "phpstan analyse --memory-limit 1G",
-		"phpunit": "phpunit",
-		"phpall": "php-cs-fixer fix && phpunit && phpstan analyse --memory-limit 1G"
+		"phpunit": "phpunit"
 	}
 }

--- a/EMS/helpers/.gitignore
+++ b/EMS/helpers/.gitignore
@@ -1,3 +1,2 @@
 /vendor
-/.php-cs-fixer.cache
 /.phpunit.result.cache

--- a/EMS/helpers/composer.json
+++ b/EMS/helpers/composer.json
@@ -51,9 +51,6 @@
 		}
 	},
 	"scripts": {
-		"phpcs": "php-cs-fixer fix",
-		"phpstan": "phpstan analyse",
-		"phpunit":  "phpunit",
-		"phpall": "php-cs-fixer fix && phpunit && phpstan"
+		"phpunit":  "phpunit"
 	}
 }

--- a/EMS/submission-bundle/.gitignore
+++ b/EMS/submission-bundle/.gitignore
@@ -1,4 +1,3 @@
 /vendor
 /node_modules
 /.phpunit.result.cache
-/.php-cs-fixer.cache

--- a/EMS/submission-bundle/composer.json
+++ b/EMS/submission-bundle/composer.json
@@ -43,9 +43,6 @@
 		"sort-packages": true
 	},
 	"scripts": {
-		"phpcs": "php-cs-fixer fix",
-		"phpstan": "phpstan analyse --memory-limit 1G",
-		"phpunit": "phpunit",
-		"phpall": "php-cs-fixer fix && phpunit && phpstan analyse --memory-limit 1G"
+		"phpunit": "phpunit"
 	}
 }

--- a/EMS/xliff/.gitignore
+++ b/EMS/xliff/.gitignore
@@ -1,3 +1,2 @@
 /vendor
-/.php-cs-fixer.cache
 /.phpunit.result.cache

--- a/EMS/xliff/composer.json
+++ b/EMS/xliff/composer.json
@@ -51,9 +51,6 @@
 		}
 	},
 	"scripts": {
-		"phpcs": "php-cs-fixer fix",
-		"phpstan": "phpstan analyse",
-		"phpunit":  "phpunit",
-		"phpall": "php-cs-fixer fix && phpunit && phpstan analyse"
+		"phpunit":  "phpunit"
 	}
 }


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |n|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

Phpstan nor Phpcs is a dev requirements of the bundles/packages.
So the composer scripts and .gitignore is useless.

