### PR TITLE
fix(common/storage): s3 upload core api not working (chunkSize)

### DIFF
--- a/EMS/common-bundle/src/Common/CoreApi/Endpoint/File/File.php
+++ b/EMS/common-bundle/src/Common/CoreApi/Endpoint/File/File.php
@@ -38,7 +38,7 @@ final class File implements FileInterface
 
         $uploaded = $fromByte;
         while (!$stream->eof()) {
-            $uploaded = $this->addChunk($hash, $stream->read(819200));
+            $uploaded = $this->addChunk($hash, $stream->read(FileHelper::DEFAULT_CHUNK_SIZE));
         }
 
         if ($uploaded !== $size) {

--- a/EMS/common-bundle/src/Common/CoreApi/Endpoint/File/File.php
+++ b/EMS/common-bundle/src/Common/CoreApi/Endpoint/File/File.php
@@ -8,8 +8,8 @@ use EMS\CommonBundle\Common\CoreApi\Client;
 use EMS\CommonBundle\Contracts\CoreApi\Endpoint\File\FileInterface;
 use EMS\CommonBundle\Storage\Service\HttpStorage;
 use EMS\CommonBundle\Storage\StorageManager;
+use EMS\Helpers\File\File as FileHelper;
 use Psr\Http\Message\StreamInterface;
-use Symfony\Component\HttpFoundation\File\File as SymfonyFile;
 
 final class File implements FileInterface
 {
@@ -51,54 +51,34 @@ final class File implements FileInterface
     public function uploadFile(string $realPath, ?string $mimeType = null, ?string $filename = null, ?callable $callback = null): string
     {
         $hash = $this->hashFile($realPath);
-        $filesize = \filesize($realPath);
-        if (!\is_int($filesize)) {
-            throw new \RuntimeException('Unexpected file size type');
-        }
 
-        $symfonyFile = new SymfonyFile($realPath, false);
-        $exploded = \explode(DIRECTORY_SEPARATOR, $realPath);
+        $file = FileHelper::fromFilename($realPath);
+        $mimeType ??= $file->mimeType;
+        $filename ??= $file->name;
 
-        $mimeType ??= $symfonyFile->guessExtension() ?? 'application/octet-stream';
-        $filename ??= \end($exploded);
+        $fromByte = $this->initUpload($hash, $file->size, $filename, $mimeType);
 
-        $fromByte = $this->initUpload($hash, $filesize, $filename, $mimeType);
         if ($fromByte < 0) {
             throw new \RuntimeException(\sprintf('Unexpected negative offset: %d', $fromByte));
         }
-        if ($fromByte > $filesize) {
-            throw new \RuntimeException(\sprintf('Unexpected bigger offset than the filesize: %d > %d', $fromByte, $filesize));
+        if ($fromByte > $file->size) {
+            throw new \RuntimeException(\sprintf('Unexpected bigger offset than the filesize: %d > %d', $fromByte, $file->size));
         }
-
-        $handle = \fopen($realPath, 'r');
-        if (false === $handle) {
-            throw new \RuntimeException(\sprintf('Unexpected error while open the archive %s', $realPath));
-        }
-        if ($fromByte > 0) {
-            if (0 !== \fseek($handle, $fromByte)) {
-                throw new \RuntimeException(\sprintf('Unexpected error while seeking the file pointer at position %s', $fromByte));
-            }
-        }
-
-        if ($fromByte === $filesize) {
+        if ($fromByte === $file->size) {
             return $hash;
         }
 
         $uploaded = $fromByte;
-        while (!\feof($handle)) {
-            $chunk = \fread($handle, 819200);
-            if (!\is_string($chunk)) {
-                throw new \RuntimeException('Unexpected chunk type');
-            }
-            $uploaded = $this->addChunk($hash, $chunk);
 
+        foreach ($file->chunk($fromByte) as $chunk) {
+            $uploaded = $this->addChunk($hash, $chunk);
             if (null !== $callback) {
                 $callback($chunk);
             }
         }
-        \fclose($handle);
-        if ($uploaded !== $filesize) {
-            throw new \RuntimeException(\sprintf('Sizes mismatched %d vs. %d for assets %s', $uploaded, $filesize, $hash));
+
+        if ($uploaded !== $file->size) {
+            throw new \RuntimeException(\sprintf('Sizes mismatched %d vs. %d for assets %s', $uploaded, $file->size, $hash));
         }
 
         return $hash;

--- a/EMS/common-bundle/src/Storage/Service/S3Storage.php
+++ b/EMS/common-bundle/src/Storage/Service/S3Storage.php
@@ -222,10 +222,10 @@ class S3Storage extends AbstractUrlStorage
     private function uploadKey(string $hash): string
     {
         if ($this->multipartUpload) {
-            return "upload_$hash";
+            return "uploads_$hash";
         }
 
-        return "upload/$hash";
+        return "uploads/$hash";
     }
 
     private function key(string $hash): string

--- a/EMS/helpers/composer.json
+++ b/EMS/helpers/composer.json
@@ -19,7 +19,8 @@
 		"ext-json": "*",
 		"ext-tidy": "*",
 		"symfony/html-sanitizer": "^6.2",
-		"symfony/options-resolver": "^5.4"
+		"symfony/options-resolver": "^5.4",
+		"symfony/mime": "^5.4"
 	},
 	"require-dev" : {
 		"mockery/mockery" : "^0.9",

--- a/EMS/helpers/src/File/File.php
+++ b/EMS/helpers/src/File/File.php
@@ -13,6 +13,8 @@ class File
     public string $mimeType;
     public int $size;
 
+    public const DEFAULT_CHUNK_SIZE = 5 * 1024 * 1024;
+
     private function __construct(private readonly \SplFileInfo $file)
     {
         $this->name = $this->file->getFilename();
@@ -28,7 +30,7 @@ class File
     /**
      * @return iterable<string>
      */
-    public function chunk(int $fromByte): iterable
+    public function chunk(int $fromByte, int $chunkSize = self::DEFAULT_CHUNK_SIZE): iterable
     {
         $realPath = $this->file->getRealPath();
 
@@ -44,9 +46,8 @@ class File
 
         while (!\feof($handle)) {
             $chunk = '';
-            $minSize = 5 * 1024 * 1024;
-            while (!\feof($handle) && \strlen($chunk) < $minSize) {
-                $chunk .= \fread($handle, $minSize - \strlen($chunk));
+            while (!\feof($handle) && \strlen($chunk) < $chunkSize) {
+                $chunk .= \fread($handle, $chunkSize - \strlen($chunk));
             }
 
             yield $chunk;

--- a/EMS/helpers/src/File/File.php
+++ b/EMS/helpers/src/File/File.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\Helpers\File;
+
+use EMS\Helpers\Standard\Type;
+use Symfony\Component\Mime\MimeTypes;
+
+class File
+{
+    public string $name;
+    public string $mimeType;
+    public int $size;
+
+    private function __construct(private readonly \SplFileInfo $file)
+    {
+        $this->name = $this->file->getFilename();
+        $this->size = Type::integer($this->file->getSize());
+        $this->mimeType = MimeTypes::getDefault()->guessMimeType($file->getPathname()) ?? 'application/octet-stream';
+    }
+
+    public static function fromFilename(string $filename): self
+    {
+        return new self(new \SplFileInfo($filename));
+    }
+
+    /**
+     * @return iterable<string>
+     */
+    public function readChunk(int $fromByte): iterable
+    {
+        $realPath = $this->file->getRealPath();
+
+        if (false === $handle = \fopen($realPath, 'r')) {
+            throw new \RuntimeException(\sprintf('Unexpected error while opening file %s', $realPath));
+        }
+
+        if ($fromByte > 0) {
+            if (0 !== \fseek($handle, $fromByte)) {
+                throw new \RuntimeException(\sprintf('Unexpected error while seeking the file pointer at position %s', $fromByte));
+            }
+        }
+
+        while (!\feof($handle)) {
+            $chunk = '';
+            $minSize = 5 * 1024 * 1024;
+            while (!\feof($handle) && \strlen($chunk) < $minSize) {
+                $chunk .= \fread($handle, $minSize - \strlen($chunk));
+            }
+
+            yield $chunk;
+        }
+        \fclose($handle);
+    }
+}

--- a/EMS/helpers/src/File/File.php
+++ b/EMS/helpers/src/File/File.php
@@ -13,7 +13,7 @@ class File
     public string $mimeType;
     public int $size;
 
-    public const DEFAULT_CHUNK_SIZE = 5 * 1024 * 1024;
+    public const DEFAULT_CHUNK_SIZE = 8 * 1024 * 1024;
 
     private function __construct(private readonly \SplFileInfo $file)
     {

--- a/EMS/helpers/src/File/File.php
+++ b/EMS/helpers/src/File/File.php
@@ -28,7 +28,7 @@ class File
     /**
      * @return iterable<string>
      */
-    public function readChunk(int $fromByte): iterable
+    public function chunk(int $fromByte): iterable
     {
         $realPath = $this->file->getRealPath();
 

--- a/EMS/helpers/src/File/File.php
+++ b/EMS/helpers/src/File/File.php
@@ -47,7 +47,10 @@ class File
         while (!\feof($handle)) {
             $chunk = '';
             while (!\feof($handle) && \strlen($chunk) < $chunkSize) {
-                $chunk .= \fread($handle, $chunkSize - \strlen($chunk));
+                $length = $chunkSize - \strlen($chunk);
+                if ($length > 0) {
+                    $chunk .= \fread($handle, $length);
+                }
             }
 
             yield $chunk;


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

Fix s3 upload min chunk size is 5mb
From the frontend javascript is chunking by 8mb -> https://github.com/ems-project/file-uploader/blob/main/FileUploader.js#L14

Created a new `File` helper, maybe overkill for bugfix. But wanted to isolate the logic for the feature.

