### PR TITLE
fix(core/api): create managed alias set alias (instanceId)

### DIFF
--- a/EMS/core-bundle/src/Core/ManagedAlias/ManagedAliasManager.php
+++ b/EMS/core-bundle/src/Core/ManagedAlias/ManagedAliasManager.php
@@ -80,7 +80,7 @@ class ManagedAliasManager implements EntityServiceInterface
         if (null !== $name && $managedAlias->getName() !== $name) {
             throw new \RuntimeException(\sprintf('Manage alias name mismatched: %s vs %s', $managedAlias->getName(), $name));
         }
-        $this->repository->update($managedAlias);
+        $this->update($managedAlias);
 
         return $managedAlias;
     }


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

On creation of a managed alias call the update function, this will set managed alias.

Got the following exception
```
An exception occurred while executing a query: SQLSTATE[23502]: Not null violation: 7 ERROR:  null value in column "alias" violates not-null   
````


