### PR TITLE
fix(core): customUserOptionsForm not null but empty string

### DIFF
--- a/EMS/core-bundle/src/Form/Form/UserOptionsType.php
+++ b/EMS/core-bundle/src/Form/Form/UserOptionsType.php
@@ -51,7 +51,7 @@ class UserOptionsType extends AbstractType
                 ]);
         }
 
-        if (null !== $this->customUserOptionsForm) {
+        if ($this->customUserOptionsForm) {
             $form = $this->formManager->getByName($this->customUserOptionsForm);
             $builder->add(UserOptions::CUSTOM_OPTIONS, $form->getFieldType()->getType(), [
                 'metadata' => $form->getFieldType(),


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

If the core is configured by environment variables, the value will be ''.
