### PR TITLE
fix(core/notifications): treat all updating contentType root field

### DIFF
--- a/EMS/core-bundle/src/Service/NotificationService.php
+++ b/EMS/core-bundle/src/Service/NotificationService.php
@@ -83,10 +83,8 @@ class NotificationService
 
         foreach ($notifications as $notification) {
             $this->logger->warning('service.notification.notification_will_be_lost_finalize', [
-                'notification_name' => $notification->getTemplate()->getName(),
-                EmsFields::LOG_CONTENTTYPE_FIELD => $event->getRevision()->getContentType(),
-                EmsFields::LOG_OUUID_FIELD => $event->getRevision()->getOuuid(),
-                EmsFields::LOG_REVISION_ID_FIELD => $event->getRevision()->getId(),
+                ...LogRevisionContext::read($notification->getRevision()),
+                ...['notification_name' => $notification->getTemplate()->getName()]
             ]);
         }
     }
@@ -110,30 +108,20 @@ class NotificationService
         $em->persist($notification);
         $em->flush();
 
+        $context = [
+            ...LogRevisionContext::read($notification->getRevision()),
+            ...[
+                'notification_name' => $notification->getTemplate()->getName(),
+                'notification_status' => $status,
+            ]
+        ];
+
         if ('error' === $level) {
-            $this->logger->error('service.notification.update', [
-                'notification_name' => $notification->getTemplate()->getName(),
-                EmsFields::LOG_CONTENTTYPE_FIELD => $notification->getRevision()->getContentType(),
-                EmsFields::LOG_OUUID_FIELD => $notification->getRevision()->getOuuid(),
-                EmsFields::LOG_REVISION_ID_FIELD => $notification->getRevision()->getId(),
-                'notification_status' => $status,
-            ]);
+            $this->logger->error('service.notification.update', $context);
         } elseif ('warning' === $level) {
-            $this->logger->warning('service.notification.update', [
-                'notification_name' => $notification->getTemplate()->getName(),
-                EmsFields::LOG_CONTENTTYPE_FIELD => $notification->getRevision()->getContentType(),
-                EmsFields::LOG_OUUID_FIELD => $notification->getRevision()->getOuuid(),
-                EmsFields::LOG_REVISION_ID_FIELD => $notification->getRevision()->getId(),
-                'notification_status' => $status,
-            ]);
+            $this->logger->warning('service.notification.update', $context);
         } else {
-            $this->logger->notice('service.notification.update', [
-                'notification_name' => $notification->getTemplate()->getName(),
-                EmsFields::LOG_CONTENTTYPE_FIELD => $notification->getRevision()->getContentType(),
-                EmsFields::LOG_OUUID_FIELD => $notification->getRevision()->getOuuid(),
-                EmsFields::LOG_REVISION_ID_FIELD => $notification->getRevision()->getId(),
-                'notification_status' => $status,
-            ]);
+            $this->logger->notice('service.notification.update', $context);
         }
 
         return $this;
@@ -167,13 +155,11 @@ class NotificationService
                 /** @var Notification $alreadyPending */
                 $alreadyPending = $alreadyPending[0];
                 $this->logger->warning('service.notification.another_one_is_pending', [
-                    'label' => $alreadyPending->getRevision()->getLabel(),
-                    'notification_name' => $alreadyPending->getTemplate()->getName(),
-                    EmsFields::LOG_CONTENTTYPE_FIELD => $alreadyPending->getRevision()->getContentType(),
-                    EmsFields::LOG_OUUID_FIELD => $alreadyPending->getRevision()->getOuuid(),
-                    EmsFields::LOG_REVISION_ID_FIELD => $alreadyPending->getRevision()->getId(),
-                    EmsFields::LOG_ENVIRONMENT_FIELD => $environment->getName(),
-                    'notification_username' => $alreadyPending->getUsername(),
+                    ...LogRevisionContext::read($revision),
+                    ...[
+                        'notification_name' => $alreadyPending->getTemplate()->getName(),
+                        'notification_username' => $alreadyPending->getUsername(),
+                    ]
                 ]);
 
                 return null;
@@ -199,29 +185,29 @@ class NotificationService
             $em->flush();
 
             $this->logger->notice('service.notification.send', [
-                'label' => $notification->getRevision()->getLabel(),
-                'notification_name' => $notification->getTemplate()->getName(),
-                EmsFields::LOG_CONTENTTYPE_FIELD => $notification->getRevision()->getContentType(),
-                EmsFields::LOG_OUUID_FIELD => $notification->getRevision()->getOuuid(),
-                EmsFields::LOG_REVISION_ID_FIELD => $notification->getRevision()->getId(),
-                EmsFields::LOG_ENVIRONMENT_FIELD => $environment->getName(),
+                ...LogRevisionContext::read($notification->getRevision()),
+                ...['notification_name' => $notification->getTemplate()->getName()]
             ]);
             $out = true;
         } catch (SkipNotificationException $e) {
             $this->logger->warning($e->getMessage(), [
-                'action_name' => $template->getName(),
-                'action_label' => $template->getLabel(),
-                'contenttype_name' => $revision->giveContentType(),
-                EmsFields::LOG_EXCEPTION_FIELD => $e,
-                EmsFields::LOG_ERROR_MESSAGE_FIELD => $e->getMessage(),
+                ...LogRevisionContext::read($revision),
+                ...[
+                    'action_name' => $template->getName(),
+                    'action_label' => $template->getLabel(),
+                    EmsFields::LOG_EXCEPTION_FIELD => $e,
+                    EmsFields::LOG_ERROR_MESSAGE_FIELD => $e->getMessage(),
+                ]
             ]);
         } catch (\Exception $e) {
             $this->logger->error('service.notification.send_error', [
-                'action_name' => $template->getName(),
-                'action_label' => $template->getLabel(),
-                'contenttype_name' => $revision->giveContentType(),
-                EmsFields::LOG_EXCEPTION_FIELD => $e,
-                EmsFields::LOG_ERROR_MESSAGE_FIELD => $e->getMessage(),
+                ...LogRevisionContext::read($revision),
+                ...[
+                    'action_name' => $template->getName(),
+                    'action_label' => $template->getLabel(),
+                    EmsFields::LOG_EXCEPTION_FIELD => $e,
+                    EmsFields::LOG_ERROR_MESSAGE_FIELD => $e->getMessage(),
+                ]
             ]);
         }
 

--- a/EMS/core-bundle/src/Service/NotificationService.php
+++ b/EMS/core-bundle/src/Service/NotificationService.php
@@ -4,6 +4,7 @@ namespace EMS\CoreBundle\Service;
 
 use Doctrine\Bundle\DoctrineBundle\Registry;
 use EMS\CommonBundle\Helper\EmsFields;
+use EMS\CoreBundle\Core\Log\LogRevisionContext;
 use EMS\CoreBundle\Core\Mail\MailerService;
 use EMS\CoreBundle\Entity\Environment;
 use EMS\CoreBundle\Entity\Form\NotificationFilter;
@@ -413,13 +414,12 @@ class NotificationService
         }
 
         $this->logger->notice('service.notification.treated', [
-            'notification_name' => $notification->getTemplate()->getName(),
-            EmsFields::LOG_CONTENTTYPE_FIELD => $notification->getRevision()->getContentType(),
-            EmsFields::LOG_OUUID_FIELD => $notification->getRevision()->getOuuid(),
-            EmsFields::LOG_REVISION_ID_FIELD => $notification->getRevision()->getId(),
-            EmsFields::LOG_ENVIRONMENT_FIELD => $notification->getEnvironment()->getName(),
-            'status' => $notification->getStatus(),
-            'label' => $notification->getRevision()->getLabel(),
+            ...LogRevisionContext::read($notification->getRevision()),
+            ...[
+                'notification_name' => $notification->getTemplate()->getName(),
+                'status' => $notification->getStatus(),
+                'label' => $notification->getRevision()->getLabel(),
+            ],
         ]);
     }
 

--- a/EMS/core-bundle/src/Service/NotificationService.php
+++ b/EMS/core-bundle/src/Service/NotificationService.php
@@ -84,7 +84,7 @@ class NotificationService
         foreach ($notifications as $notification) {
             $this->logger->warning('service.notification.notification_will_be_lost_finalize', [
                 ...LogRevisionContext::read($notification->getRevision()),
-                ...['notification_name' => $notification->getTemplate()->getName()]
+                ...['notification_name' => $notification->getTemplate()->getName()],
             ]);
         }
     }
@@ -113,7 +113,7 @@ class NotificationService
             ...[
                 'notification_name' => $notification->getTemplate()->getName(),
                 'notification_status' => $status,
-            ]
+            ],
         ];
 
         if ('error' === $level) {
@@ -159,7 +159,7 @@ class NotificationService
                     ...[
                         'notification_name' => $alreadyPending->getTemplate()->getName(),
                         'notification_username' => $alreadyPending->getUsername(),
-                    ]
+                    ],
                 ]);
 
                 return null;
@@ -186,7 +186,7 @@ class NotificationService
 
             $this->logger->notice('service.notification.send', [
                 ...LogRevisionContext::read($notification->getRevision()),
-                ...['notification_name' => $notification->getTemplate()->getName()]
+                ...['notification_name' => $notification->getTemplate()->getName()],
             ]);
             $out = true;
         } catch (SkipNotificationException $e) {
@@ -197,7 +197,7 @@ class NotificationService
                     'action_label' => $template->getLabel(),
                     EmsFields::LOG_EXCEPTION_FIELD => $e,
                     EmsFields::LOG_ERROR_MESSAGE_FIELD => $e->getMessage(),
-                ]
+                ],
             ]);
         } catch (\Exception $e) {
             $this->logger->error('service.notification.send_error', [
@@ -207,7 +207,7 @@ class NotificationService
                     'action_label' => $template->getLabel(),
                     EmsFields::LOG_EXCEPTION_FIELD => $e,
                     EmsFields::LOG_ERROR_MESSAGE_FIELD => $e->getMessage(),
-                ]
+                ],
             ]);
         }
 


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

Treat **more** then 1 notifications, will update the contentType structure and detach the root field and update all child fields with parent_id = null.

Inside the notificationService we are passing a contentType entity (proxy) as loggingContext
```php
EmsFields::LOG_CONTENTTYPE_FIELD => $notification->getRevision()->getContentType(),
```

In the commonBundle the doctrineLogHandler will insert the log record into the db using DBAL, but inside the statement is a true proxy entity object. On the next iteration, doctrine ORM will see the contentType as dirty and  preform an update.
