### PR TITLE
fix(standard/html): sanitizer allow emsLinks

### DIFF
--- a/EMS/helpers/src/Html/Sanitizer/HtmlSanitizerConfigBuilder.php
+++ b/EMS/helpers/src/Html/Sanitizer/HtmlSanitizerConfigBuilder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace EMS\Helpers\Html\Sanitizer;
 
 use Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig;
+use Symfony\Component\HtmlSanitizer\Visitor\AttributeSanitizer\UrlAttributeSanitizer;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class HtmlSanitizerConfigBuilder
@@ -51,7 +52,17 @@ class HtmlSanitizerConfigBuilder
     public function build(): HtmlSanitizerConfig
     {
         $config = new HtmlSanitizerConfig();
-        $config = $config->withAttributeSanitizer(new HtmlSanitizerClass($this->classes));
+
+        $defaultSanitizers = $config->getAttributeSanitizers();
+        foreach ($defaultSanitizers as $sanitizer) {
+            if ($sanitizer instanceof UrlAttributeSanitizer) {
+                $config = $config->withoutAttributeSanitizer($sanitizer);
+            }
+        }
+
+        $config = $config
+            ->withAttributeSanitizer(new HtmlSanitizerClass($this->classes))
+            ->withAttributeSanitizer(new HtmlSanitizerLink());
 
         foreach ($this->configSettings as $setting => $value) {
             $config = match ($setting) {

--- a/EMS/helpers/src/Html/Sanitizer/HtmlSanitizerLink.php
+++ b/EMS/helpers/src/Html/Sanitizer/HtmlSanitizerLink.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\Helpers\Html\Sanitizer;
+
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig;
+use Symfony\Component\HtmlSanitizer\Visitor\AttributeSanitizer\AttributeSanitizerInterface;
+use Symfony\Component\HtmlSanitizer\Visitor\AttributeSanitizer\UrlAttributeSanitizer;
+
+use function Symfony\Component\String\u;
+
+class HtmlSanitizerLink implements AttributeSanitizerInterface
+{
+    public function getSupportedElements(): ?array
+    {
+        return null;
+    }
+
+    public function getSupportedAttributes(): ?array
+    {
+        return ['src', 'href', 'lowsrc', 'background', 'ping'];
+    }
+
+    public function sanitizeAttribute(string $element, string $attribute, string $value, HtmlSanitizerConfig $config): ?string
+    {
+        if (u($value)->startsWith('ems://')) {
+            return $value;
+        }
+
+        $urlSanitizer = new UrlAttributeSanitizer();
+
+        return $urlSanitizer->sanitizeAttribute($element, $attribute, $value, $config);
+    }
+}

--- a/EMS/helpers/tests/Unit/Standard/HtmlTest.php
+++ b/EMS/helpers/tests/Unit/Standard/HtmlTest.php
@@ -52,6 +52,21 @@ HTML;
     private function getDataHtmlSanitize(): array
     {
         return [
+            'testEMSLinks' => [
+                '<a href="ems://object:page:876eb204-c3a3-43a6-94b6-9124a7206b1b">test</a>',
+                '<a href="ems://object:page:876eb204-c3a3-43a6-94b6-9124a7206b1b">test</a>',
+                ['allow_safe_elements' => true],
+            ],
+            'testAllowLinks' => [
+                '<a href="http://www.example.com">http test</a><a href="https://www.example.com">http test</a><a href="mailto:support@example.com">mail test</a>',
+                '<a href="http://www.example.com">http test</a><a href="https://www.example.com">http test</a><a href="mailto:support&#64;example.com">mail test</a>',
+                ['allow_safe_elements' => true],
+            ],
+            'testInlineData' => [
+                '<img src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAgAAZABkAAD" />',
+                '<img src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAgAAZABkAAD" />',
+                ['allow_safe_elements' => true],
+            ],
             'testSafeElements' => [
                 '<div>div test</div><span>span test</span>',
                 '<div>div test</div><span>span test</span>',


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

Overwrite the default symfony [UrlAttributeSanitizer](https://github.com/symfony/html-sanitizer/blob/6.4/Visitor/AttributeSanitizer/UrlAttributeSanitizer.php)
