### PR TITLE
fix(common/storage): image processor bad horizontal mirroring

### DIFF
--- a/EMS/common-bundle/src/Storage/Processor/Image.php
+++ b/EMS/common-bundle/src/Storage/Processor/Image.php
@@ -350,17 +350,17 @@ class Image
                     break;
                 case 5:
                     $angle = 270;
+                    $mirrored = true;
                     break;
                 case 6:
                     $angle = 270;
-                    $mirrored = true;
                     break;
                 case 7:
                     $angle = 90;
+                    $mirrored = true;
                     break;
                 case 8:
                     $angle = 90;
-                    $mirrored = true;
                     break;
             }
             $image = $this->rotate($image, $angle);


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

https://jdhao.github.io/2019/07/31/image_rotation_exif_info/

Orientations 5 and 7 are flipped not 6 and 8
