### PR TITLE
fix(common/storage): limit a range request size to 8MB if not specified by the client

### DIFF
--- a/EMS/common-bundle/src/Storage/Processor/StreamRange.php
+++ b/EMS/common-bundle/src/Storage/Processor/StreamRange.php
@@ -8,6 +8,7 @@ use Symfony\Component\HttpFoundation\HeaderBag;
 
 class StreamRange
 {
+    private const DEFAULT_RANGE_SIZE = 8 * 1024 * 1024;
     private int $end;
     private int $start = 0;
 
@@ -29,15 +30,13 @@ class StreamRange
             return;
         }
 
-        [$start, $end] = \explode('-', \substr($range, 6), 2) + [0];
+        [$start, $end] = \explode('-', \substr($range, 6), 2);
 
-        $this->end = ('' === $end) ? $this->fileSize - 1 : (int) $end;
-
-        if ('' === $start) {
-            $this->start = $this->fileSize - $this->end;
-            $this->end = $this->fileSize - 1;
+        $this->start = ('' === $start) ? 0 : (int) $start;
+        if ('' === $end) {
+            $this->end = \min($this->fileSize - 1, $this->start + self::DEFAULT_RANGE_SIZE);
         } else {
-            $this->start = (int) $start;
+            $this->end = (int) $end;
         }
     }
 


### PR DESCRIPTION

|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|


