### PR TITLE
fix(core/job): schedule jobs not running by ems:job:run

### DIFF
--- a/EMS/core-bundle/src/Repository/ScheduleRepository.php
+++ b/EMS/core-bundle/src/Repository/ScheduleRepository.php
@@ -115,14 +115,19 @@ class ScheduleRepository extends ServiceEntityRepository
     public function findNext(?string $tag = null): ?Schedule
     {
         $qb = $this->createQueryBuilder('schedule');
-        $qb->andWhere($qb->expr()->lte('schedule.nextRun', ':now'))
-        ->andWhere($qb->expr()->eq('schedule.tag', ':tag'))
-        ->setParameters([
-            'now' => new \DateTimeImmutable(),
-            'tag' => $tag,
-        ])
-        ->orderBy('schedule.nextRun', 'asc')
-        ->setMaxResults(1);
+        $qb
+            ->andWhere($qb->expr()->lte('schedule.nextRun', ':now'))
+            ->setParameter('now', new \DateTimeImmutable())
+            ->orderBy('schedule.nextRun', 'asc')
+            ->setMaxResults(1);
+
+        if ($tag) {
+            $qb
+                ->andWhere($qb->expr()->eq('schedule.tag', ':tag'))
+                ->setParameter('tag', $tag);
+        } else {
+            $qb->andWhere($qb->expr()->isNull('schedule.tag'));
+        }
 
         $schedule = $qb->getQuery()->getOneOrNullResult();
         if (null !== $schedule && !$schedule instanceof Schedule) {


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

Passing and empty tag will result in a broken query where tag = null, should be tag is null
