### PR TITLE
feat(cli/media-sync): new options

### DIFF
--- a/EMS/common-bundle/src/Common/CoreApi/Endpoint/File/File.php
+++ b/EMS/common-bundle/src/Common/CoreApi/Endpoint/File/File.php
@@ -92,11 +92,11 @@ final class File implements FileInterface
 
     public function downloadFile(string $hash): string
     {
-        if (!$this->storageManager->head($hash)) {
+        if (!$this->headHash($hash)) {
             throw new \RuntimeException(\sprintf('Could not download file with hash %s', $hash));
         }
 
-        $stream = $this->storageManager->getStream($hash);
+        $stream = $this->client->download($this->downloadLink($hash));
 
         return TempFile::fromStream($stream, $hash)->path;
     }

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
     "ext-ctype": "*",
     "ext-dom": "*",
     "ext-exif": "*",
+    "ext-fileinfo": "*",
     "ext-gd": "*",
     "ext-iconv": "*",
     "ext-intl": "*",

--- a/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySync.php
+++ b/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySync.php
@@ -222,8 +222,8 @@ final class MediaLibrarySync
         $rows = $this->fileReader->getData($metadataFile);
         $header = $rows[0] ?? [];
         $this->metadatas = [];
-        foreach ($rows as $key => $value) {
-            if (0 === $key) {
+        foreach ($rows as $rowIndex => $value) {
+            if (0 === $rowIndex) {
                 continue;
             }
             $row = [];

--- a/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySync.php
+++ b/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySync.php
@@ -96,7 +96,8 @@ final class MediaLibrarySync
         $metaData = $this->getMetadata($path);
 
         if ($this->options->onlyMetadataFile && 0 === \count($metaData)) {
-            $this->io->warning(sprintf('Skipped "%s" with reason metadata was found', $path));
+            $this->io->warning(\sprintf('Skipped "%s" with reason metadata was found', $path));
+
             return;
         }
 

--- a/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySync.php
+++ b/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySync.php
@@ -52,6 +52,10 @@ final class MediaLibrarySync
     {
         $this->io->title('MediaLibrary sync files located in a folder');
 
+        if (null !== $this->options->metaDataFile) {
+            $this->loadMetadata($this->options->metaDataFile);
+        }
+
         $finder = new Finder();
         $finder->files()->in($this->getFolderPath());
 
@@ -222,7 +226,7 @@ final class MediaLibrarySync
         return $assetArray;
     }
 
-    public function loadMetadata(string $metadataFile, string $locateRowExpression): void
+    public function loadMetadata(string $metadataFile): void
     {
         $metadataFilePath = $this->options->hashMetaDataFile ? $this->getFileByHash($metadataFile) : $metadataFile;
 
@@ -238,7 +242,7 @@ final class MediaLibrarySync
                 $row[$header[$key] ?? $key] = $cell;
             }
 
-            $filename = $this->expressionService->evaluateToString($locateRowExpression, [
+            $filename = $this->expressionService->evaluateToString($this->options->locateRowExpression, [
                 'row' => $row,
             ]);
             if (\is_string($filename)) {

--- a/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySync.php
+++ b/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySync.php
@@ -29,6 +29,7 @@ final class MediaLibrarySync
     private DataInterface $contentTypeApi;
     private string $defaultAlias;
     private MimeTypes $mimeTypes;
+    private ?TikaHelper $tikaHelper = null;
 
     public function __construct(
         private readonly MediaLibrarySyncOptions $options,
@@ -36,11 +37,15 @@ final class MediaLibrarySync
         private readonly CoreApiInterface $coreApi,
         private readonly FileReaderInterface $fileReader,
         private readonly ExpressionServiceInterface $expressionService,
-        private readonly ?TikaHelper $tikaHelper
     ) {
         $this->contentTypeApi = $this->coreApi->data($this->options->contentType);
         $this->defaultAlias = $this->coreApi->meta()->getDefaultContentTypeEnvironmentAlias($this->options->contentType);
         $this->mimeTypes = new MimeTypes();
+    }
+
+    public function setTikaHelper(?TikaHelper $tikaHelper): void
+    {
+        $this->tikaHelper = $tikaHelper;
     }
 
     public function execute(): self

--- a/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySync.php
+++ b/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySync.php
@@ -81,9 +81,14 @@ final class MediaLibrarySync
 
     private function uploadMediaFile(SplFileInfo $file): void
     {
-        $this->uploadMedia(DIRECTORY_SEPARATOR.$file->getRelativePathname(), [
-            self::SYNC_METADATA => $this->getMetadata(DIRECTORY_SEPARATOR.$file->getRelativePathname()),
-        ], $file);
+        $path = DIRECTORY_SEPARATOR.$file->getRelativePathname();
+        $metaData = $this->getMetadata($path);
+
+        if ($this->options->onlyMetadataFile && 0 === \count($metaData)) {
+            return;
+        }
+
+        $this->uploadMedia($path, [self::SYNC_METADATA => $metaData], $file);
 
         $exploded = \explode(DIRECTORY_SEPARATOR, $file->getRelativePath());
         while (\count($exploded) > 0) {

--- a/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySync.php
+++ b/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySync.php
@@ -96,6 +96,7 @@ final class MediaLibrarySync
         $metaData = $this->getMetadata($path);
 
         if ($this->options->onlyMetadataFile && 0 === \count($metaData)) {
+            $this->io->warning(sprintf('Skipped "%s" with reason metadata was found', $path));
             return;
         }
 

--- a/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySyncOptions.php
+++ b/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySyncOptions.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\CLI\Client\MediaLibrary;
+
+final class MediaLibrarySyncOptions
+{
+    public function __construct(
+        public readonly string $folder,
+        public readonly string $contentType,
+        public readonly string $folderField,
+        public readonly string $pathField,
+        public readonly string $fileField,
+        public readonly bool $dryRun,
+        public readonly bool $onlyMissingFile,
+        public readonly int $maxContentSize = 5120
+    ) {
+    }
+}

--- a/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySyncOptions.php
+++ b/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySyncOptions.php
@@ -12,6 +12,8 @@ final class MediaLibrarySyncOptions
         public readonly string $folderField,
         public readonly string $pathField,
         public readonly string $fileField,
+        public readonly ?string $metaDataFile,
+        public readonly string $locateRowExpression,
         public readonly bool $dryRun,
         public readonly bool $onlyMissingFile,
         public readonly bool $onlyMetadataFile,

--- a/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySyncOptions.php
+++ b/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySyncOptions.php
@@ -14,6 +14,7 @@ final class MediaLibrarySyncOptions
         public readonly string $fileField,
         public readonly bool $dryRun,
         public readonly bool $onlyMissingFile,
+        public readonly bool $onlyMetadataFile,
         public readonly bool $hashFolder,
         public readonly bool $hashMetaDataFile,
         public readonly int $maxContentSize = 5120

--- a/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySyncOptions.php
+++ b/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySyncOptions.php
@@ -15,6 +15,7 @@ final class MediaLibrarySyncOptions
         public readonly bool $dryRun,
         public readonly bool $onlyMissingFile,
         public readonly bool $hashFolder,
+        public readonly bool $hashMetaDataFile,
         public readonly int $maxContentSize = 5120
     ) {
     }

--- a/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySyncOptions.php
+++ b/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySyncOptions.php
@@ -14,6 +14,7 @@ final class MediaLibrarySyncOptions
         public readonly string $fileField,
         public readonly bool $dryRun,
         public readonly bool $onlyMissingFile,
+        public readonly bool $hashFolder,
         public readonly int $maxContentSize = 5120
     ) {
     }

--- a/elasticms-cli/src/Command/MediaLibrary/MediaLibrarySyncCommand.php
+++ b/elasticms-cli/src/Command/MediaLibrary/MediaLibrarySyncCommand.php
@@ -34,6 +34,7 @@ final class MediaLibrarySyncCommand extends AbstractCommand
     private const OPTION_TIKA_BASE_URL = 'tika-base-url';
     private const OPTION_MAX_CONTENT_SIZE = 'max-content-size';
     private const OPTION_HASH_FOLDER = 'hash-folder';
+    private const OPTION_HASH_METADATA_FILE = 'hash-metadata-file';
 
     private ?string $metadataFile;
     private string $locateRowExpression;
@@ -60,13 +61,14 @@ final class MediaLibrarySyncCommand extends AbstractCommand
             ->addOption(self::OPTION_PATH_FIELD, null, InputOption::VALUE_OPTIONAL, 'Media Library path field (default: media_path)', 'media_path')
             ->addOption(self::OPTION_FILE_FIELD, null, InputOption::VALUE_OPTIONAL, 'Media Library file field (default: media_file)', 'media_file')
             ->addOption(self::OPTION_DRY_RUN, null, InputOption::VALUE_NONE, 'Just do a dry run')
-            ->addOption(self::OPTION_METADATA_FILE, null, InputOption::VALUE_OPTIONAL, 'Path to a file containing metadata (CSV or  Excel)')
+            ->addOption(self::OPTION_METADATA_FILE, null, InputOption::VALUE_OPTIONAL, 'Path to a file containing metadata (CSV or Excel)')
             ->addOption(self::OPTION_LOCATE_ROW_EXPRESSION, null, InputOption::VALUE_OPTIONAL, 'Expression language apply to excel rows in order to identify the file by its filename', "row['filename']")
             ->addOption(self::OPTION_ONLY_MISSING, null, InputOption::VALUE_NONE, 'Skip known files (already uploaded)')
             ->addOption(self::OPTION_TIKA, null, InputOption::VALUE_NONE, 'Add a Tika extract for IndexedFile')
             ->addOption(self::OPTION_TIKA_BASE_URL, null, InputOption::VALUE_OPTIONAL, 'Tika\'s server base url. If not defined a JVM will be instantiated')
             ->addOption(self::OPTION_MAX_CONTENT_SIZE, null, InputOption::VALUE_OPTIONAL, 'Will keep the x first characters extracted by Tika to be indexed', 5120)
-            ->addOption(self::OPTION_HASH_FOLDER, null, InputOption::VALUE_NONE, 'Folder argument equals a hash of a zip file')
+            ->addOption(self::OPTION_HASH_FOLDER, null, InputOption::VALUE_NONE, 'Provide a hash for folder argument (zip file)')
+            ->addOption(self::OPTION_HASH_METADATA_FILE, null, InputOption::VALUE_NONE, 'Provide a hash for option metadata file (CSV or Excel)')
         ;
     }
 
@@ -83,6 +85,7 @@ final class MediaLibrarySyncCommand extends AbstractCommand
             $this->getOptionBool(self::OPTION_DRY_RUN),
             $this->getOptionBool(self::OPTION_ONLY_MISSING),
             $this->getOptionBool(self::OPTION_HASH_FOLDER),
+            $this->getOptionBool(self::OPTION_HASH_METADATA_FILE),
             $this->getOptionInt(self::OPTION_MAX_CONTENT_SIZE),
         );
 

--- a/elasticms-cli/src/Command/MediaLibrary/MediaLibrarySyncCommand.php
+++ b/elasticms-cli/src/Command/MediaLibrary/MediaLibrarySyncCommand.php
@@ -30,6 +30,7 @@ final class MediaLibrarySyncCommand extends AbstractCommand
     private const OPTION_METADATA_FILE = 'metadata-file';
     private const OPTION_LOCATE_ROW_EXPRESSION = 'locate-row-expression';
     private const OPTION_ONLY_MISSING = 'only-missing';
+    private const OPTION_ONLY_METADATA_FILE = 'only-metadata-file';
     private const OPTION_TIKA = 'tika';
     private const OPTION_TIKA_BASE_URL = 'tika-base-url';
     private const OPTION_MAX_CONTENT_SIZE = 'max-content-size';
@@ -64,6 +65,7 @@ final class MediaLibrarySyncCommand extends AbstractCommand
             ->addOption(self::OPTION_METADATA_FILE, null, InputOption::VALUE_OPTIONAL, 'Path to a file containing metadata (CSV or Excel)')
             ->addOption(self::OPTION_LOCATE_ROW_EXPRESSION, null, InputOption::VALUE_OPTIONAL, 'Expression language apply to excel rows in order to identify the file by its filename', "row['filename']")
             ->addOption(self::OPTION_ONLY_MISSING, null, InputOption::VALUE_NONE, 'Skip known files (already uploaded)')
+            ->addOption(self::OPTION_ONLY_METADATA_FILE, null, InputOption::VALUE_NONE, 'Skip files that are not referenced in the metadata file')
             ->addOption(self::OPTION_TIKA, null, InputOption::VALUE_NONE, 'Add a Tika extract for IndexedFile')
             ->addOption(self::OPTION_TIKA_BASE_URL, null, InputOption::VALUE_OPTIONAL, 'Tika\'s server base url. If not defined a JVM will be instantiated')
             ->addOption(self::OPTION_MAX_CONTENT_SIZE, null, InputOption::VALUE_OPTIONAL, 'Will keep the x first characters extracted by Tika to be indexed', 5120)
@@ -84,6 +86,7 @@ final class MediaLibrarySyncCommand extends AbstractCommand
             $this->getOptionString(self::OPTION_FILE_FIELD),
             $this->getOptionBool(self::OPTION_DRY_RUN),
             $this->getOptionBool(self::OPTION_ONLY_MISSING),
+            $this->getOptionBool(self::OPTION_ONLY_METADATA_FILE),
             $this->getOptionBool(self::OPTION_HASH_FOLDER),
             $this->getOptionBool(self::OPTION_HASH_METADATA_FILE),
             $this->getOptionInt(self::OPTION_MAX_CONTENT_SIZE),

--- a/elasticms-cli/src/Command/MediaLibrary/MediaLibrarySyncCommand.php
+++ b/elasticms-cli/src/Command/MediaLibrary/MediaLibrarySyncCommand.php
@@ -37,8 +37,6 @@ final class MediaLibrarySyncCommand extends AbstractCommand
     private const OPTION_HASH_FOLDER = 'hash-folder';
     private const OPTION_HASH_METADATA_FILE = 'hash-metadata-file';
 
-    private ?string $metadataFile;
-    private string $locateRowExpression;
     private bool $tika;
     private ?string $tikaBaseUrl;
 
@@ -84,6 +82,8 @@ final class MediaLibrarySyncCommand extends AbstractCommand
             $this->getOptionString(self::OPTION_FOLDER_FIELD),
             $this->getOptionString(self::OPTION_PATH_FIELD),
             $this->getOptionString(self::OPTION_FILE_FIELD),
+            $this->getOptionStringNull(self::OPTION_METADATA_FILE),
+            $this->getOptionString(self::OPTION_LOCATE_ROW_EXPRESSION),
             $this->getOptionBool(self::OPTION_DRY_RUN),
             $this->getOptionBool(self::OPTION_ONLY_MISSING),
             $this->getOptionBool(self::OPTION_ONLY_METADATA_FILE),
@@ -92,8 +92,6 @@ final class MediaLibrarySyncCommand extends AbstractCommand
             $this->getOptionInt(self::OPTION_MAX_CONTENT_SIZE),
         );
 
-        $this->metadataFile = $this->getOptionStringNull(self::OPTION_METADATA_FILE);
-        $this->locateRowExpression = $this->getOptionString(self::OPTION_LOCATE_ROW_EXPRESSION);
         $this->tika = $this->getOptionBool(self::OPTION_TIKA);
         $this->tikaBaseUrl = $this->getOptionStringNull(self::OPTION_TIKA_BASE_URL);
     }
@@ -122,9 +120,6 @@ final class MediaLibrarySyncCommand extends AbstractCommand
             $mediaSync->setTikaHelper($tikaHelper);
         }
 
-        if (null !== $this->metadataFile) {
-            $mediaSync->loadMetadata($this->metadataFile, $this->locateRowExpression);
-        }
         $mediaSync->execute();
 
         return self::EXECUTE_SUCCESS;

--- a/elasticms-cli/src/Command/MediaLibrary/MediaLibrarySyncCommand.php
+++ b/elasticms-cli/src/Command/MediaLibrary/MediaLibrarySyncCommand.php
@@ -33,6 +33,8 @@ final class MediaLibrarySyncCommand extends AbstractCommand
     private const OPTION_TIKA = 'tika';
     private const OPTION_TIKA_BASE_URL = 'tika-base-url';
     private const OPTION_MAX_CONTENT_SIZE = 'max-content-size';
+    private const OPTION_HASH_FOLDER = 'hash-folder';
+
     private ?string $metadataFile;
     private string $locateRowExpression;
     private bool $tika;
@@ -40,8 +42,11 @@ final class MediaLibrarySyncCommand extends AbstractCommand
 
     private MediaLibrarySyncOptions $options;
 
-    public function __construct(private readonly AdminHelper $adminHelper, private readonly FileReaderInterface $fileReader, private readonly ExpressionServiceInterface $expressionService)
-    {
+    public function __construct(
+        private readonly AdminHelper $adminHelper,
+        private readonly FileReaderInterface $fileReader,
+        private readonly ExpressionServiceInterface $expressionService
+    ) {
         parent::__construct();
     }
 
@@ -61,6 +66,7 @@ final class MediaLibrarySyncCommand extends AbstractCommand
             ->addOption(self::OPTION_TIKA, null, InputOption::VALUE_NONE, 'Add a Tika extract for IndexedFile')
             ->addOption(self::OPTION_TIKA_BASE_URL, null, InputOption::VALUE_OPTIONAL, 'Tika\'s server base url. If not defined a JVM will be instantiated')
             ->addOption(self::OPTION_MAX_CONTENT_SIZE, null, InputOption::VALUE_OPTIONAL, 'Will keep the x first characters extracted by Tika to be indexed', 5120)
+            ->addOption(self::OPTION_HASH_FOLDER, null, InputOption::VALUE_NONE, 'Folder argument equals a hash of a zip file')
         ;
     }
 
@@ -76,6 +82,7 @@ final class MediaLibrarySyncCommand extends AbstractCommand
             $this->getOptionString(self::OPTION_FILE_FIELD),
             $this->getOptionBool(self::OPTION_DRY_RUN),
             $this->getOptionBool(self::OPTION_ONLY_MISSING),
+            $this->getOptionBool(self::OPTION_HASH_FOLDER),
             $this->getOptionInt(self::OPTION_MAX_CONTENT_SIZE),
         );
 
@@ -101,7 +108,7 @@ final class MediaLibrarySyncCommand extends AbstractCommand
             $this->io,
             $coreApi,
             $this->fileReader,
-            $this->expressionService,
+            $this->expressionService
         );
 
         if ($this->tika) {

--- a/elasticms-cli/src/Command/MediaLibrary/MediaLibrarySyncCommand.php
+++ b/elasticms-cli/src/Command/MediaLibrary/MediaLibrarySyncCommand.php
@@ -102,8 +102,12 @@ final class MediaLibrarySyncCommand extends AbstractCommand
             $coreApi,
             $this->fileReader,
             $this->expressionService,
-            $this->getTikaHelper()
         );
+
+        if ($this->tika) {
+            $tikaHelper = $this->tikaBaseUrl ? TikaHelper::initTikaServer($this->tikaBaseUrl) : TikaHelper::initTikaJar();
+            $mediaSync->setTikaHelper($tikaHelper);
+        }
 
         if (null !== $this->metadataFile) {
             $mediaSync->loadMetadata($this->metadataFile, $this->locateRowExpression);
@@ -111,17 +115,5 @@ final class MediaLibrarySyncCommand extends AbstractCommand
         $mediaSync->execute();
 
         return self::EXECUTE_SUCCESS;
-    }
-
-    private function getTikaHelper(): ?TikaHelper
-    {
-        if (!$this->tika) {
-            return null;
-        }
-        if (null !== $this->tikaBaseUrl) {
-            return TikaHelper::initTikaServer($this->tikaBaseUrl);
-        } else {
-            return TikaHelper::initTikaJar();
-        }
     }
 }


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |n|
|New feature?   |y|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

- [x] New option to only update/import file that are referenced in the metadata file input (if a file is not referenced the metadata file is not updated/imported)
       `only-metadata-file`
- [x] New option to say that the folder option is a file hash identifying a zip file in the file store services
       `hash-folder`
- [x] New option to says that the metadata is a file hash identifying a file input in the file store services
       `hash-metadata-file`

