### PR TITLE
fix(helper): tempFile load from stream not working

### DIFF
--- a/EMS/common-bundle/src/Common/CoreApi/Endpoint/File/File.php
+++ b/EMS/common-bundle/src/Common/CoreApi/Endpoint/File/File.php
@@ -98,7 +98,7 @@ final class File implements FileInterface
 
         $stream = $this->client->download($this->downloadLink($hash));
 
-        return TempFile::fromStream($stream, $hash)->path;
+        return TempFile::createNamed($hash)->loadFromStream($stream)->path;
     }
 
     public function downloadLink(string $hash): string

--- a/EMS/common-bundle/src/Twig/AssetRuntime.php
+++ b/EMS/common-bundle/src/Twig/AssetRuntime.php
@@ -63,12 +63,14 @@ class AssetRuntime
             return null;
         }
 
-        return TempFile::fromStream($this->storageManager->getStream($hash), $hash, $this->cacheDir)->path;
+        return TempFile::createNamed($hash, $this->cacheDir)
+            ->loadFromStream($this->storageManager->getStream($hash))
+            ->path;
     }
 
     public static function extract(StreamInterface $stream, string $destination): bool
     {
-        $tempFile = TempFile::fromStream($stream);
+        $tempFile = TempFile::create()->loadFromStream($stream);
 
         $zip = new \ZipArchive();
         if (true !== $open = $zip->open($tempFile->path)) {

--- a/EMS/helpers/src/File/TempFile.php
+++ b/EMS/helpers/src/File/TempFile.php
@@ -33,17 +33,7 @@ class TempFile
         return \file_exists($this->path);
     }
 
-    public static function fromStream(StreamInterface $stream, ?string $name = null, ?string $cacheFolder = null): self
-    {
-        $tempFile = $name ? self::createNamed($name) : self::create($cacheFolder);
-        if (!$tempFile->exists()) {
-            $tempFile->loadFromStream($stream);
-        }
-
-        return $tempFile;
-    }
-
-    public function loadFromStream(StreamInterface $stream): void
+    public function loadFromStream(StreamInterface $stream): self
     {
         if (!$handle = \fopen($this->path, 'w')) {
             throw new \RuntimeException(\sprintf('Can\'t open a temporary file %s', $this->path));
@@ -58,6 +48,8 @@ class TempFile
         if (false === \fclose($handle)) {
             throw new \RuntimeException(\sprintf('Can\'t close the temporary file %s', $this->path));
         }
+
+        return $this;
     }
 
     public function clean(): void


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

Not passing a name will use \tempnam which creates an empty file, the exits function will return true. And the loadFromStream will not be called.

Removed the fromStream function.