### PR TITLE
refactor(core/dataTable): all tables should be types

### DIFF
--- a/EMS/core-bundle/src/Controller/ContentManagement/ActionController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/ActionController.php
@@ -8,7 +8,7 @@ use Doctrine\ORM\EntityManager;
 use EMS\CommonBundle\Helper\EmsFields;
 use EMS\CommonBundle\Helper\Text\Encoder;
 use EMS\CoreBundle\Core\DataTable\DataTableFactory;
-use EMS\CoreBundle\DataTable\Type\ContentType\ActionDataTableType;
+use EMS\CoreBundle\DataTable\Type\ContentType\ContentTypeActionDataTableType;
 use EMS\CoreBundle\Entity\ContentType;
 use EMS\CoreBundle\Entity\Template;
 use EMS\CoreBundle\Form\Data\EntityTable;
@@ -64,7 +64,7 @@ final class ActionController extends AbstractController
             throw new \RuntimeException('Unexpected deleted contentType');
         }
 
-        $table = $this->dataTableFactory->create(ActionDataTableType::class, [
+        $table = $this->dataTableFactory->create(ContentTypeActionDataTableType::class, [
             'content_type_name' => $contentType->getName(),
         ]);
 

--- a/EMS/core-bundle/src/Controller/ContentManagement/ActionController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/ActionController.php
@@ -7,14 +7,13 @@ namespace EMS\CoreBundle\Controller\ContentManagement;
 use Doctrine\ORM\EntityManager;
 use EMS\CommonBundle\Helper\EmsFields;
 use EMS\CommonBundle\Helper\Text\Encoder;
+use EMS\CoreBundle\Core\DataTable\DataTableFactory;
+use EMS\CoreBundle\DataTable\Type\ContentType\ActionDataTableType;
 use EMS\CoreBundle\Entity\ContentType;
 use EMS\CoreBundle\Entity\Template;
-use EMS\CoreBundle\Form\Data\BoolTableColumn;
 use EMS\CoreBundle\Form\Data\EntityTable;
-use EMS\CoreBundle\Form\Data\TableAbstract;
 use EMS\CoreBundle\Form\Form\ActionType;
 use EMS\CoreBundle\Form\Form\TableType;
-use EMS\CoreBundle\Helper\DataTableRequest;
 use EMS\CoreBundle\Repository\ContentTypeRepository;
 use EMS\CoreBundle\Repository\TemplateRepository;
 use EMS\CoreBundle\Service\ActionService;
@@ -23,7 +22,6 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\SubmitButton;
-use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -31,20 +29,11 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 final class ActionController extends AbstractController
 {
-    public function __construct(private readonly LoggerInterface $logger, private readonly ActionService $actionService)
-    {
-    }
-
-    public function ajaxDataTableAction(ContentType $contentType, Request $request): Response
-    {
-        $table = $this->initTable($contentType);
-        $dataTableRequest = DataTableRequest::fromRequest($request);
-        $table->resetIterator($dataTableRequest);
-
-        return $this->render('@EMSCore/datatable/ajax.html.twig', [
-            'dataTableRequest' => $dataTableRequest,
-            'table' => $table,
-        ], new JsonResponse());
+    public function __construct(
+        private readonly LoggerInterface $logger,
+        private readonly ActionService $actionService,
+        private readonly DataTableFactory $dataTableFactory
+    ) {
     }
 
     /** @deprecated */
@@ -75,7 +64,9 @@ final class ActionController extends AbstractController
             throw new \RuntimeException('Unexpected deleted contentType');
         }
 
-        $table = $this->initTable($contentType);
+        $table = $this->dataTableFactory->create(ActionDataTableType::class, [
+            'content_type_name' => $contentType->getName(),
+        ]);
 
         $form = $this->createForm(TableType::class, $table);
         $form->handleRequest($request);
@@ -247,21 +238,5 @@ final class ActionController extends AbstractController
         return $this->redirectToRoute('ems_core_action_index', [
             'contentType' => $action->giveContentType()->getId(),
         ]);
-    }
-
-    private function initTable(ContentType $contentType): EntityTable
-    {
-        $table = new EntityTable($this->actionService, $this->generateUrl('ems_core_action_datatable_ajax', ['contentType' => $contentType->getId()]), $contentType);
-        $table->addColumn('table.index.column.loop_count', 'orderKey');
-        $table->addColumnDefinition(new BoolTableColumn('action.index.column.public', 'public'));
-        $table->addColumn('action.index.column.name', 'name');
-        $table->addColumn('action.index.column.label', 'label')
-            ->setItemIconCallback(fn (Template $action) => $action->getIcon());
-        $table->addColumn('action.index.column.type', 'renderOption');
-        $table->addItemGetAction('ems_core_action_edit', 'action.actions.edit', 'pencil', ['contentType' => $contentType]);
-        $table->addItemPostAction('ems_core_action_delete', 'action.actions.delete', 'trash', 'action.actions.delete_confirm', ['contentType' => $contentType->getId()]);
-        $table->addTableAction(TableAbstract::DELETE_ACTION, 'fa fa-trash', 'action.actions.delete_selected', 'action.actions.delete_selected_confirm');
-
-        return $table;
     }
 }

--- a/EMS/core-bundle/src/Controller/ContentManagement/ViewController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/ViewController.php
@@ -2,55 +2,46 @@
 
 namespace EMS\CoreBundle\Controller\ContentManagement;
 
+use EMS\CoreBundle\Core\DataTable\DataTableFactory;
 use EMS\CoreBundle\Core\View\ViewManager;
-use EMS\CoreBundle\EMSCoreBundle;
-use EMS\CoreBundle\Entity\ContentType;
+use EMS\CoreBundle\DataTable\Type\ContentType\ViewDataTableType;
 use EMS\CoreBundle\Entity\View;
 use EMS\CoreBundle\Form\Data\EntityTable;
-use EMS\CoreBundle\Form\Data\TableAbstract;
-use EMS\CoreBundle\Form\Data\TemplateBlockTableColumn;
-use EMS\CoreBundle\Form\Data\TranslationTableColumn;
 use EMS\CoreBundle\Form\Form\TableType;
 use EMS\CoreBundle\Form\Form\ViewType;
-use EMS\CoreBundle\Helper\DataTableRequest;
 use EMS\CoreBundle\Routes;
 use EMS\CoreBundle\Service\ContentTypeService;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\SubmitButton;
-use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class ViewController extends AbstractController
 {
-    public function __construct(private readonly ContentTypeService $contentTypeService, private readonly ViewManager $viewManager, private readonly LoggerInterface $logger)
-    {
+    public function __construct(
+        private readonly ContentTypeService $contentTypeService,
+        private readonly ViewManager $viewManager,
+        private readonly DataTableFactory $dataTableFactory,
+        private readonly LoggerInterface $logger
+    ) {
     }
 
     /** @deprecated */
-    public function indexDeprecated(string $type, string $_format, Request $request): Response
+    public function indexDeprecated(string $type, Request $request): Response
     {
         @\trigger_error(\sprintf('Route view.index is deprecated, use %s instead', Routes::VIEW_INDEX), E_USER_DEPRECATED);
 
-        return $this->index($type, $_format, $request);
+        return $this->index($type, $request);
     }
 
-    public function index(string $type, string $_format, Request $request): Response
+    public function index(string $type, Request $request): Response
     {
         $contentType = $this->contentTypeService->giveByName($type);
-        $table = $this->initTable($contentType);
-        $dataTableRequest = DataTableRequest::fromRequest($request);
-
-        if ('json' === $_format) {
-            $table->resetIterator($dataTableRequest);
-
-            return $this->render('@EMSCore/datatable/ajax.html.twig', [
-                'dataTableRequest' => $dataTableRequest,
-                'table' => $table,
-            ], new JsonResponse());
-        }
+        $table = $this->dataTableFactory->create(ViewDataTableType::class, [
+            'content_type_name' => $contentType->getName(),
+        ]);
 
         $form = $this->createForm(TableType::class, $table);
         $form->handleRequest($request);
@@ -194,26 +185,5 @@ class ViewController extends AbstractController
         return $this->redirectToRoute(Routes::VIEW_INDEX, [
             'type' => $contentType->getName(),
         ]);
-    }
-
-    private function initTable(ContentType $contentType): EntityTable
-    {
-        $table = new EntityTable($this->viewManager, $this->generateUrl(Routes::VIEW_INDEX, [
-            'type' => $contentType->getName(),
-            '_format' => 'json',
-        ]), $contentType);
-        $table->addColumn('table.index.column.loop_count', 'orderKey');
-        $table->addColumnDefinition(new TemplateBlockTableColumn('dashboard.index.column.public', 'public', '@EMSCore/view/columns.html.twig'));
-        $table->addColumn('view.index.column.name', 'name');
-        $table->addColumn('view.index.column.label', 'label')->setItemIconCallback(fn (View $view) => $view->getIcon() ?? '');
-        $table->addColumnDefinition(new TranslationTableColumn('dashboard.index.column.type', 'type', EMSCoreBundle::TRANS_FORM_DOMAIN));
-        $table->addItemGetAction(Routes::VIEW_EDIT, 'view.actions.edit', 'pencil');
-        $table->addItemPostAction(Routes::VIEW_DUPLICATE, 'view.actions.duplicate', 'pencil', 'view.actions.duplicate_confirm');
-        $table->addItemPostAction(Routes::VIEW_DELETE, 'view.actions.delete', 'trash', 'view.actions.delete_confirm')->setButtonType('outline-danger');
-        $table->addTableAction(TableAbstract::DELETE_ACTION, 'fa fa-trash', 'view.actions.delete_selected', 'view.actions.delete_selected_confirm')
-            ->setCssClass('btn btn-outline-danger');
-        $table->setDefaultOrder('orderKey');
-
-        return $table;
     }
 }

--- a/EMS/core-bundle/src/Controller/ContentManagement/ViewController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/ViewController.php
@@ -4,7 +4,7 @@ namespace EMS\CoreBundle\Controller\ContentManagement;
 
 use EMS\CoreBundle\Core\DataTable\DataTableFactory;
 use EMS\CoreBundle\Core\View\ViewManager;
-use EMS\CoreBundle\DataTable\Type\ContentType\ViewDataTableType;
+use EMS\CoreBundle\DataTable\Type\ContentType\ContentTypeViewDataTableType;
 use EMS\CoreBundle\Entity\View;
 use EMS\CoreBundle\Form\Data\EntityTable;
 use EMS\CoreBundle\Form\Form\TableType;
@@ -39,7 +39,7 @@ class ViewController extends AbstractController
     public function index(string $type, Request $request): Response
     {
         $contentType = $this->contentTypeService->giveByName($type);
-        $table = $this->dataTableFactory->create(ViewDataTableType::class, [
+        $table = $this->dataTableFactory->create(ContentTypeViewDataTableType::class, [
             'content_type_name' => $contentType->getName(),
         ]);
 

--- a/EMS/core-bundle/src/Controller/Log/LogController.php
+++ b/EMS/core-bundle/src/Controller/Log/LogController.php
@@ -5,41 +5,31 @@ declare(strict_types=1);
 namespace EMS\CoreBundle\Controller\Log;
 
 use EMS\CommonBundle\Entity\Log;
-use EMS\CoreBundle\Core\Log\LogEntityTableContext;
+use EMS\CoreBundle\Core\DataTable\DataTableFactory;
 use EMS\CoreBundle\Core\Log\LogManager;
-use EMS\CoreBundle\Form\Data\DatetimeTableColumn;
+use EMS\CoreBundle\DataTable\Type\LogDataTableType;
 use EMS\CoreBundle\Form\Data\EntityTable;
-use EMS\CoreBundle\Form\Data\TableAbstract;
-use EMS\CoreBundle\Form\Data\UserTableColumn;
 use EMS\CoreBundle\Form\Form\TableType;
-use EMS\CoreBundle\Helper\DataTableRequest;
 use EMS\CoreBundle\Routes;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\SubmitButton;
-use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class LogController extends AbstractController
 {
-    public function __construct(private readonly LogManager $logManager, private readonly LoggerInterface $logger)
-    {
+    public function __construct(
+        private readonly LogManager $logManager,
+        private readonly DataTableFactory $dataTableFactory,
+        private readonly LoggerInterface $logger
+    ) {
     }
 
-    public function index(Request $request, string $_format): Response
+    public function index(Request $request): Response
     {
-        $table = $this->initTable();
-        if ('json' === $_format) {
-            $dataTableRequest = DataTableRequest::fromRequest($request);
-            $table->resetIterator($dataTableRequest);
-
-            return $this->render('@EMSCore/datatable/ajax.html.twig', [
-                'dataTableRequest' => $dataTableRequest,
-                'table' => $table,
-            ], new JsonResponse());
-        }
+        $table = $this->dataTableFactory->create(LogDataTableType::class);
 
         $form = $this->createForm(TableType::class, $table);
         $form->handleRequest($request);
@@ -73,28 +63,5 @@ class LogController extends AbstractController
         $this->logManager->delete($log);
 
         return $this->redirectToRoute(Routes::LOG_INDEX);
-    }
-
-    private function initTable(): EntityTable
-    {
-        $table = new EntityTable(
-            $this->logManager,
-            $this->generateUrl(Routes::LOG_INDEX, ['_format' => 'json']),
-            new LogEntityTableContext()
-        );
-        $table->setLabelAttribute('id');
-        $table->addColumnDefinition(new DatetimeTableColumn('log.index.column.created', 'created'));
-        $table->addColumn('log.index.column.channel', 'channel');
-        $table->addColumn('log.index.column.level_name', 'levelName');
-        $table->addColumn('log.index.column.message', 'message');
-        $table->addColumnDefinition(new UserTableColumn('log.index.column.username', 'username'));
-        $table->addColumnDefinition(new UserTableColumn('log.index.column.impersonator', 'impersonator'));
-        $table->addItemGetAction(Routes::LOG_VIEW, 'view.actions.view', 'eye');
-        $table->addItemPostAction(Routes::LOG_DELETE, 'view.actions.delete', 'trash', 'view.actions.delete_confirm')->setButtonType('outline-danger');
-        $table->addTableAction(TableAbstract::DELETE_ACTION, 'fa fa-trash', 'log.actions.delete_selected', 'log.actions.delete_selected_confirm')
-            ->setCssClass('btn btn-outline-danger');
-        $table->setDefaultOrder('created', 'desc');
-
-        return $table;
     }
 }

--- a/EMS/core-bundle/src/Controller/UploadedFileWysiwygController.php
+++ b/EMS/core-bundle/src/Controller/UploadedFileWysiwygController.php
@@ -4,47 +4,25 @@ declare(strict_types=1);
 
 namespace EMS\CoreBundle\Controller;
 
-use EMS\CommonBundle\Common\EMSLink;
-use EMS\CommonBundle\Helper\Text\Encoder;
+use EMS\CoreBundle\Core\DataTable\DataTableFactory;
 use EMS\CoreBundle\Core\UI\AjaxService;
-use EMS\CoreBundle\EMSCoreBundle;
-use EMS\CoreBundle\Entity\UploadedAsset;
-use EMS\CoreBundle\Form\Data\BytesTableColumn;
-use EMS\CoreBundle\Form\Data\DatetimeTableColumn;
-use EMS\CoreBundle\Form\Data\EntityTable;
-use EMS\CoreBundle\Form\Data\UserTableColumn;
+use EMS\CoreBundle\DataTable\Type\WysiwygUploadedFileDataTableType;
 use EMS\CoreBundle\Form\Form\TableType;
-use EMS\CoreBundle\Helper\DataTableRequest;
-use EMS\CoreBundle\Service\FileService;
-use EMS\Helpers\Standard\Json;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\RouterInterface;
 
 final class UploadedFileWysiwygController extends AbstractController
 {
-    public function __construct(private readonly FileService $fileService, private readonly AjaxService $ajax, private readonly RouterInterface $router)
-    {
-    }
-
-    public function ajaxDataTable(Request $request): Response
-    {
-        $table = $this->initTable();
-        $dataTableRequest = DataTableRequest::fromRequest($request);
-        $table->resetIterator($dataTableRequest);
-
-        return $this->render('@EMSCore/datatable/ajax.html.twig', [
-            'dataTableRequest' => $dataTableRequest,
-            'table' => $table,
-        ], new JsonResponse());
+    public function __construct(
+        private readonly AjaxService $ajax,
+        private readonly DataTableFactory $dataTableFactory
+    ) {
     }
 
     public function index(Request $request): Response
     {
-        $table = $this->initTable();
-
+        $table = $this->dataTableFactory->create(WysiwygUploadedFileDataTableType::class);
         $form = $this->createForm(TableType::class, $table);
         $form->handleRequest($request);
 
@@ -56,58 +34,11 @@ final class UploadedFileWysiwygController extends AbstractController
 
     public function modal(): Response
     {
-        $form = $this->createForm(TableType::class, $this->initTable());
+        $table = $this->dataTableFactory->create(WysiwygUploadedFileDataTableType::class);
+        $form = $this->createForm(TableType::class, $table);
 
         return $this->ajax->newAjaxModel('@EMSCore/uploaded-file-wysiwyg/modal.html.twig')
-            ->setBody('modalBody', [
-                'form' => $form->createView(),
-            ])
+            ->setBody('modalBody', ['form' => $form->createView()])
             ->getResponse();
-    }
-
-    private function initTable(): EntityTable
-    {
-        $table = new EntityTable($this->fileService, $this->router->generate('ems_core_uploaded_file_wysiwyg_ajax'), ['available' => false]);
-        $router = $this->router;
-        $table->addColumn('uploaded-file.index.column.name', 'name')
-            ->addHtmlAttribute('data-url', fn (UploadedAsset $data) => EMSLink::EMSLINK_ASSET_PREFIX.$data->getSha1().'?name='.$data->getName().'&type='.$data->getType())
-            ->addHtmlAttribute('data-json', function (UploadedAsset $data) use ($router) {
-                $json = $data->getData();
-                $json = \array_merge($json, [
-                    'preview_url' => $router->generate('ems_asset_processor', [
-                        'hash' => $data->getSha1(),
-                        'processor' => 'preview',
-                        'type' => $data->getType(),
-                        'name' => $data->getName(),
-                    ]),
-                    'view_url' => $router->generate('ems.file.view', [
-                        'sha1' => $data->getSha1(),
-                        'type' => $data->getType(),
-                        'name' => $data->getName(),
-                    ]),
-                ]);
-
-                return Json::encode($json);
-            })
-            ->setRoute('ems_file_download', function (UploadedAsset $data) {
-                if (!$data->getAvailable()) {
-                    return null;
-                }
-
-                return [
-                    'sha1' => $data->getSha1(),
-                    'type' => $data->getType(),
-                    'name' => $data->getName(),
-                ];
-            });
-
-        $table->addColumnDefinition(new DatetimeTableColumn('uploaded-file.index.column.created', 'created'));
-        $table->addColumnDefinition(new UserTableColumn('uploaded-file.index.column.username', 'user'));
-        $table->addColumnDefinition(new BytesTableColumn('uploaded-file.index.column.size', 'size'));
-        $table->addColumn('uploaded-file.index.column.type', 'type')->setItemIconCallback(fn (UploadedAsset $data) => Encoder::getFontAwesomeFromMimeType($data->getType(), EMSCoreBundle::FONTAWESOME_VERSION));
-
-        $table->setDefaultOrder('created', 'desc');
-
-        return $table;
     }
 }

--- a/EMS/core-bundle/src/DataTable/Type/ContentType/ActionDataTableType.php
+++ b/EMS/core-bundle/src/DataTable/Type/ContentType/ActionDataTableType.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\DataTable\Type\ContentType;
+
+use EMS\CoreBundle\Core\DataTable\Type\AbstractEntityTableType;
+use EMS\CoreBundle\Entity\ContentType;
+use EMS\CoreBundle\Entity\Template;
+use EMS\CoreBundle\Form\Data\BoolTableColumn;
+use EMS\CoreBundle\Form\Data\EntityTable;
+use EMS\CoreBundle\Form\Data\TableAbstract;
+use EMS\CoreBundle\Roles;
+use EMS\CoreBundle\Service\ActionService;
+use EMS\CoreBundle\Service\ContentTypeService;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ActionDataTableType extends AbstractEntityTableType
+{
+    public function __construct(
+        ActionService $entityService,
+        private readonly ContentTypeService $contentTypeService
+    ) {
+        parent::__construct($entityService);
+    }
+
+    public function build(EntityTable $table): void
+    {
+        /** @var ContentType $contentType */
+        $contentType = $table->getContext();
+
+        $table->addColumn('table.index.column.loop_count', 'orderKey');
+        $table->addColumnDefinition(new BoolTableColumn('action.index.column.public', 'public'));
+        $table->addColumn('action.index.column.name', 'name');
+        $table->addColumn('action.index.column.label', 'label')
+            ->setItemIconCallback(fn (Template $action) => $action->getIcon());
+        $table->addColumn('action.index.column.type', 'renderOption');
+        $table->addItemGetAction('ems_core_action_edit', 'action.actions.edit', 'pencil', ['contentType' => $contentType]);
+        $table->addItemPostAction('ems_core_action_delete', 'action.actions.delete', 'trash', 'action.actions.delete_confirm', ['contentType' => $contentType->getId()]);
+        $table->addTableAction(TableAbstract::DELETE_ACTION, 'fa fa-trash', 'action.actions.delete_selected', 'action.actions.delete_selected_confirm');
+    }
+
+    public function getRoles(): array
+    {
+        return [Roles::ROLE_ADMIN];
+    }
+
+    public function getContext(array $options): ContentType
+    {
+        return $this->contentTypeService->giveByName($options['content_type_name']);
+    }
+
+    public function configureOptions(OptionsResolver $optionsResolver): void
+    {
+        $optionsResolver->setRequired(['content_type_name']);
+    }
+}

--- a/EMS/core-bundle/src/DataTable/Type/ContentType/ContentTypeActionDataTableType.php
+++ b/EMS/core-bundle/src/DataTable/Type/ContentType/ContentTypeActionDataTableType.php
@@ -15,7 +15,7 @@ use EMS\CoreBundle\Service\ActionService;
 use EMS\CoreBundle\Service\ContentTypeService;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class ActionDataTableType extends AbstractEntityTableType
+class ContentTypeActionDataTableType extends AbstractEntityTableType
 {
     public function __construct(
         ActionService $entityService,

--- a/EMS/core-bundle/src/DataTable/Type/ContentType/ContentTypeViewDataTableType.php
+++ b/EMS/core-bundle/src/DataTable/Type/ContentType/ContentTypeViewDataTableType.php
@@ -18,7 +18,7 @@ use EMS\CoreBundle\Routes;
 use EMS\CoreBundle\Service\ContentTypeService;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class ViewDataTableType extends AbstractEntityTableType
+class ContentTypeViewDataTableType extends AbstractEntityTableType
 {
     public function __construct(
         ViewManager $entityService,

--- a/EMS/core-bundle/src/DataTable/Type/ContentType/ViewDataTableType.php
+++ b/EMS/core-bundle/src/DataTable/Type/ContentType/ViewDataTableType.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\DataTable\Type\ContentType;
+
+use EMS\CoreBundle\Core\DataTable\Type\AbstractEntityTableType;
+use EMS\CoreBundle\Core\View\ViewManager;
+use EMS\CoreBundle\EMSCoreBundle;
+use EMS\CoreBundle\Entity\ContentType;
+use EMS\CoreBundle\Entity\View;
+use EMS\CoreBundle\Form\Data\EntityTable;
+use EMS\CoreBundle\Form\Data\TableAbstract;
+use EMS\CoreBundle\Form\Data\TemplateBlockTableColumn;
+use EMS\CoreBundle\Form\Data\TranslationTableColumn;
+use EMS\CoreBundle\Roles;
+use EMS\CoreBundle\Routes;
+use EMS\CoreBundle\Service\ContentTypeService;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ViewDataTableType extends AbstractEntityTableType
+{
+    public function __construct(
+        ViewManager $entityService,
+        private readonly ContentTypeService $contentTypeService
+    ) {
+        parent::__construct($entityService);
+    }
+
+    public function build(EntityTable $table): void
+    {
+        $table->addColumn('table.index.column.loop_count', 'orderKey');
+        $table->addColumnDefinition(new TemplateBlockTableColumn('dashboard.index.column.public', 'public', '@EMSCore/view/columns.html.twig'));
+        $table->addColumn('view.index.column.name', 'name');
+        $table->addColumn('view.index.column.label', 'label')->setItemIconCallback(fn (View $view) => $view->getIcon() ?? '');
+        $table->addColumnDefinition(new TranslationTableColumn('dashboard.index.column.type', 'type', EMSCoreBundle::TRANS_FORM_DOMAIN));
+        $table->addItemGetAction(Routes::VIEW_EDIT, 'view.actions.edit', 'pencil');
+        $table->addItemPostAction(Routes::VIEW_DUPLICATE, 'view.actions.duplicate', 'pencil', 'view.actions.duplicate_confirm');
+        $table->addItemPostAction(Routes::VIEW_DELETE, 'view.actions.delete', 'trash', 'view.actions.delete_confirm')->setButtonType('outline-danger');
+        $table->addTableAction(TableAbstract::DELETE_ACTION, 'fa fa-trash', 'view.actions.delete_selected', 'view.actions.delete_selected_confirm')
+            ->setCssClass('btn btn-outline-danger');
+        $table->setDefaultOrder('orderKey');
+    }
+
+    public function getRoles(): array
+    {
+        return [Roles::ROLE_ADMIN];
+    }
+
+    public function getContext(array $options): ContentType
+    {
+        return $this->contentTypeService->giveByName($options['content_type_name']);
+    }
+
+    public function configureOptions(OptionsResolver $optionsResolver): void
+    {
+        $optionsResolver->setRequired(['content_type_name']);
+    }
+}

--- a/EMS/core-bundle/src/DataTable/Type/LogDataTableType.php
+++ b/EMS/core-bundle/src/DataTable/Type/LogDataTableType.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\DataTable\Type;
+
+use EMS\CoreBundle\Core\DataTable\Type\AbstractEntityTableType;
+use EMS\CoreBundle\Core\Log\LogEntityTableContext;
+use EMS\CoreBundle\Core\Log\LogManager;
+use EMS\CoreBundle\Form\Data\DatetimeTableColumn;
+use EMS\CoreBundle\Form\Data\EntityTable;
+use EMS\CoreBundle\Form\Data\TableAbstract;
+use EMS\CoreBundle\Form\Data\UserTableColumn;
+use EMS\CoreBundle\Roles;
+use EMS\CoreBundle\Routes;
+
+class LogDataTableType extends AbstractEntityTableType
+{
+    public function __construct(LogManager $logManager)
+    {
+        parent::__construct($logManager);
+    }
+
+    public function getContext(array $options): LogEntityTableContext
+    {
+        return new LogEntityTableContext();
+    }
+
+    public function build(EntityTable $table): void
+    {
+        $table->setLabelAttribute('id');
+        $table->addColumnDefinition(new DatetimeTableColumn('log.index.column.created', 'created'));
+        $table->addColumn('log.index.column.channel', 'channel');
+        $table->addColumn('log.index.column.level_name', 'levelName');
+        $table->addColumn('log.index.column.message', 'message');
+        $table->addColumnDefinition(new UserTableColumn('log.index.column.username', 'username'));
+        $table->addColumnDefinition(new UserTableColumn('log.index.column.impersonator', 'impersonator'));
+        $table->addItemGetAction(Routes::LOG_VIEW, 'view.actions.view', 'eye');
+        $table->addItemPostAction(Routes::LOG_DELETE, 'view.actions.delete', 'trash', 'view.actions.delete_confirm')->setButtonType('outline-danger');
+        $table->addTableAction(TableAbstract::DELETE_ACTION, 'fa fa-trash', 'log.actions.delete_selected', 'log.actions.delete_selected_confirm')
+            ->setCssClass('btn btn-outline-danger');
+        $table->setDefaultOrder('created', 'desc');
+    }
+
+    public function getRoles(): array
+    {
+        return [Roles::ROLE_ADMIN];
+    }
+}

--- a/EMS/core-bundle/src/DataTable/Type/Release/ReleaseOverviewDataTableType.php
+++ b/EMS/core-bundle/src/DataTable/Type/Release/ReleaseOverviewDataTableType.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\DataTable\Type\Release;
+
+use EMS\CoreBundle\Core\DataTable\Type\AbstractEntityTableType;
+use EMS\CoreBundle\Entity\Release;
+use EMS\CoreBundle\Form\Data\Condition\NotEmpty;
+use EMS\CoreBundle\Form\Data\Condition\Terms;
+use EMS\CoreBundle\Form\Data\DatetimeTableColumn;
+use EMS\CoreBundle\Form\Data\EntityTable;
+use EMS\CoreBundle\Form\Data\TableAbstract;
+use EMS\CoreBundle\Form\Data\TemplateBlockTableColumn;
+use EMS\CoreBundle\Roles;
+use EMS\CoreBundle\Routes;
+use EMS\CoreBundle\Service\ReleaseService;
+
+class ReleaseOverviewDataTableType extends AbstractEntityTableType
+{
+    public function __construct(ReleaseService $releaseService)
+    {
+        parent::__construct($releaseService);
+    }
+
+    public function build(EntityTable $table): void
+    {
+        $table->setDefaultOrder('executionDate', 'desc');
+        $table->addColumn('release.index.column.name', 'name');
+        $table->addColumnDefinition(new DatetimeTableColumn('release.index.column.execution_date', 'executionDate'));
+        $table->addColumnDefinition(new TemplateBlockTableColumn('release.index.column.status', 'status', '@EMSCore/release/columns/revisions.html.twig'));
+        $table->addColumnDefinition(new TemplateBlockTableColumn('release.index.column.docs_count', 'docs_count', '@EMSCore/release/columns/revisions.html.twig'))->setCellClass('text-right');
+
+        $table->addColumnDefinition(new TemplateBlockTableColumn('release.index.column.env_source', 'environmentSource', '@EMSCore/release/columns/revisions.html.twig'));
+        $table->addColumnDefinition(new TemplateBlockTableColumn('release.index.column.env_target', 'environmentTarget', '@EMSCore/release/columns/revisions.html.twig'));
+        $table->addItemGetAction(Routes::RELEASE_VIEW, 'release.actions.show', 'eye')
+            ->addCondition(new Terms('status', [Release::APPLIED_STATUS, Release::SCHEDULED_STATUS, Release::READY_STATUS]));
+        $table->addItemGetAction(Routes::RELEASE_EDIT, 'release.actions.edit', 'pencil')
+            ->addCondition(new Terms('status', [Release::WIP_STATUS]));
+        $table->addItemGetAction(Routes::RELEASE_ADD_REVISIONS, 'release.actions.add_revisions', 'plus')
+            ->addCondition(new Terms('status', [Release::WIP_STATUS]));
+        $table->addItemGetAction(Routes::RELEASE_SET_STATUS, 'release.actions.set_status_ready', 'play', ['status' => Release::READY_STATUS])
+            ->addCondition(new Terms('status', [Release::WIP_STATUS]))
+            ->addCondition(new NotEmpty('revisionsOuuids'));
+        $table->addItemGetAction(Routes::RELEASE_SET_STATUS, 'release.actions.set_status_wip', 'rotate-left', ['status' => Release::WIP_STATUS])
+            ->addCondition(new Terms('status', [Release::CANCELED_STATUS]));
+        $table->addItemPostAction(Routes::RELEASE_PUBLISH, 'release.actions.publish_release', 'toggle-on', 'release.actions.publish_confirm')
+            ->addCondition(new Terms('status', [Release::READY_STATUS]));
+        $table->addItemGetAction(Routes::RELEASE_SET_STATUS, 'release.actions.set_status_canceled', 'ban', ['status' => Release::CANCELED_STATUS])
+            ->addCondition(new Terms('status', [Release::READY_STATUS]));
+        $table->addItemPostAction(Routes::RELEASE_DELETE, 'release.actions.delete', 'trash', 'release.actions.delete_confirm')
+            ->setButtonType('outline-danger');
+        $table->addTableAction(TableAbstract::DELETE_ACTION, 'fa fa-trash', 'release.actions.delete_selected', 'release.actions.delete_selected_confirm')->setCssClass('btn btn-outline-danger');
+    }
+
+    public function getRoles(): array
+    {
+        return [Roles::ROLE_PUBLISHER];
+    }
+}

--- a/EMS/core-bundle/src/DataTable/Type/Release/ReleasePickDataTableType.php
+++ b/EMS/core-bundle/src/DataTable/Type/Release/ReleasePickDataTableType.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\DataTable\Type\Release;
+
+use EMS\CoreBundle\Core\DataTable\Type\AbstractEntityTableType;
+use EMS\CoreBundle\Entity\Revision;
+use EMS\CoreBundle\Form\Data\DatetimeTableColumn;
+use EMS\CoreBundle\Form\Data\EntityTable;
+use EMS\CoreBundle\Form\Data\TemplateBlockTableColumn;
+use EMS\CoreBundle\Roles;
+use EMS\CoreBundle\Routes;
+use EMS\CoreBundle\Service\ReleaseService;
+use EMS\CoreBundle\Service\Revision\RevisionService;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ReleasePickDataTableType extends AbstractEntityTableType
+{
+    public function __construct(
+        ReleaseService $releaseService,
+        private readonly RevisionService $revisionService
+    ) {
+        parent::__construct($releaseService);
+    }
+
+    public function build(EntityTable $table): void
+    {
+        /** @var Revision $revision */
+        $revision = $table->getContext();
+
+        $table->setDefaultOrder('executionDate', 'desc');
+        $table->addColumn('release.index.column.name', 'name');
+        $table->addColumnDefinition(new DatetimeTableColumn('release.index.column.execution_date', 'executionDate'));
+        $table->addColumnDefinition(new TemplateBlockTableColumn('release.index.column.status', 'status', '@EMSCore/release/columns/revisions.html.twig'));
+        $table->addColumnDefinition(new TemplateBlockTableColumn('release.index.column.docs_count', 'docs_count', '@EMSCore/release/columns/revisions.html.twig'))->setCellClass('text-right');
+
+        $table->addItemPostAction(Routes::DATA_ADD_REVISION_TO_RELEASE, 'data.actions.add_to_release', 'plus', 'data.actions.add_to_release_confirm', ['revision' => $revision->getId()])->setButtonType('primary');
+    }
+
+    public function getRoles(): array
+    {
+        return [Roles::ROLE_PUBLISHER];
+    }
+
+    public function getContext(array $options): Revision
+    {
+        return $this->revisionService->getByRevisionId($options['revision_id']);
+    }
+
+    public function configureOptions(OptionsResolver $optionsResolver): void
+    {
+        $optionsResolver->setRequired(['revision_id']);
+    }
+}

--- a/EMS/core-bundle/src/DataTable/Type/Release/ReleaseRevisionDataTableType.php
+++ b/EMS/core-bundle/src/DataTable/Type/Release/ReleaseRevisionDataTableType.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\DataTable\Type\Release;
+
+use EMS\CoreBundle\Core\DataTable\Type\AbstractEntityTableType;
+use EMS\CoreBundle\Entity\Release;
+use EMS\CoreBundle\Form\Data\Condition\NotEmpty;
+use EMS\CoreBundle\Form\Data\EntityTable;
+use EMS\CoreBundle\Form\Data\TableAbstract;
+use EMS\CoreBundle\Form\Data\TemplateBlockTableColumn;
+use EMS\CoreBundle\Roles;
+use EMS\CoreBundle\Routes;
+use EMS\CoreBundle\Service\ReleaseRevisionService;
+use EMS\CoreBundle\Service\ReleaseService;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ReleaseRevisionDataTableType extends AbstractEntityTableType
+{
+    public function __construct(
+        ReleaseRevisionService $releaseRevisionService,
+        private readonly ReleaseService $releaseService
+    ) {
+        parent::__construct($releaseRevisionService);
+    }
+
+    public function build(EntityTable $table): void
+    {
+        /** @var Release $release */
+        $release = $table->getContext();
+
+        $table->setMassAction(true);
+        $table->addColumnDefinition(new TemplateBlockTableColumn('release.revision.index.column.CT', 'contentType', '@EMSCore/release/columns/release-revisions.html.twig'));
+        $table->addColumnDefinition(new TemplateBlockTableColumn('release.revision.index.column.document', 'label', '@EMSCore/release/columns/release-revisions.html.twig'));
+        $table->addColumnDefinition(new TemplateBlockTableColumn('release.revision.index.column.revision', 'revision', '@EMSCore/release/columns/release-revisions.html.twig'));
+        $table->addColumnDefinition(new TemplateBlockTableColumn('release.revision.index.column.action', 'action', '@EMSCore/release/columns/release-revisions.html.twig'));
+
+        switch ($release->getStatus()) {
+            case Release::WIP_STATUS:
+                $table->addTableAction(TableAbstract::REMOVE_ACTION, 'fa fa-minus', 'release.revision.actions.remove', 'release.revision.actions.remove_confirm');
+                break;
+            case Release::APPLIED_STATUS:
+                $table->addColumnDefinition(new TemplateBlockTableColumn('release.revision.index.column.still_in_target', 'stil_in_target', '@EMSCore/release/columns/release-revisions.html.twig'))->setLabelTransOption(['%target%' => $release->getEnvironmentTarget()->getLabel()]);
+                $table->addColumnDefinition(new TemplateBlockTableColumn('release.revision.index.column.previous', 'previous', '@EMSCore/release/columns/release-revisions.html.twig'));
+                $table->addDynamicItemGetAction(Routes::VIEW_REVISIONS, 'release.revision.index.column.compare', 'compress', ['type' => 'contentType', 'ouuid' => 'revisionOuuid', 'revisionId' => 'revision.id', 'compareId' => 'revisionBeforePublish.id'])->addCondition(new NotEmpty('revisionBeforePublish', 'revision'));
+                $table->addTableAction('rollback_action', 'fa fa-rotate-left', 'release.revision.table.rollback.action', 'release.revision.table.rollback.confirm');
+                break;
+        }
+    }
+
+    public function getRoles(): array
+    {
+        return [Roles::ROLE_PUBLISHER];
+    }
+
+    public function getContext(array $options): Release
+    {
+        return $this->releaseService->getById($options['release_id']);
+    }
+
+    public function configureOptions(OptionsResolver $optionsResolver): void
+    {
+        $optionsResolver->setRequired(['release_id']);
+    }
+}

--- a/EMS/core-bundle/src/DataTable/Type/Revision/RevisionAuditDataTableType.php
+++ b/EMS/core-bundle/src/DataTable/Type/Revision/RevisionAuditDataTableType.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\DataTable\Type\Revision;
+
+use EMS\CoreBundle\Core\DataTable\Type\AbstractEntityTableType;
+use EMS\CoreBundle\Core\Log\LogEntityTableContext;
+use EMS\CoreBundle\Core\Log\LogManager;
+use EMS\CoreBundle\Form\Data\DatetimeTableColumn;
+use EMS\CoreBundle\Form\Data\EntityTable;
+use EMS\CoreBundle\Form\Data\TableColumn;
+use EMS\CoreBundle\Form\Data\UserTableColumn;
+use EMS\CoreBundle\Roles;
+use EMS\CoreBundle\Service\Revision\RevisionService;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class RevisionAuditDataTableType extends AbstractEntityTableType
+{
+    public function __construct(
+        LogManager $logManager,
+        private readonly RevisionService $revisionService
+    ) {
+        parent::__construct($logManager);
+    }
+
+    public function build(EntityTable $table): void
+    {
+        $table
+            ->addColumnDefinition(new DatetimeTableColumn('log.index.column.created', 'created'))
+            ->setCellClass('col-sm');
+        $table
+            ->addColumnDefinition(new TableColumn('log.index.column.level_name', 'levelName'))
+            ->setCellClass('text-center col-xs');
+        $table
+            ->addColumnDefinition(new TableColumn('log.index.column.message', 'message'));
+        $table
+            ->addColumnDefinition(new UserTableColumn('log.index.column.username', 'username'))
+            ->setCellClass('col-sm');
+        $table->setDefaultOrder('created', 'desc');
+    }
+
+    public function getContext(array $options): LogEntityTableContext
+    {
+        $revision = $this->revisionService->getByRevisionId($options['revision_id']);
+
+        $context = new LogEntityTableContext();
+        $context->revision = $revision;
+        $context->channels = ['audit'];
+
+        return $context;
+    }
+
+    public function getRoles(): array
+    {
+        return [Roles::ROLE_ADMIN, Roles::ROLE_AUDITOR];
+    }
+
+    public function configureOptions(OptionsResolver $optionsResolver): void
+    {
+        $optionsResolver->setRequired(['revision_id']);
+    }
+}

--- a/EMS/core-bundle/src/DataTable/Type/Revision/RevisionDraftsDataTableType.php
+++ b/EMS/core-bundle/src/DataTable/Type/Revision/RevisionDraftsDataTableType.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\DataTable\Type\Revision;
+
+use EMS\CoreBundle\Core\DataTable\Type\AbstractEntityTableType;
+use EMS\CoreBundle\Core\Revision\DraftInProgress;
+use EMS\CoreBundle\Entity\ContentType;
+use EMS\CoreBundle\Form\Data\Condition\DateInFuture;
+use EMS\CoreBundle\Form\Data\Condition\InMyCircles;
+use EMS\CoreBundle\Form\Data\Condition\NotEmpty;
+use EMS\CoreBundle\Form\Data\DatetimeTableColumn;
+use EMS\CoreBundle\Form\Data\EntityTable;
+use EMS\CoreBundle\Form\Data\UserTableColumn;
+use EMS\CoreBundle\Roles;
+use EMS\CoreBundle\Routes;
+use EMS\CoreBundle\Service\ContentTypeService;
+use EMS\CoreBundle\Service\UserService;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class RevisionDraftsDataTableType extends AbstractEntityTableType
+{
+    public function __construct(
+        DraftInProgress $draftInProgress,
+        private readonly ContentTypeService $contentTypeService,
+        private readonly UserService $userService
+    ) {
+        parent::__construct($draftInProgress);
+    }
+
+    public function build(EntityTable $table): void
+    {
+        /** @var ContentType $contentType */
+        $contentType = $table->getContext();
+
+        $table->setRowActionsClass('pull-right');
+        $table->setLabelAttribute('label');
+        $table->setDefaultOrder('modified', 'desc');
+        $table->addColumnDefinition(new DatetimeTableColumn('revision.draft-in-progress.column.modified', 'draftSaveDate'));
+        $table->addColumnDefinition(new UserTableColumn('revision.draft-in-progress.column.auto-save-by', 'autoSaveBy'));
+        $table->addColumn('revision.draft-in-progress.column.label', 'label')->setOrderField('labelField');
+        $lockUntil = new DatetimeTableColumn('revision.draft-in-progress.column.locked', 'lockUntil');
+        $condition = new DateInFuture('lockUntil');
+        $lockUntil->addCondition($condition);
+        $table->addColumnDefinition($lockUntil);
+        $lockBy = new UserTableColumn('revision.draft-in-progress.column.locked-by', 'lockBy');
+        $lockBy->addCondition($condition);
+        $table->addColumnDefinition($lockBy);
+        $inMyCircles = new InMyCircles($this->userService);
+        $table->addDynamicItemGetAction(Routes::EDIT_REVISION, 'revision.draft-in-progress.column.edit-draft', 'pencil', [
+            'revisionId' => 'id',
+        ])->addCondition($inMyCircles)->setButtonType('primary');
+        $table->addDynamicItemGetAction(Routes::VIEW_REVISIONS, 'revision.draft-in-progress.column.view-revision', '', [
+            'type' => 'contentType.name',
+            'ouuid' => 'ouuid',
+        ])->addCondition(new NotEmpty('ouuid'));
+        $table->addDynamicItemPostAction(Routes::DISCARD_DRAFT, 'revision.draft-in-progress.column.discard-draft', 'trash', 'revision.draft-in-progress.column.confirm-discard-draft', [
+            'revisionId' => 'id',
+        ])->addCondition($inMyCircles)->setButtonType('outline-danger');
+
+        if (null !== $contentType && (null === $contentType->getCirclesField() || '' === $contentType->getCirclesField())) {
+            $table->addTableAction(DraftInProgress::DISCARD_SELECTED_DRAFT, 'fa fa-trash', 'revision.draft-in-progress.action.discard-selected-draft', 'revision.draft-in-progress.action.discard-selected-confirm')
+                ->setCssClass('btn btn-outline-danger');
+        }
+    }
+
+    public function getContext(array $options): ContentType
+    {
+        return $this->contentTypeService->giveByName($options['content_type_name']);
+    }
+
+    public function getRoles(): array
+    {
+        return [Roles::ROLE_USER];
+    }
+
+    public function configureOptions(OptionsResolver $optionsResolver): void
+    {
+        $optionsResolver->setRequired(['content_type_name']);
+    }
+}

--- a/EMS/core-bundle/src/DataTable/Type/WysiwygUploadedFileDataTableType.php
+++ b/EMS/core-bundle/src/DataTable/Type/WysiwygUploadedFileDataTableType.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\DataTable\Type;
+
+use EMS\CommonBundle\Common\EMSLink;
+use EMS\CommonBundle\Helper\Text\Encoder;
+use EMS\CoreBundle\Core\DataTable\Type\AbstractEntityTableType;
+use EMS\CoreBundle\EMSCoreBundle;
+use EMS\CoreBundle\Entity\UploadedAsset;
+use EMS\CoreBundle\Form\Data\BytesTableColumn;
+use EMS\CoreBundle\Form\Data\DatetimeTableColumn;
+use EMS\CoreBundle\Form\Data\EntityTable;
+use EMS\CoreBundle\Form\Data\UserTableColumn;
+use EMS\CoreBundle\Roles;
+use EMS\CoreBundle\Service\FileService;
+use EMS\Helpers\Standard\Json;
+use Symfony\Component\Routing\RouterInterface;
+
+class WysiwygUploadedFileDataTableType extends AbstractEntityTableType
+{
+    public function __construct(
+        FileService $fileService,
+        private readonly RouterInterface $router
+    ) {
+        parent::__construct($fileService);
+    }
+
+    public function build(EntityTable $table): void
+    {
+        $router = $this->router;
+
+        $table->addColumn('uploaded-file.index.column.name', 'name')
+            ->addHtmlAttribute('data-url', fn (UploadedAsset $data) => EMSLink::EMSLINK_ASSET_PREFIX.$data->getSha1().'?name='.$data->getName().'&type='.$data->getType())
+            ->addHtmlAttribute('data-json', function (UploadedAsset $data) use ($router) {
+                $json = $data->getData();
+                $json = \array_merge($json, [
+                    'preview_url' => $router->generate('ems_asset_processor', [
+                        'hash' => $data->getSha1(),
+                        'processor' => 'preview',
+                        'type' => $data->getType(),
+                        'name' => $data->getName(),
+                    ]),
+                    'view_url' => $router->generate('ems.file.view', [
+                        'sha1' => $data->getSha1(),
+                        'type' => $data->getType(),
+                        'name' => $data->getName(),
+                    ]),
+                ]);
+
+                return Json::encode($json);
+            })
+            ->setRoute('ems_file_download', function (UploadedAsset $data) {
+                if (!$data->getAvailable()) {
+                    return null;
+                }
+
+                return [
+                    'sha1' => $data->getSha1(),
+                    'type' => $data->getType(),
+                    'name' => $data->getName(),
+                ];
+            });
+
+        $table->addColumnDefinition(new DatetimeTableColumn('uploaded-file.index.column.created', 'created'));
+        $table->addColumnDefinition(new UserTableColumn('uploaded-file.index.column.username', 'user'));
+        $table->addColumnDefinition(new BytesTableColumn('uploaded-file.index.column.size', 'size'));
+        $table->addColumn('uploaded-file.index.column.type', 'type')->setItemIconCallback(fn (UploadedAsset $data) => Encoder::getFontAwesomeFromMimeType($data->getType(), EMSCoreBundle::FONTAWESOME_VERSION));
+
+        $table->setDefaultOrder('created', 'desc');
+    }
+
+    /**
+     * @return array{'available': false}
+     */
+    public function getContext(array $options): array
+    {
+        return ['available' => false];
+    }
+
+    public function getRoles(): array
+    {
+        return [Roles::ROLE_USER];
+    }
+}

--- a/EMS/core-bundle/src/Repository/ReleaseRepository.php
+++ b/EMS/core-bundle/src/Repository/ReleaseRepository.php
@@ -60,7 +60,7 @@ final class ReleaseRepository extends ServiceEntityRepository
         return $queryBuilder->getQuery()->getResult();
     }
 
-    public function getById(string $id): Release
+    public function getById(int|string $id): Release
     {
         $queryBuilder = $this->createQueryBuilder('r');
         $queryBuilder->where('r.id = :id')

--- a/EMS/core-bundle/src/Resources/config/controllers.xml
+++ b/EMS/core-bundle/src/Resources/config/controllers.xml
@@ -60,6 +60,7 @@
         <service id="EMS\CoreBundle\Controller\ContentManagement\ActionController" public="true">
             <argument type="service" id="logger" />
             <argument type="service" id="ems.service.action" />
+            <argument type="service" id="emsco.data_table.factory" />
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>

--- a/EMS/core-bundle/src/Resources/config/controllers.xml
+++ b/EMS/core-bundle/src/Resources/config/controllers.xml
@@ -190,6 +190,7 @@
             <argument type="service" id="logger" />
             <argument type="service" id="ems.service.release" />
             <argument type="service" id="ems.service.release_revision" />
+            <argument type="service" id="emsco.data_table.factory" />
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>

--- a/EMS/core-bundle/src/Resources/config/controllers.xml
+++ b/EMS/core-bundle/src/Resources/config/controllers.xml
@@ -197,6 +197,7 @@
         <service id="EMS\CoreBundle\Controller\ContentManagement\ViewController" public="true">
             <argument type="service" id="ems.service.contenttype" />
             <argument type="service" id="ems.view.manager" />
+            <argument type="service" id="emsco.data_table.factory" />
             <argument type="service" id="logger"/>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>

--- a/EMS/core-bundle/src/Resources/config/controllers.xml
+++ b/EMS/core-bundle/src/Resources/config/controllers.xml
@@ -498,9 +498,8 @@
             <tag name="container.service_subscriber"/>
         </service>
         <service id="EMS\CoreBundle\Controller\UploadedFileWysiwygController" public="true">
-            <argument type="service" id="ems.service.file" />
             <argument type="service" id="ems_core.core_ui.ajax_service" />
-            <argument type="service" id="router" />
+            <argument type="service" id="emsco.data_table.factory"/>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>

--- a/EMS/core-bundle/src/Resources/config/controllers.xml
+++ b/EMS/core-bundle/src/Resources/config/controllers.xml
@@ -297,11 +297,11 @@
         </service>
         <service id="EMS\CoreBundle\Controller\Revision\EditController" public="true">
             <argument type="service" id="ems.service.data" />
-            <argument type="service" id="ems_core.core_revision.draft_in_progress" />
             <argument type="service" id="logger" />
             <argument type="service" id="ems.service.publish" />
             <argument type="service" id="ems.service.revision" />
             <argument type="service" id="translator" />
+            <argument type="service" id="emsco.data_table.factory" />
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>

--- a/EMS/core-bundle/src/Resources/config/controllers.xml
+++ b/EMS/core-bundle/src/Resources/config/controllers.xml
@@ -289,7 +289,7 @@
             <argument type="service" id="EMS\CoreBundle\Repository\RevisionRepository" />
             <argument type="service" id="ems_common.service.elastica" />
             <argument type="service" id="ems.service.search" />
-            <argument type="service" id="ems.log.manager"/>
+            <argument type="service" id="emsco.data_table.factory"/>
             <argument type="service" id="logger" />
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>

--- a/EMS/core-bundle/src/Resources/config/controllers.xml
+++ b/EMS/core-bundle/src/Resources/config/controllers.xml
@@ -255,6 +255,7 @@
         <!-- Log -->
         <service id="EMS\CoreBundle\Controller\Log\LogController" public="true">
             <argument type="service" id="ems.log.manager" />
+            <argument type="service" id="emsco.data_table.factory" />
             <argument type="service" id="logger" />
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>

--- a/EMS/core-bundle/src/Resources/config/datatable.xml
+++ b/EMS/core-bundle/src/Resources/config/datatable.xml
@@ -36,6 +36,12 @@
             <argument type="service" id="ems.service.revision"/>
             <tag name="emsco.datatable" />
         </service>
+        <service id="emsco.data_table.revision.drafts" class="EMS\CoreBundle\DataTable\Type\Revision\RevisionDraftsDataTableType">
+            <argument type="service" id="ems_core.core_revision.draft_in_progress" />
+            <argument type="service" id="EMS\CoreBundle\Service\ContentTypeService" />
+            <argument type="service" id="ems.service.user" />
+            <tag name="emsco.datatable" />
+        </service>
         <service id="emsco.data_table.channel" class="EMS\CoreBundle\DataTable\Type\ChannelDataTableType">
             <argument type="service" id="ems.service.channel"/>
             <tag name="emsco.datatable" />

--- a/EMS/core-bundle/src/Resources/config/datatable.xml
+++ b/EMS/core-bundle/src/Resources/config/datatable.xml
@@ -31,6 +31,11 @@
             <argument type="service" id="ems.service.release"/>
             <tag name="emsco.datatable" />
         </service>
+        <service id="emsco.data_table.revision.audit" class="EMS\CoreBundle\DataTable\Type\Revision\RevisionAuditDataTableType">
+            <argument type="service" id="ems.log.manager"/>
+            <argument type="service" id="ems.service.revision"/>
+            <tag name="emsco.datatable" />
+        </service>
         <service id="emsco.data_table.channel" class="EMS\CoreBundle\DataTable\Type\ChannelDataTableType">
             <argument type="service" id="ems.service.channel"/>
             <tag name="emsco.datatable" />

--- a/EMS/core-bundle/src/Resources/config/datatable.xml
+++ b/EMS/core-bundle/src/Resources/config/datatable.xml
@@ -51,6 +51,10 @@
             <argument type="service" id="ems.schedule.manager" />
             <tag name="emsco.datatable" />
         </service>
+        <service id="emsco.data_table.log" class="EMS\CoreBundle\DataTable\Type\LogDataTableType">
+            <argument type="service" id="ems.log.manager" />
+            <tag name="emsco.datatable" />
+        </service>
         <service id="emsco.data_table.query_search" class="EMS\CoreBundle\DataTable\Type\QuerySearchDataTableType">
             <argument type="service" id="ems.service.query_search" />
             <tag name="emsco.datatable" />

--- a/EMS/core-bundle/src/Resources/config/datatable.xml
+++ b/EMS/core-bundle/src/Resources/config/datatable.xml
@@ -12,6 +12,11 @@
             <argument type="service" id="EMS\CoreBundle\Service\ContentTypeService"/>
             <tag name="emsco.datatable" />
         </service>
+        <service id="emsco.data_table.content_type.view" class="EMS\CoreBundle\DataTable\Type\ContentType\ViewDataTableType">
+            <argument type="service" id="ems.view.manager"/>
+            <argument type="service" id="EMS\CoreBundle\Service\ContentTypeService"/>
+            <tag name="emsco.datatable" />
+        </service>
         <service id="emsco.data_table.channel" class="EMS\CoreBundle\DataTable\Type\ChannelDataTableType">
             <argument type="service" id="ems.service.channel"/>
             <tag name="emsco.datatable" />

--- a/EMS/core-bundle/src/Resources/config/datatable.xml
+++ b/EMS/core-bundle/src/Resources/config/datatable.xml
@@ -7,12 +7,12 @@
         <defaults public="false" />
 
         <!-- Types -->
-        <service id="emsco.data_table.content_type.action" class="EMS\CoreBundle\DataTable\Type\ContentType\ActionDataTableType">
+        <service id="emsco.data_table.content_type.action" class="EMS\CoreBundle\DataTable\Type\ContentType\ContentTypeActionDataTableType">
             <argument type="service" id="ems.service.action"/>
             <argument type="service" id="EMS\CoreBundle\Service\ContentTypeService"/>
             <tag name="emsco.datatable" />
         </service>
-        <service id="emsco.data_table.content_type.view" class="EMS\CoreBundle\DataTable\Type\ContentType\ViewDataTableType">
+        <service id="emsco.data_table.content_type.view" class="EMS\CoreBundle\DataTable\Type\ContentType\ContentTypeViewDataTableType">
             <argument type="service" id="ems.view.manager"/>
             <argument type="service" id="EMS\CoreBundle\Service\ContentTypeService"/>
             <tag name="emsco.datatable" />

--- a/EMS/core-bundle/src/Resources/config/datatable.xml
+++ b/EMS/core-bundle/src/Resources/config/datatable.xml
@@ -7,6 +7,11 @@
         <defaults public="false" />
 
         <!-- Types -->
+        <service id="emsco.data_table.content_type.action" class="EMS\CoreBundle\DataTable\Type\ContentType\ActionDataTableType">
+            <argument type="service" id="ems.service.action"/>
+            <argument type="service" id="EMS\CoreBundle\Service\ContentTypeService"/>
+            <tag name="emsco.datatable" />
+        </service>
         <service id="emsco.data_table.channel" class="EMS\CoreBundle\DataTable\Type\ChannelDataTableType">
             <argument type="service" id="ems.service.channel"/>
             <tag name="emsco.datatable" />

--- a/EMS/core-bundle/src/Resources/config/datatable.xml
+++ b/EMS/core-bundle/src/Resources/config/datatable.xml
@@ -73,5 +73,11 @@
             <argument>%ems_core.circles_object%</argument>
             <tag name="emsco.datatable" />
         </service>
+        <service id="emsco.data_table.wysiwyg_uploaded_file" class="EMS\CoreBundle\DataTable\Type\WysiwygUploadedFileDataTableType">
+            <argument type="service" id="ems.service.file" />
+            <argument type="service" id="router" />
+            <argument>%ems_core.circles_object%</argument>
+            <tag name="emsco.datatable" />
+        </service>
     </services>
 </container>

--- a/EMS/core-bundle/src/Resources/config/datatable.xml
+++ b/EMS/core-bundle/src/Resources/config/datatable.xml
@@ -21,6 +21,11 @@
             <argument type="service" id="ems.service.release"/>
             <tag name="emsco.datatable" />
         </service>
+        <service id="emsco.data_table.release.pick" class="EMS\CoreBundle\DataTable\Type\Release\ReleasePickDataTableType">
+            <argument type="service" id="ems.service.release"/>
+            <argument type="service" id="ems.service.revision"/>
+            <tag name="emsco.datatable" />
+        </service>
         <service id="emsco.data_table.channel" class="EMS\CoreBundle\DataTable\Type\ChannelDataTableType">
             <argument type="service" id="ems.service.channel"/>
             <tag name="emsco.datatable" />

--- a/EMS/core-bundle/src/Resources/config/datatable.xml
+++ b/EMS/core-bundle/src/Resources/config/datatable.xml
@@ -17,6 +17,10 @@
             <argument type="service" id="EMS\CoreBundle\Service\ContentTypeService"/>
             <tag name="emsco.datatable" />
         </service>
+        <service id="emsco.data_table.release.overview" class="EMS\CoreBundle\DataTable\Type\Release\ReleaseOverviewDataTableType">
+            <argument type="service" id="ems.service.release"/>
+            <tag name="emsco.datatable" />
+        </service>
         <service id="emsco.data_table.channel" class="EMS\CoreBundle\DataTable\Type\ChannelDataTableType">
             <argument type="service" id="ems.service.channel"/>
             <tag name="emsco.datatable" />

--- a/EMS/core-bundle/src/Resources/config/datatable.xml
+++ b/EMS/core-bundle/src/Resources/config/datatable.xml
@@ -26,6 +26,11 @@
             <argument type="service" id="ems.service.revision"/>
             <tag name="emsco.datatable" />
         </service>
+        <service id="emsco.data_table.release.revision" class="EMS\CoreBundle\DataTable\Type\Release\ReleaseRevisionDataTableType">
+            <argument type="service" id="ems.service.release_revision"/>
+            <argument type="service" id="ems.service.release"/>
+            <tag name="emsco.datatable" />
+        </service>
         <service id="emsco.data_table.channel" class="EMS\CoreBundle\DataTable\Type\ChannelDataTableType">
             <argument type="service" id="ems.service.channel"/>
             <tag name="emsco.datatable" />

--- a/EMS/core-bundle/src/Resources/config/routing/action.xml
+++ b/EMS/core-bundle/src/Resources/config/routing/action.xml
@@ -17,7 +17,4 @@
     <route id="ems_core_action_delete" path="/{contentType}/delete/{action}"
            controller="EMS\CoreBundle\Controller\ContentManagement\ActionController::delete"
            methods="POST"/>
-    <route id="ems_core_action_datatable_ajax" path="/{contentType}/datatable.json"
-           controller="EMS\CoreBundle\Controller\ContentManagement\ActionController::ajaxDataTableAction"
-           methods="GET|POST"/>
 </routes>

--- a/EMS/core-bundle/src/Resources/config/routing/admin/view.xml
+++ b/EMS/core-bundle/src/Resources/config/routing/admin/view.xml
@@ -4,7 +4,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://symfony.com/schema/routing https://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="emsco_view_index" path="/{type}.{_format}"
+    <route id="emsco_view_index" path="/{type}"
            controller="EMS\CoreBundle\Controller\ContentManagement\ViewController::index"
            methods="GET|POST"
            format="html"/>

--- a/EMS/core-bundle/src/Resources/config/routing/data.xml
+++ b/EMS/core-bundle/src/Resources/config/routing/data.xml
@@ -30,9 +30,6 @@
         <default key="revisionId">0</default>
         <default key="compareId">0</default>
     </route>
-    <route id="emsco_view_revisions_table_audit" path="/revisions/{type}:{ouuid}/audit.json"
-           controller="EMS\CoreBundle\Controller\Revision\DetailController::ajaxAuditDataTable"
-           methods="GET"/>
     <route id="emsco_duplicate_revision" path="/duplicate/{environment}/{type}/{ouuid}"
            controller="EMS\CoreBundle\Controller\ContentManagement\DataController::duplicateAction"
            methods="POST"/>

--- a/EMS/core-bundle/src/Resources/config/routing/data.xml
+++ b/EMS/core-bundle/src/Resources/config/routing/data.xml
@@ -125,9 +125,6 @@
            path="/json-menu-nested/silent-publish/{revision}/{fieldType}/{field}"
            controller="EMS\CoreBundle\Controller\Revision\JsonMenuNestedController::silentPublish"
            methods="POST"/>
-    <route id="emsco_data_pick_a_release_ajax_data_table" path="/pick-a-release/{revision}.json"
-           controller="EMS\CoreBundle\Controller\ContentManagement\ReleaseController::ajaxReleaseTable"
-           methods="GET"/>
     <route id="emsco_pick_a_release" path="/pick-a-release/{revision}"
            controller="EMS\CoreBundle\Controller\ContentManagement\ReleaseController::pickRelease"
            methods="GET|POST"/>

--- a/EMS/core-bundle/src/Resources/config/routing/edit.xml
+++ b/EMS/core-bundle/src/Resources/config/routing/edit.xml
@@ -13,9 +13,6 @@
     <route id="emsco_draft_in_progress" path="/draft/{contentTypeId}"
            controller="EMS\CoreBundle\Controller\Revision\EditController::draftInProgress"
            methods="GET|POST"/>
-    <route id="emsco_draft_in_progress_ajax" path="/draft/{contentType}/datatable.json"
-           controller="EMS\CoreBundle\Controller\Revision\EditController::ajaxDraftInProgress"
-           methods="GET|POST"/>
     <route id="emsco_revision_archive" path="/archive/{revision}"
            controller="EMS\CoreBundle\Controller\Revision\EditController::archiveRevision"
            methods="POST"/>

--- a/EMS/core-bundle/src/Resources/config/routing/log.xml
+++ b/EMS/core-bundle/src/Resources/config/routing/log.xml
@@ -4,10 +4,9 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://symfony.com/schema/routing https://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="emsco_log_index" path="/index.{_format}"
+    <route id="emsco_log_index" path="/index"
            controller="EMS\CoreBundle\Controller\Log\LogController::index"
-           methods="GET|POST"
-           format="html"/>
+           methods="GET|POST"/>
     <route id="emsco_log_delete" path="/delete/{log}"
            controller="EMS\CoreBundle\Controller\Log\LogController::delete"
            methods="POST"/>

--- a/EMS/core-bundle/src/Resources/config/routing/release.xml
+++ b/EMS/core-bundle/src/Resources/config/routing/release.xml
@@ -28,9 +28,6 @@
     <route id="emsco_release_add_revisions" path="/{release}/add-revisions"
            controller="EMS\CoreBundle\Controller\ContentManagement\ReleaseController::addRevisions"
            methods="GET|POST"/>
-    <route id="emsco_release_ajax_data_table" path="/release-datatable.json"
-           controller="EMS\CoreBundle\Controller\ContentManagement\ReleaseController::ajaxReleaseTable"
-           methods="GET"/>
     <route id="emsco_release_ajax_data_table_member_revision" path="/{release}/member-datatable.json"
            controller="EMS\CoreBundle\Controller\ContentManagement\ReleaseController::ajaxReleaseTableMemberRevisions"
            methods="GET"/>

--- a/EMS/core-bundle/src/Resources/config/routing/release.xml
+++ b/EMS/core-bundle/src/Resources/config/routing/release.xml
@@ -28,9 +28,6 @@
     <route id="emsco_release_add_revisions" path="/{release}/add-revisions"
            controller="EMS\CoreBundle\Controller\ContentManagement\ReleaseController::addRevisions"
            methods="GET|POST"/>
-    <route id="emsco_release_ajax_data_table_member_revision" path="/{release}/member-datatable.json"
-           controller="EMS\CoreBundle\Controller\ContentManagement\ReleaseController::ajaxReleaseTableMemberRevisions"
-           methods="GET"/>
     <route id="emsco_release_ajax_data_table_non_member_revision" path="/{release}/non-member-datatable.json"
            controller="EMS\CoreBundle\Controller\ContentManagement\ReleaseController::ajaxReleaseTableNonMemberRevisions"
            methods="GET"/>

--- a/EMS/core-bundle/src/Resources/config/routing/template-deprecated.xml
+++ b/EMS/core-bundle/src/Resources/config/routing/template-deprecated.xml
@@ -4,9 +4,6 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://symfony.com/schema/routing https://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="template.datatable.ajax" path="/{contentType}/datatable.json"
-           controller="EMS\CoreBundle\Controller\ContentManagement\ActionController::ajaxDataTableAction"
-           methods="GET|POST"/>
     <route id="template.index" path="/{type}"
            controller="EMS\CoreBundle\Controller\ContentManagement\ActionController::indexAction"
            methods="GET|HEAD"/>

--- a/EMS/core-bundle/src/Resources/config/routing/uploaded-file-wysiwyg.xml
+++ b/EMS/core-bundle/src/Resources/config/routing/uploaded-file-wysiwyg.xml
@@ -11,8 +11,4 @@
     <route id="ems_core_uploaded_file_wysiwyg_modal" path="/modal"
            controller="EMS\CoreBundle\Controller\UploadedFileWysiwygController::modal"
            methods="GET|POST"/>
-
-    <route id="ems_core_uploaded_file_wysiwyg_ajax" path="/datatable.json"
-           controller="EMS\CoreBundle\Controller\UploadedFileWysiwygController::ajaxDataTable"
-           methods="GET"/>
 </routes>

--- a/EMS/core-bundle/src/Resources/config/services.xml
+++ b/EMS/core-bundle/src/Resources/config/services.xml
@@ -164,7 +164,6 @@
         <service id="ems_core.service.uploaded-file" alias="EMS\CoreBundle\Service\DatatableService"/>
         <service id="ems_core.core_revision.draft_in_progress" class="EMS\CoreBundle\Core\Revision\DraftInProgress">
             <argument type="service" id="EMS\CoreBundle\Repository\RevisionRepository"/>
-            <argument type="service" id="ems.service.user"/>
         </service>
 
         <service id="ems_core.core_ui.flash_message_logger" class="EMS\CoreBundle\Core\UI\FlashMessageLogger">

--- a/EMS/core-bundle/src/Routes.php
+++ b/EMS/core-bundle/src/Routes.php
@@ -12,7 +12,6 @@ class Routes
     final public const VIEW_REVISIONS_AUDIT = 'emsco_view_revisions_table_audit';
     final public const DISCARD_DRAFT = 'emsco_discard_draft';
     final public const DRAFT_IN_PROGRESS = 'emsco_draft_in_progress';
-    final public const DRAFT_IN_PROGRESS_AJAX = 'emsco_draft_in_progress_ajax';
     final public const DATA_TABLE_AJAX_TABLE = 'emsco_datatable_ajax_table';
     final public const DASHBOARD_ADMIN_INDEX = 'emsco_dashboard_admin_index';
     final public const DASHBOARD_ADMIN_ADD = 'emsco_dashboard_admin_add';
@@ -36,8 +35,6 @@ class Routes
     final public const RELEASE_SET_STATUS = 'emsco_release_set_status';
     final public const RELEASE_ADD_REVISION = 'emsco_release_add_revision';
     final public const RELEASE_ADD_REVISIONS = 'emsco_release_add_revisions';
-    final public const RELEASE_AJAX_DATA_TABLE = 'emsco_release_ajax_data_table';
-    final public const RELEASE_MEMBER_REVISION_AJAX = 'emsco_release_ajax_data_table_member_revision';
     final public const RELEASE_NON_MEMBER_REVISION_AJAX = 'emsco_release_ajax_data_table_non_member_revision';
     final public const VIEW_INDEX = 'emsco_view_index';
     final public const VIEW_EDIT = 'emsco_view_edit';
@@ -50,7 +47,6 @@ class Routes
     final public const DATA_PRIVATE_VIEW = 'emsco_data_private_view';
     final public const DATA_ADD = 'emsco_data_add';
     final public const DATA_TRASH = 'emsco_data_trash';
-    final public const DATA_PICK_A_RELEASE_AJAX_DATA_TABLE = 'emsco_data_pick_a_release_ajax_data_table';
     final public const DATA_ADD_REVISION_TO_RELEASE = 'emsco_data_add_revision_to_release';
     final public const SCHEDULE_INDEX = 'emsco_schedule_index';
     final public const SCHEDULE_ADD = 'emsco_schedule_add';

--- a/EMS/core-bundle/src/Service/ReleaseRevisionService.php
+++ b/EMS/core-bundle/src/Service/ReleaseRevisionService.php
@@ -17,7 +17,12 @@ use Psr\Log\LoggerInterface;
 
 final class ReleaseRevisionService implements QueryServiceInterface, EntityServiceInterface
 {
-    public function __construct(private readonly ReleaseRevisionRepository $releaseRevisionRepository, private readonly RevisionRepository $revisionRepository, private readonly LoggerInterface $logger, private readonly ContentTypeService $contentTypeService, private readonly UserService $userService)
+    public function __construct(
+        private readonly ReleaseRevisionRepository $releaseRevisionRepository,
+        private readonly RevisionRepository $revisionRepository,
+        private readonly LoggerInterface $logger,
+        private readonly ContentTypeService $contentTypeService,
+        private readonly UserService $userService)
     {
     }
 

--- a/EMS/core-bundle/src/Service/ReleaseService.php
+++ b/EMS/core-bundle/src/Service/ReleaseService.php
@@ -243,6 +243,11 @@ final class ReleaseService implements EntityServiceInterface
         return $rollback;
     }
 
+    public function getById(int $id): Release
+    {
+        return $this->releaseRepository->getById($id);
+    }
+
     public function getByItemName(string $name): ?EntityInterface
     {
         return $this->releaseRepository->getById($name);

--- a/EMS/core-bundle/src/Service/Revision/RevisionService.php
+++ b/EMS/core-bundle/src/Service/Revision/RevisionService.php
@@ -322,7 +322,7 @@ class RevisionService implements RevisionServiceInterface
         }
     }
 
-    public function getByRevisionId(string $revisionId): Revision
+    public function getByRevisionId(int|string $revisionId): Revision
     {
         $revision = $this->revisionRepository->find($revisionId);
         if (!$revision instanceof Revision) {

--- a/Makefile
+++ b/Makefile
@@ -48,13 +48,13 @@ stop: ## stop docker, admin server, web server
 	@$(MAKE) -s admin-server-stop
 	@$(MAKE) -s web-server-stop
 	@$(MAKE) -s docker-down
-clear-cache:
+cache-clear: ## cache clear
 	@$(RUN_ADMIN) c:cl
 	@$(RUN_WEB) c:cl
 
 ## —— Demo —————————————————————————————————————————————————————————————————————————————————————————————————————————————
 demo-init: ## init demo (new database PostgreSQL)
-	@$(MAKE) clear-cache
+	@$(MAKE) cache-clear
 	@$(MAKE) -C ./demo -s init
 	@$(MAKE) demo-symlink-assets
 demo-load: ## load demo data


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |n|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

Except the task DataTables, all other EntityTables are now rendered by the DataTableFactory with their own type.
