### PR TITLE
fix(cli/media-sync): typo in warning only metadata file

### DIFF
--- a/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySync.php
+++ b/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySync.php
@@ -96,7 +96,7 @@ final class MediaLibrarySync
         $metaData = $this->getMetadata($path);
 
         if ($this->options->onlyMetadataFile && 0 === \count($metaData)) {
-            $this->io->warning(\sprintf('Skipped "%s" with reason metadata was found', $path));
+            $this->io->warning(\sprintf('Skipped "%s" with reason metadata was not found', $path));
 
             return;
         }


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|


