### PR TITLE
fix(common/emsLink): support json encode

### DIFF
--- a/EMS/common-bundle/src/Common/EMSLink.php
+++ b/EMS/common-bundle/src/Common/EMSLink.php
@@ -4,7 +4,7 @@ namespace EMS\CommonBundle\Common;
 
 use EMS\CommonBundle\Elasticsearch\Document\EMSSource;
 
-class EMSLink implements \Stringable
+class EMSLink implements \Stringable, \JsonSerializable
 {
     final public const EMSLINK_ASSET_PREFIX = 'ems://asset:';
     private string $linkType = 'object';
@@ -27,6 +27,11 @@ class EMSLink implements \Stringable
 
     private function __construct()
     {
+    }
+
+    public function jsonSerialize(): string
+    {
+        return $this->__toString();
     }
 
     public static function fromContentTypeOuuid(string $contentType, string $ouuid): EMSLink

--- a/EMS/common-bundle/tests/Unit/Common/EMSLinkTest.php
+++ b/EMS/common-bundle/tests/Unit/Common/EMSLinkTest.php
@@ -3,6 +3,7 @@
 namespace EMS\CommonBundle\Tests\Unit\Common;
 
 use EMS\CommonBundle\Common\EMSLink;
+use EMS\Helpers\Standard\Json;
 use PHPUnit\Framework\TestCase;
 
 class EMSLinkTest extends TestCase
@@ -31,5 +32,14 @@ class EMSLinkTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
         EMSLink::fromMatch([]);
+    }
+
+    public function testJsonSerialize()
+    {
+        $link = EMSLink::fromText('page:AWTLzKLc8K-kdP4iJ3rt');
+
+        $encoded = Json::encode(['link' => $link]);
+        $this->assertEquals('{"link":"ems:\/\/object:page:AWTLzKLc8K-kdP4iJ3rt"}', $encoded);
+        $this->assertEquals(['link' => 'ems://object:page:AWTLzKLc8K-kdP4iJ3rt'], Json::decode($encoded));
     }
 }


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

Json encoding an array with a EMSLink object, should output the text representation
