### PR TITLE
fix(core/field): placeholder empty string when not defined

### DIFF
--- a/EMS/core-bundle/src/Form/DataField/ChoiceFieldType.php
+++ b/EMS/core-bundle/src/Form/DataField/ChoiceFieldType.php
@@ -102,7 +102,7 @@ class ChoiceFieldType extends DataFieldType
                 'empty_data' => $options['multiple'] ? [] : null,
                 'multiple' => $options['multiple'],
                 'expanded' => $options['expanded'],
-                'placeholder' => $options['placeholder'],
+                'placeholder' => $options['placeholder'] ?? '',
                 'choice_attr' => $this->choiceAttr(...),
         ]);
     }


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

"If you leave the placeholder option unset, then a blank (with no text) option will automatically be added if and only if the required option is false"