### PR TITLE
fix(core/api): index/update refresh wait

### DIFF
--- a/EMS/core-bundle/src/Controller/ContentManagement/CrudController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/CrudController.php
@@ -350,14 +350,17 @@ class CrudController extends AbstractController
             }
         }
 
+        $contentType = $this->contentTypeService->giveByName($name);
         $rawData = Json::decode(Type::string($request->getContent()));
+
         if (null === $revision) {
-            $contentType = $this->contentTypeService->giveByName($name);
             $draft = $this->dataService->createData($ouuid, $rawData, $contentType);
         } else {
             $draft = $this->dataService->replaceData($revision, $rawData, $replaceOrMerge);
         }
+
         $newRevision = $this->dataService->finalizeDraft($draft);
+        $this->dataService->refresh($contentType->giveEnvironment());
 
         return new JsonResponse([
             'success' => !$newRevision->getDraft(),

--- a/EMS/core-bundle/src/Controller/ContentManagement/CrudController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/CrudController.php
@@ -360,7 +360,10 @@ class CrudController extends AbstractController
         }
 
         $newRevision = $this->dataService->finalizeDraft($draft);
-        $this->dataService->refresh($contentType->giveEnvironment());
+
+        if ($request->query->getBoolean('refresh')) {
+            $this->dataService->refresh($contentType->giveEnvironment());
+        }
 
         return new JsonResponse([
             'success' => !$newRevision->getDraft(),

--- a/EMS/core-bundle/src/Service/DataService.php
+++ b/EMS/core-bundle/src/Service/DataService.php
@@ -706,6 +706,11 @@ class DataService
         return $form;
     }
 
+    public function refresh(Environment $environment): bool
+    {
+        return $this->elasticaService->refresh($environment->getAlias());
+    }
+
     /**
      * @throws DataStateException
      * @throws \Exception


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

On api index or create, refresh before returning response.
Using the parameter refresh