### PR TITLE
fix(core/api): no flash messages

### DIFF
--- a/EMS/core-bundle/src/Core/UI/FlashMessageLogger.php
+++ b/EMS/core-bundle/src/Core/UI/FlashMessageLogger.php
@@ -29,11 +29,9 @@ final class FlashMessageLogger extends AbstractProcessingHandler
             return;
         }
 
-        if ('json' === $currentRequest->getContentType()) {
-            return;
-        }
-
-        if (true === ($record['context']['noFlash'] ?? false)) {
+        $headerFlashMessages = $currentRequest->headers->get('x-flash-messages', 'true');
+        if (true === ($record['context']['noFlash'] ?? false)
+            || !\filter_var($headerFlashMessages, FILTER_VALIDATE_BOOL)) {
             return;
         }
 

--- a/EMS/core-bundle/src/Core/UI/FlashMessageLogger.php
+++ b/EMS/core-bundle/src/Core/UI/FlashMessageLogger.php
@@ -23,15 +23,18 @@ final class FlashMessageLogger extends AbstractProcessingHandler
      */
     protected function write(array $record): void
     {
-        $currentRequest = $this->requestStack->getCurrentRequest();
-
-        if (null === $currentRequest || $record['level'] < Logger::NOTICE) {
+        if (null === $currentRequest = $this->requestStack->getCurrentRequest()) {
             return;
         }
 
-        $headerFlashMessages = $currentRequest->headers->get('x-flash-messages', 'true');
-        if (true === ($record['context']['noFlash'] ?? false)
-            || !\filter_var($headerFlashMessages, FILTER_VALIDATE_BOOL)) {
+        $headers = $currentRequest->headers;
+        $logLevel = $headers->has('x-log-level') ? (int) $headers->get('x-log-level') : Logger::NOTICE;
+
+        if ($record['level'] < $logLevel) {
+            return;
+        }
+
+        if (true === ($record['context']['noFlash'] ?? false)) {
             return;
         }
 

--- a/EMS/core-bundle/src/Core/UI/FlashMessageLogger.php
+++ b/EMS/core-bundle/src/Core/UI/FlashMessageLogger.php
@@ -29,6 +29,10 @@ final class FlashMessageLogger extends AbstractProcessingHandler
             return;
         }
 
+        if ('json' === $currentRequest->getContentType()) {
+            return;
+        }
+
         if (true === ($record['context']['noFlash'] ?? false)) {
             return;
         }


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

Add a header `X-Log-Level` to define the log level for the flash message logger.
This way we can skip (blue notice) logs, by setting the X-Log-Level to 300
