### PR TITLE
fix(core/api): data not consumed multipex fields

### DIFF
--- a/EMS/core-bundle/src/Form/DataField/MultiplexedTabContainerFieldType.php
+++ b/EMS/core-bundle/src/Form/DataField/MultiplexedTabContainerFieldType.php
@@ -156,6 +156,16 @@ final class MultiplexedTabContainerFieldType extends DataFieldType
     /**
      * {@inheritDoc}
      */
+    public function importData(DataField $dataField, float|int|bool|array|string|null $sourceArray, bool $isMigration): array
+    {
+        parent::importData($dataField, $sourceArray, $isMigration);
+
+        return self::getJsonNames($dataField->giveFieldType());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public static function isVirtual(array $option = []): bool
     {
         return true;


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

Passing multiple data from api calls, was throwing 'data not consumed errors'
Added the import function to the MultiplexedTab field
