### PR TITLE
fix(admin/mediaLib): template modal not found

### DIFF
--- a/EMS/core-bundle/src/Controller/Component/MediaLibraryController.php
+++ b/EMS/core-bundle/src/Controller/Component/MediaLibraryController.php
@@ -82,6 +82,6 @@ class MediaLibraryController
 
     private function getAjaxModal(): AjaxModal
     {
-        return $this->ajax->newAjaxModel("$this->templateNamespace/components/media_library/modal.html.twig");
+        return $this->ajax->newAjaxModel("@$this->templateNamespace/components/media_library/modal.html.twig");
     }
 }


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

Add folder not working
