### PR TITLE
feat(http-submission): no redirect http handler

### DIFF
--- a/EMS/submission-bundle/src/Handler/HttpHandler.php
+++ b/EMS/submission-bundle/src/Handler/HttpHandler.php
@@ -13,6 +13,7 @@ use EMS\SubmissionBundle\Response\HttpHandleResponse;
 use EMS\SubmissionBundle\Response\NoHttpRequest;
 use EMS\SubmissionBundle\Response\ResponseTransformer;
 use EMS\SubmissionBundle\Twig\TwigRenderer;
+use Symfony\Component\HttpClient\Exception\RedirectionException;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class HttpHandler extends AbstractHandler
@@ -31,8 +32,13 @@ final class HttpHandler extends AbstractHandler
             if (null !== $httpRequest->getIgnoreBodyValue() && $body === $httpRequest->getIgnoreBodyValue()) {
                 $handleResponse = new NoHttpRequest();
             } else {
-                $httpResponse = $this->client->request($httpRequest->getMethod(), $httpRequest->getUrl(), $httpRequest->getHttpOptions());
-                $httpResponseContent = $httpResponse->getContent(true);
+                try {
+                    $httpResponse = $this->client->request($httpRequest->getMethod(), $httpRequest->getUrl(), $httpRequest->getHttpOptions());
+                    $httpResponseContent = $httpResponse->getContent(true);
+                } catch (RedirectionException $exception) {
+                    $httpResponse = $exception->getResponse();
+                    $httpResponseContent = '';
+                }
                 $handleResponse = new HttpHandleResponse($httpResponse, $httpResponseContent);
             }
 

--- a/EMS/submission-bundle/src/Request/HttpRequest.php
+++ b/EMS/submission-bundle/src/Request/HttpRequest.php
@@ -18,6 +18,7 @@ final class HttpRequest extends AbstractRequest
         'headers' => [],
         'timeout' => 30,
         'query' => [],
+        'max_redirects' => 20,
     ];
 
     /**

--- a/EMS/submission-bundle/tests/Functional/Handler/HttpHandlerTest.php
+++ b/EMS/submission-bundle/tests/Functional/Handler/HttpHandlerTest.php
@@ -100,7 +100,7 @@ final class HttpHandlerTest extends AbstractHandlerTest
         $message = \file_get_contents(__DIR__.'/../fixtures/twig/message_http.twig');
 
         $this->assertEquals(
-            '{"status":"error","data":"Submission failed, contact your admin. (Invalid endpoint configuration: The option \"test\" does not exist. Defined options are: \"auth_basic\", \"auth_bearer\", \"headers\", \"ignore_body_value\", \"method\", \"query\", \"timeout\", \"url\".)"}',
+            '{"status":"error","data":"Submission failed, contact your admin. (Invalid endpoint configuration: The option \"test\" does not exist. Defined options are: \"auth_basic\", \"auth_bearer\", \"headers\", \"ignore_body_value\", \"max_redirects\", \"method\", \"query\", \"timeout\", \"url\".)"}',
             $this->handle($this->createForm(), $endpoint, $message)->getResponse()
         );
     }


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |n|
|New feature?   |y|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

It might be useful to not follow a redirect (30x) in some (rare/extreme) cases
