### PR TITLE
feat(admin/unpublish): db revisions not updated

### DIFF
--- a/EMS/core-bundle/src/Command/Environment/UnpublishCommand.php
+++ b/EMS/core-bundle/src/Command/Environment/UnpublishCommand.php
@@ -68,12 +68,13 @@ final class UnpublishCommand extends AbstractEnvironmentCommand
         foreach ($this->revisionSearcher->search($this->environment, $search) as $revisions) {
             $this->revisionSearcher->lock($revisions, $this->lockUser);
             $this->publishService->bulkStart($bulkSize, $this->logger);
+            $transactionEnvironment = $this->environmentService->clearCache()->giveByName($this->environment->getName());
 
             foreach ($revisions->transaction() as $revision) {
                 $this->io->progressAdvance();
 
                 try {
-                    $this->publishService->bulkUnpublish($revision, $this->environment);
+                    $this->publishService->bulkUnpublish($revision, $transactionEnvironment);
                     ++$this->counter;
                 } catch (\LogicException $e) {
                     $this->warnings[$e->getMessage()] = ($this->warnings[$e->getMessage()] ?? 0) + 1;

--- a/EMS/core-bundle/src/Service/EnvironmentService.php
+++ b/EMS/core-bundle/src/Service/EnvironmentService.php
@@ -331,11 +331,13 @@ class EnvironmentService implements EntityServiceInterface
         });
     }
 
-    public function clearCache(): void
+    public function clearCache(): self
     {
         $this->environments = [];
         $this->notSnapshotEnvironments = [];
         $this->environmentsById = [];
+
+        return $this;
     }
 
     public function updateEnvironment(Environment $environment): void


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

Only the first batch size revisions are updated in the database. The reason: inside the transaction doctrine clear is called, next batch we pass a detached entity to the bulkUnpublish method. This method removes the environment with a detached entity.

Before starting a new transaction, fetch the environment object again.

