### PR TITLE
feat(core/api): user profile return options

### DIFF
--- a/EMS/client-helper-bundle/src/Security/CoreApi/User/CoreApiUser.php
+++ b/EMS/client-helper-bundle/src/Security/CoreApi/User/CoreApiUser.php
@@ -16,7 +16,7 @@ class CoreApiUser implements UserInterface
     public array $circles;
 
     public function __construct(
-        private readonly ProfileInterface $profile,
+        public readonly ProfileInterface $profile,
         private readonly string $token
     ) {
         $this->displayName = $this->profile->getDisplayName();

--- a/EMS/common-bundle/src/Common/CoreApi/Endpoint/User/Profile.php
+++ b/EMS/common-bundle/src/Common/CoreApi/Endpoint/User/Profile.php
@@ -16,6 +16,8 @@ final class Profile implements ProfileInterface
     private readonly array $roles;
     /** @var string[] */
     private readonly array $circles;
+    /** @var array<string, mixed> */
+    private readonly array $userOptions;
     private ?\DateTimeImmutable $lastLogin = null;
 
     /**
@@ -29,6 +31,7 @@ final class Profile implements ProfileInterface
         $this->displayName = $data['displayName'] ?? null;
         $this->roles = $data['roles'] ?? [];
         $this->circles = $data['circles'] ?? [];
+        $this->userOptions = $data['userOptions'] ?? [];
 
         if (isset($data['lastLogin'])) {
             $lastLogin = \DateTimeImmutable::createFromFormat(\DateTimeImmutable::ATOM, $data['lastLogin']);
@@ -75,5 +78,13 @@ final class Profile implements ProfileInterface
     public function getLastLogin(): ?\DateTimeImmutable
     {
         return $this->lastLogin;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getUserOptions(): array
+    {
+        return $this->userOptions;
     }
 }

--- a/EMS/common-bundle/src/Contracts/CoreApi/Endpoint/User/ProfileInterface.php
+++ b/EMS/common-bundle/src/Contracts/CoreApi/Endpoint/User/ProfileInterface.php
@@ -25,4 +25,9 @@ interface ProfileInterface
     public function getCircles(): array;
 
     public function getLastLogin(): ?\DateTimeImmutable;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getUserOptions(): array;
 }

--- a/EMS/core-bundle/src/Entity/User.php
+++ b/EMS/core-bundle/src/Entity/User.php
@@ -126,7 +126,7 @@ class User implements UserInterface, EntityInterface, PasswordAuthenticatedUserI
      */
     private array $roles = [];
     /**
-     * @var ?array<string, bool>
+     * @var ?array<string, mixed>
      *
      * @ORM\Column(name="user_options", type="json", nullable=true)
      */
@@ -147,7 +147,7 @@ class User implements UserInterface, EntityInterface, PasswordAuthenticatedUserI
     }
 
     /**
-     * @return array{id: int|string, username:string, displayName:string, roles:array<string>, email:string, circles:array<string>, lastLogin: ?string}
+     * {@inheritDoc}
      */
     public function toArray(): array
     {
@@ -161,6 +161,7 @@ class User implements UserInterface, EntityInterface, PasswordAuthenticatedUserI
             'lastLogin' => null !== $this->getLastLogin() ? $this->getLastLogin()->format('c') : null,
             'locale' => $this->getLocale(),
             'localePreferred' => $this->getLocalePreferred(),
+            'userOptions' => $this->userOptions,
         ];
     }
 

--- a/EMS/core-bundle/src/Entity/UserInterface.php
+++ b/EMS/core-bundle/src/Entity/UserInterface.php
@@ -56,7 +56,16 @@ interface UserInterface extends \Symfony\Component\Security\Core\User\UserInterf
     public function getLastLogin(): ?\DateTime;
 
     /**
-     * @return array{id: int|string, username:string, displayName:string, roles:array<string>, email:string, circles:array<string>, lastLogin: ?string}
+     * @return array{
+     *     id: int|string,
+     *     username:string,
+     *     displayName:string,
+     *     roles:array<string>,
+     *     email:string,
+     *     circles:array<string>,
+     *     lastLogin: ?string,
+     *     userOptions: ?array<string, mixed>
+     * }
      */
     public function toArray(): array;
 }


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |n|
|New feature?   |y|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

Return userOptions defined with custom user form through api.

Example implementation with emsch_login route and authenticated routes

```twig
{% set customOptions = app.user.profile.userOptions.custom_options %}
```
