### PR TITLE
fix(admin/jmn): link fieldType needs environment

### DIFF
--- a/EMS/core-bundle/src/Resources/config/form.xml
+++ b/EMS/core-bundle/src/Resources/config/form.xml
@@ -209,6 +209,7 @@
             <argument type="service" id="form.registry" />
             <argument type="service" id="ems.service.elasticsearch" />
             <argument type="service" id="ems_common.service.elastica" />
+            <argument type="service" id="EMS\CoreBundle\Service\EnvironmentService" />
             <argument type="service" id="twig" />
             <argument type="service" id="emsco.logger" />
             <tag name="ems.form.datafieldtype" alias="json_menu_nested_link" />

--- a/EMS/core-bundle/src/Resources/views/macros/data-field-type.html.twig
+++ b/EMS/core-bundle/src/Resources/views/macros/data-field-type.html.twig
@@ -1030,7 +1030,12 @@
 	{%- set jmnQuery = displayOptions.query|default(false) -%}
 
 	{%- if jmnField and jmnQuery and dataField.rawData is not null -%}
-		{%- set hits = { index:  dataField.fieldType.contentType.environment.alias, body: jmnQuery}|search.hits.hits -%}
+        {% if displayOptions.environment is not null %}
+            {% set index = displayOptions.environment|emsco_get_environment.alias %}
+        {% else %}
+            {% set index = dataField.fieldType.contentType.environment.alias %}
+        {% endif %}
+		{%- set hits = { index: index, body: jmnQuery}|search.hits.hits -%}
 		{%- set structures = [] -%}
 		{%- for h in hits -%}
 			{% set structures = structures|merge([{


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

If the structure has a different environment, 'default' for example
