### PR TITLE
fix(clientHelper): emsch_routing only prefix internal urls

### DIFF
--- a/EMS/client-helper-bundle/src/Helper/Routing/Url/Generator.php
+++ b/EMS/client-helper-bundle/src/Helper/Routing/Url/Generator.php
@@ -38,6 +38,11 @@ final class Generator
     public function prependBaseUrl(string $url): string
     {
         $url = \trim($url);
+
+        if (!\str_starts_with($url, '/')) {
+            return $url;
+        }
+
         $baseUrl = $this->baseUrl.$this->phpApp;
 
         if (\strlen($baseUrl) > 0 && \str_starts_with($url, $baseUrl)) {

--- a/EMS/client-helper-bundle/src/Helper/Routing/Url/Transformer.php
+++ b/EMS/client-helper-bundle/src/Helper/Routing/Url/Transformer.php
@@ -40,7 +40,7 @@ final class Transformer
         try {
             $emsLink = EMSLink::fromMatch($match);
 
-            if (str_ends_with('asset', $emsLink->getLinkType())) {
+            if (\str_ends_with('asset', $emsLink->getLinkType())) {
                 return $this->generateForAsset($emsLink, $match, $config);
             }
 

--- a/EMS/client-helper-bundle/src/Helper/Routing/Url/Transformer.php
+++ b/EMS/client-helper-bundle/src/Helper/Routing/Url/Transformer.php
@@ -40,7 +40,7 @@ final class Transformer
         try {
             $emsLink = EMSLink::fromMatch($match);
 
-            if ('asset' === $emsLink->getLinkType()) {
+            if (str_ends_with('asset', $emsLink->getLinkType())) {
                 return $this->generateForAsset($emsLink, $match, $config);
             }
 


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

relative urls (../file/..) should not be prefixed with basePath, using a different contentType 'project_asset', is not working because we check on 'asset' as linkType.

External links from a contentType (http://www.github.com) are prefixed with the base path.
