### PR TITLE
fix(emsch/search): add option fields_exclude

### DIFF
--- a/EMS/client-helper-bundle/src/Helper/Search/Manager.php
+++ b/EMS/client-helper-bundle/src/Helper/Search/Manager.php
@@ -32,6 +32,7 @@ final class Manager
 
         $qbService = new QueryBuilder($this->clientRequest, $requestSearch);
         $search = $qbService->buildSearch($requestSearch->getTypes());
+        $search->setSourceExcludes($requestSearch->getFieldsExclude());
         $search->setFrom($requestSearch->getFrom());
         $search->setSize($requestSearch->getSize());
         $search->setRegex($requestSearch->getIndexRegex());

--- a/EMS/client-helper-bundle/src/Helper/Search/Search.php
+++ b/EMS/client-helper-bundle/src/Helper/Search/Search.php
@@ -24,6 +24,8 @@ final class Search
     private array $synonyms = [];
     /** @var string[] */
     private array $fields = [];
+    /** @var string[] */
+    private array $fieldsExclude;
     /** @var ?array<mixed> */
     private ?array $querySearch = null;
     /** @var string[] */
@@ -71,6 +73,7 @@ final class Search
         $this->minimumShouldMatch = $options['minimum_should_match'] ?? null;
         $this->defaultSorts = $this->parseSorts($options['default_sorts'] ?? []);
         $this->sorts = $this->parseSorts($options['sorts'] ?? []);
+        $this->fieldsExclude = $options['fields_exclude'] ?? ['*._content'];
 
         $this->setHighlight($options['highlight'] ?? []);
         $this->setFields($options['fields'] ?? []);
@@ -303,6 +306,14 @@ final class Search
     public function getMinimumShouldMatch(): ?string
     {
         return $this->minimumShouldMatch;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getFieldsExclude(): array
+    {
+        return $this->fieldsExclude;
     }
 
     /**


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |y|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

Add new option `fields_exclude` for emsch search config.
If not defined, the default value is ```["*._content"]```

Currently returning documents with file fields, we return the file content for each hit.
Before this pr, a search result page was hitting 122mb memory usages, after this pr (excluding _content), 12mb
