### PR TITLE
feat(elk client): support advance host connection definition

### DIFF
--- a/EMS/common-bundle/src/Elasticsearch/ElasticaFactory.php
+++ b/EMS/common-bundle/src/Elasticsearch/ElasticaFactory.php
@@ -21,6 +21,10 @@ class ElasticaFactory
     {
         $servers = [];
         foreach ($hosts as $host) {
+            if (!\is_string($host)) {
+                $servers[] = $host;
+                continue;
+            }
             if (!\str_ends_with($host, '/')) {
                 $host .= '/';
             }


### PR DESCRIPTION
Sometime the elasticsearch cluster might required more advance configurations than a list of URLs. For exemple, if you have to work with elasticsearch cluster using a self signed certificate for it's encryption. Instead of installing a certificate you might consider to skip the SSL validation. To do so you can defined CURL option per host config) like this:

```dotenv
EMS_ELASTICSEARCH_HOSTS='[{"transport":"Https","host":"elastic:fewl13@localhost","port":9200,"curl":{"64":false}}]'
```

[List of curl options](https://github.com/JetBrains/phpstorm-stubs/blob/master/curl/curl_d.php)