### PR TITLE
feat(elasticsearc):  one host means SimpleConnectionPool strategy

### DIFF
--- a/EMS/common-bundle/src/Elasticsearch/ElasticaFactory.php
+++ b/EMS/common-bundle/src/Elasticsearch/ElasticaFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EMS\CommonBundle\Elasticsearch;
 
+use Elasticsearch\ConnectionPool\SimpleConnectionPool;
 use Elasticsearch\ConnectionPool\SniffingConnectionPool;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
@@ -31,9 +32,13 @@ class ElasticaFactory
             $servers[] = ['url' => $host];
         }
 
+        if (null === $connectionPool) {
+            $connectionPool = 1 === \count($servers) ? SimpleConnectionPool::class : SniffingConnectionPool::class;
+        }
+
         $config = [
             'servers' => $servers,
-            'connectionPool' => $connectionPool ?? SniffingConnectionPool::class,
+            'connectionPool' => $connectionPool,
         ];
 
         $client = new Client($config);


### PR DESCRIPTION

|Q              |A  |
|---------------|---|
|Bug fix?       ||
|New feature?   ||
|BC breaks?     ||
|Deprecations?  ||
|Fixed tickets  ||

If only one host/server is defined in the elasticsearch config, we may assume that the cluster is behind a reverse proxy or it a cloud service. In that case we can use the SimpleConnectionPool strategy in order to avoid extra (and useless) sniffing requests.
