### PR TITLE
fix(core/repository): fieldType repository is service entity

### DIFF
--- a/EMS/core-bundle/src/Entity/FieldType.php
+++ b/EMS/core-bundle/src/Entity/FieldType.php
@@ -18,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * @ORM\Table(name="field_type")
  *
- * @ORM\Entity(repositoryClass="EMS\CoreBundle\Repository\FieldTypeRepository")
+ * @ORM\Entity()
  *
  * @ORM\HasLifecycleCallbacks()
  */


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|
|BC breaks?     |n|
|Deprecations?  |n|
|Fixed tickets  |n|

FieldType repository became ServiceEntityRepository but was still defined on entity.

The "EMS\CoreBundle\Repository\FieldTypeRepository" entity repository implements "Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepositoryInterface", but its service could not be found. Make sure the service exists and is tagged with "doctrine.repository_service".

https://github.com/ems-project/elasticms/commit/6ff72a49586a3bd13f4dde72ebe4ef768775ffc4

