### PR TITLE
fix(core/jmn): jmn refresh after change

### DIFF
--- a/EMS/core-bundle/src/Core/Component/JsonMenuNested/JsonMenuNestedService.php
+++ b/EMS/core-bundle/src/Core/Component/JsonMenuNested/JsonMenuNestedService.php
@@ -6,6 +6,7 @@ namespace EMS\CoreBundle\Core\Component\JsonMenuNested;
 
 use EMS\CommonBundle\Json\JsonMenuNested;
 use EMS\CommonBundle\Json\JsonMenuNestedException;
+use EMS\CommonBundle\Service\ElasticaService;
 use EMS\CoreBundle\Core\Component\JsonMenuNested\Config\JsonMenuNestedConfig;
 use EMS\CoreBundle\Core\Component\JsonMenuNested\Config\JsonMenuNestedNode;
 use EMS\CoreBundle\Core\Component\JsonMenuNested\Template\Context\JsonMenuNestedRenderContext;
@@ -22,7 +23,8 @@ class JsonMenuNestedService
     public function __construct(
         private readonly JsonMenuNestedTemplateFactory $jsonMenuNestedTemplateFactory,
         private readonly RevisionService $revisionService,
-        private readonly UserService $userService
+        private readonly UserService $userService,
+        private readonly ElasticaService $elasticaService
     ) {
     }
 
@@ -163,5 +165,6 @@ class JsonMenuNestedService
         (new PropertyAccessor())->setValue($rawData, $path, $structure);
 
         $this->revisionService->updateRawData($config->revision, $rawData, $username);
+        $this->elasticaService->refresh($config->revision->giveContentType()->giveEnvironment()->getAlias());
     }
 }

--- a/EMS/core-bundle/src/Resources/config/core.xml
+++ b/EMS/core-bundle/src/Resources/config/core.xml
@@ -31,6 +31,7 @@
             <argument type="service" id="emsco.core.json_menu_nested.template_factory" />
             <argument type="service" id="ems.service.revision" />
             <argument type="service" id="ems.service.user" />
+            <argument type="service" id="ems_common.service.elastica" />
         </service>
 
         <!-- Media Library -->


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? |  n |
| Documentation? | n  |

After updating a json menu nested, we should refresh the index. Because we may redirect to a new revision in edit mode, and the new node needs to be directly visible.
