### PR TITLE
fix(emsch/search): 'query_string' search escape query

### DIFF
--- a/EMS/common-bundle/src/Elasticsearch/QueryStringEscaper.php
+++ b/EMS/common-bundle/src/Elasticsearch/QueryStringEscaper.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CommonBundle\Elasticsearch;
+
+class QueryStringEscaper
+{
+    private const REGEX_RESERVED_CHARACTERS = '/[\\+\\-\\=\\&\\|\\!\\(\\)\\{\\}\\[\\]\\^\\\"\\~\\*\\<\\>\\?\\:\\\\\\/]/';
+
+    public static function escape(string $queryString): string
+    {
+        $result = \preg_replace(self::REGEX_RESERVED_CHARACTERS, \addslashes('\\$0'), $queryString);
+
+        return $result ?: $queryString;
+    }
+}

--- a/EMS/common-bundle/tests/Unit/Elasticsearch/QueryStringEscaperTest.php
+++ b/EMS/common-bundle/tests/Unit/Elasticsearch/QueryStringEscaperTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CommonBundle\Tests\Unit\Elasticsearch;
+
+use EMS\CommonBundle\Elasticsearch\QueryStringEscaper;
+use PHPUnit\Framework\TestCase;
+
+class QueryStringEscaperTest extends TestCase
+{
+    /**
+     * @dataProvider provider
+     */
+    public function testEscape(string $input, string $output): void
+    {
+        $this->assertSame($output, QueryStringEscaper::escape($input));
+    }
+
+    public function provider(): array
+    {
+        return [
+            ['example \ / ', 'example \\\ \\/ '],
+            ['test & = test ! ', 'test \\& \\= test \\! '],
+            ['<code> ~ + ? test', '\\<code\\> \\~ \\+ \\? test'],
+            ['e-example \ 01/06', 'e\\-example \\\ 01\\/06'],
+            ['e-example \ ', 'e\\-example \\\ '],
+        ];
+    }
+}


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  |  n |
| Fixed tickets? |  n |
| Documentation? | n  |

Defining a emsch search with a custom query and using 'query_string' was not escaping the reserved characters:

Searching for ` test / test` was throwing errors

```json
{
  "query_search": {
    "bool": {
      "minimum_should_match": "1",
      "should": [
        {
          "query_string": {
            "query": "%query%",
            "default_operator": "AND",
            "boost": 20,
            "default_field": "title_%_locale%"
          }
        }
      ]
    }
  }
}
```



