### PR TITLE
fix(core/extract): new tika content limit for admin

### DIFF
--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/ajax/extract-data-file.json.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/ajax/extract-data-file.json.twig
@@ -1,4 +1,4 @@
-{% extends '@EMSCore/ajax/notification.json.twig' %}
+{% extends '@EMSAdminUI/bootstrap5/ajax/notification.json.twig' %}
 
 {% block body %}
     "content": {{ (data.content)|json_encode|raw }},

--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/ajax/extract-data-file.json.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/ajax/extract-data-file.json.twig
@@ -1,9 +1,9 @@
-{% extends '@EMSAdminUI/bootstrap5/ajax/notification.json.twig' %}
+{% extends '@EMSCore/ajax/notification.json.twig' %}
 
 {% block body %}
-	"content": {{ (data.content is defined ? data.content : '')|json_encode|raw }},
-	"author": {{ (data.author is defined ? data.author : (data.Author is defined ? data.Author : ''))|json_encode|raw }},
-	"date": {{ (data.date is defined ? data.date : '')|json_encode|raw }},
-	"language": {{ (data.language is defined ? data.language : '')|json_encode|raw }},
-	"title": {{ (data.title is defined ? data.title : '')|json_encode|raw }},
+    "content": {{ (data.content)|json_encode|raw }},
+    "author": {{ data.author|json_encode|raw }},
+    "date": {{ data.date|json_encode|raw }},
+    "language": {{ data.locale|json_encode|raw }},
+    "title": {{ data.title|json_encode|raw }},
 {% endblock %}

--- a/EMS/core-bundle/src/Controller/ContentManagement/FileController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/FileController.php
@@ -61,7 +61,7 @@ class FileController extends AbstractController
         $this->closeSession($request);
 
         try {
-            $data = $this->assetExtractorService->extractData($sha1, null, $forced);
+            $data = $this->assetExtractorService->extractMetaData($sha1, null, $forced);
         } catch (NotFoundException) {
             throw new NotFoundHttpException(\sprintf('Asset %s not found', $sha1));
         }

--- a/EMS/core-bundle/src/DependencyInjection/Configuration.php
+++ b/EMS/core-bundle/src/DependencyInjection/Configuration.php
@@ -32,6 +32,7 @@ class Configuration implements ConfigurationInterface
     final public const PUBLIC_KEY = null;
     final public const ASSET_CONFIG = [];
     final public const TIKA_SERVER = null;
+    final public const TIKA_MAX_CONTENT = 5120;
     final public const SAVE_ASSETS_IN_DB = false;
     final public const DEFAULT_BULK_SIZE = 500;
     final public const CLEAN_JOBS_TIME_STRING = '-7 days';
@@ -72,6 +73,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('private_key')->defaultValue(self::PRIVATE_KEY)->end()
                 ->scalarNode('public_key')->defaultValue(self::PUBLIC_KEY)->end()
                 ->scalarNode('tika_server')->defaultValue(self::TIKA_SERVER)->end()
+                ->scalarNode('tika_max_content')->defaultValue(self::TIKA_MAX_CONTENT)->end()
                 ->scalarNode('elasticsearch_version')->defaultValue('depreacted')->end()
                 ->booleanNode('pre_generated_ouuids')->defaultValue(false)->end()
                 ->arrayNode('template_options')->defaultValue([])->prototype('variable')->end()->end()

--- a/EMS/core-bundle/src/DependencyInjection/EMSCoreExtension.php
+++ b/EMS/core-bundle/src/DependencyInjection/EMSCoreExtension.php
@@ -63,6 +63,7 @@ class EMSCoreExtension extends Extension implements PrependExtensionInterface
         $container->setParameter('ems_core.template_options', $config['template_options']);
         $container->setParameter('ems_core.asset_config', $config['asset_config']);
         $container->setParameter('ems_core.tika_server', $config['tika_server']);
+        $container->setParameter('ems_core.tika_max_content', $config['tika_max_content']);
         $container->setParameter('ems_core.pre_generated_ouuids', $config['pre_generated_ouuids']);
         $container->setParameter('ems_core.private_key', $config['private_key']);
         $container->setParameter('ems_core.public_key', $config['public_key']);

--- a/EMS/core-bundle/src/Resources/config/services.xml
+++ b/EMS/core-bundle/src/Resources/config/services.xml
@@ -410,6 +410,7 @@
             <argument>%ems_core.tika_server%</argument>
             <argument>%kernel.project_dir%</argument>
             <argument>%ems_core.tika_download_url%</argument>
+            <argument>%ems_core.tika_max_content%</argument>
             <tag name="kernel.cache_warmer" />
         </service>
         <service id="ems.service.search" class="EMS\CoreBundle\Service\SearchService">

--- a/EMS/core-bundle/src/Resources/views/ajax/extract-data-file.json.twig
+++ b/EMS/core-bundle/src/Resources/views/ajax/extract-data-file.json.twig
@@ -1,9 +1,9 @@
 {% extends '@EMSCore/ajax/notification.json.twig' %}
 
 {% block body %}
-	"content": {{ (data.content is defined ? data.content : '')|json_encode|raw }},
-	"author": {{ (data.author is defined ? data.author : (data.Author is defined ? data.Author : ''))|json_encode|raw }},
-	"date": {{ (data.date is defined ? data.date : '')|json_encode|raw }},
-	"language": {{ (data.language is defined ? data.language : '')|json_encode|raw }},
-	"title": {{ (data.title is defined ? data.title : '')|json_encode|raw }},
+	"content": {{ (data.content)|json_encode|raw }},
+	"author": {{ data.author|json_encode|raw }},
+	"date": {{ data.date|json_encode|raw }},
+	"language": {{ data.locale|json_encode|raw }},
+	"title": {{ data.title|json_encode|raw }},
 {% endblock %}

--- a/elasticms-admin/config/packages/ems_core.yaml
+++ b/elasticms-admin/config/packages/ems_core.yaml
@@ -35,6 +35,7 @@ parameters:
     env(EMS_ELASTICSEARCH_HOSTS): '%env(string:ELASTICSEARCH_CLUSTER)%'
     env(EMSCO_TIKA_SERVER): '%env(string:TIKA_SERVER)%'
     env(EMSCO_TIKA_DOWNLOAD_URL): '%env(string:TIKA_DOWNLOAD_URL)%'
+    env(EMSCO_TIKA_MAX_CONTENT): 5120
     env(EMSCO_PRIVATE_KEY): '%env(string:EMS_PRIVATE_KEY)%'
     env(EMSCO_PUBLIC_KEY): '%env(string:EMS_PUBLIC_KEY)%'
     env(EMSCO_INSTANCE_ID): '%env(string:EMS_INSTANCE_ID)%'
@@ -91,6 +92,7 @@ ems_core:
     asset_config: '%env(json:EMSCO_ASSET_CONFIG)%'
     tika_server: '%env(string:EMSCO_TIKA_SERVER)%'
     tika_download_url: '%env(string:EMSCO_TIKA_DOWNLOAD_URL)%'
+    tika_max_content: '%env(int:EMSCO_TIKA_MAX_CONTENT)%'
     trigger_job_from_web:  '%env(bool:EMSCO_TRIGGER_JOB_FROM_WEB)%'
     pre_generated_ouuids: '%env(bool:EMSCO_PRE_GENERATED_OUUIDS)%'
     default_bulk_size: '%env(int:EMSCO_DEFAULT_BULK_SIZE)%'


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? |  n |
| Documentation? | n  |

Just like the CLI the admin needs to have a limit on the extracted content. The limit will apply on the getContent method, because the full extracted content is stored in db.
