### PR TITLE
fix(core): deprecation migration event subscriber

### DIFF
--- a/EMS/common-bundle/src/EventListener/DoctrineMigrationListener.php
+++ b/EMS/common-bundle/src/EventListener/DoctrineMigrationListener.php
@@ -2,23 +2,16 @@
 
 declare(strict_types=1);
 
-namespace EMS\CoreBundle\EventListener;
+namespace EMS\CommonBundle\EventListener;
 
-use Doctrine\Bundle\DoctrineBundle\EventSubscriber\EventSubscriberInterface;
 use Doctrine\DBAL\Schema\PostgreSQLSchemaManager;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
-use Doctrine\ORM\Tools\ToolEvents;
 
-class MigrationEventSubscriber implements EventSubscriberInterface
+class DoctrineMigrationListener
 {
-    public function getSubscribedEvents(): array
-    {
-        return [ToolEvents::postGenerateSchema => 'postGenerateSchema'];
-    }
-
     public function postGenerateSchema(GenerateSchemaEventArgs $args): void
     {
-        $schemaManager = $args->getEntityManager()->getConnection()->getSchemaManager();
+        $schemaManager = $args->getEntityManager()->getConnection()->createSchemaManager();
 
         if (!$schemaManager instanceof PostgreSqlSchemaManager) {
             return;

--- a/EMS/common-bundle/src/Resources/config/services.xml
+++ b/EMS/common-bundle/src/Resources/config/services.xml
@@ -53,6 +53,9 @@
         <service id="ems_common.event_listener.command" class="EMS\CommonBundle\EventListener\CommandListener">
             <tag name="kernel.event_subscriber" />
         </service>
+        <service id="ems.event_listener.doctrine_migration" class="EMS\CommonBundle\EventListener\DoctrineMigrationListener">
+            <tag name="doctrine.event_listener" event="postGenerateSchema"/>
+        </service>
 
         <service id="ems_common.text.encoder" class="EMS\CommonBundle\Helper\Text\Encoder">
             <argument type="string">%ems_common.webalize.removable_regex%</argument>

--- a/EMS/core-bundle/src/Resources/config/services.xml
+++ b/EMS/core-bundle/src/Resources/config/services.xml
@@ -26,9 +26,6 @@
             <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="110" />
             <tag name="kernel.event_listener" event="kernel.response" method="onKernelResponse" />
         </service>
-        <service id="emsco.event_listener.migration" class="EMS\CoreBundle\EventListener\MigrationEventSubscriber">
-            <tag name="doctrine.event_subscriber" connection="default" />
-        </service>
 
         <!-- core service -->
         <service id="ems.dashboard.manager" class="EMS\CoreBundle\Core\Dashboard\DashboardManager">


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  |  y |
| Fixed tickets? | n  |
| Documentation? | n  |

coming from: https://github.com/ems-project/elasticms/pull/625

Want this deprecation to be fixed in 5.x, but we will merge the annotations to xml in the 6.x branch

php.INFO: User Deprecated: The "EMS\CoreBundle\EventListener\MigrationEventSubscriber" class implements "Doctrine\Bundle\DoctrineBundle\EventSubscriber\EventSubscriberIn terface" that is deprecated use the {@see AsDoctrineListener} attribute instead.
