### PR TITLE
fix(core/doctrine): invalid entities bigint, decimal returns string

### DIFF
--- a/EMS/core-bundle/src/Entity/Form/Search.php
+++ b/EMS/core-bundle/src/Entity/Form/Search.php
@@ -23,7 +23,7 @@ class Search implements \JsonSerializable
      *
      * @ORM\GeneratedValue(strategy="AUTO")
      */
-    private int $id;
+    private string $id;
 
     /**
      * @var Collection<int, SearchFilter>
@@ -111,14 +111,9 @@ class Search implements \JsonSerializable
         return $out;
     }
 
-    /**
-     * Get id.
-     *
-     * @return int
-     */
-    public function getId()
+    public function getId(): int
     {
-        return $this->id;
+        return (int) $this->id;
     }
 
     /**


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  |  n |
| Fixed tickets? |  n |
| Documentation? | n  |

Forgot one fix:

The field 'EMS\CoreBundle\Entity\Form\Search#id' has the property type 'int' that differs from the metadata field type 'string' returned by the 'bigint' DBAL type.

Plus by accident did a direct commit on 5.12: https://github.com/ems-project/elasticms/commit/ac8172082fb3b93123c3c95db4a29214d0af66d5

