### PR TITLE
fix(symfony/6.4): commands $defaultName is deprecated

### DIFF
--- a/EMS/client-helper-bundle/src/Command/HealthCheckCommand.php
+++ b/EMS/client-helper-bundle/src/Command/HealthCheckCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EMS\ClientHelperBundle\Command;
 
+use EMS\ClientHelperBundle\Commands;
 use EMS\ClientHelperBundle\Exception\ClusterHealthNotGreenException;
 use EMS\ClientHelperBundle\Exception\ClusterHealthRedException;
 use EMS\ClientHelperBundle\Exception\IndexNotFoundException;
@@ -11,14 +12,18 @@ use EMS\ClientHelperBundle\Helper\Environment\EnvironmentHelper;
 use EMS\CommonBundle\Common\Command\AbstractCommand;
 use EMS\CommonBundle\Service\ElasticaService;
 use EMS\CommonBundle\Storage\StorageManager;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::HEALTH_CHECK,
+    description: 'Performs system health check.',
+    hidden: false
+)]
 final class HealthCheckCommand extends AbstractCommand
 {
-    protected static $defaultName = 'emsch:health-check';
-
     public function __construct(
         private readonly EnvironmentHelper $environmentHelper,
         private readonly ElasticaService $elasticaService,
@@ -29,7 +34,7 @@ final class HealthCheckCommand extends AbstractCommand
 
     protected function configure(): void
     {
-        $this->setDescription('Performs system health check.')
+        $this
             ->setHelp('Verify that the assets folder exists and is not empty. Verify that the Elasticsearch cluster is at least yellow and that the configured indexes exist.')
             ->addOption('green', 'g', InputOption::VALUE_NONE, 'Require a green Elasticsearch cluster health.', null)
             ->addOption('skip-storage', 's', InputOption::VALUE_NONE, 'Skip the storage health check.', null);

--- a/EMS/client-helper-bundle/src/Commands.php
+++ b/EMS/client-helper-bundle/src/Commands.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\ClientHelperBundle;
+
+final class Commands
+{
+    public const HEALTH_CHECK = 'emsch:health-check';
+}

--- a/EMS/common-bundle/src/Command/Admin/CommandCommand.php
+++ b/EMS/common-bundle/src/Command/Admin/CommandCommand.php
@@ -7,15 +7,19 @@ namespace EMS\CommonBundle\Command\Admin;
 use EMS\CommonBundle\Commands;
 use EMS\CommonBundle\Common\Admin\AdminHelper;
 use EMS\CommonBundle\Common\Command\AbstractCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::ADMIN_COMMAND,
+    hidden: false
+)]
 class CommandCommand extends AbstractCommand
 {
     final public const COMMAND = 'remote-command';
-    protected static $defaultName = Commands::ADMIN_COMMAND;
     private string $command;
 
     public function __construct(private readonly AdminHelper $adminHelper)

--- a/EMS/common-bundle/src/Command/Admin/NextJobCommand.php
+++ b/EMS/common-bundle/src/Command/Admin/NextJobCommand.php
@@ -8,17 +8,22 @@ use EMS\CommonBundle\Commands;
 use EMS\CommonBundle\Common\Admin\AdminHelper;
 use EMS\CommonBundle\Common\Command\AbstractCommand;
 use EMS\CommonBundle\Common\Job\JobManager;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::ADMIN_NEXT_JOB,
+    description: 'Contact the admin to check if a job is planned for the given tag and run it locally.',
+    hidden: false
+)]
 class NextJobCommand extends AbstractCommand
 {
     final public const TAG_ARGUMENT = 'tag';
     final public const SILENT_OPTION = 'silent';
-    protected static $defaultName = Commands::ADMIN_NEXT_JOB;
     private string $tag;
     private bool $silent;
 
@@ -30,7 +35,6 @@ class NextJobCommand extends AbstractCommand
     protected function configure(): void
     {
         parent::configure();
-        $this->setDescription('Contact the admin to check if a job is planned for the given tag and run it locally');
         $this->addArgument(self::TAG_ARGUMENT, InputArgument::REQUIRED, 'Tag that identifies the scheduled jobs');
         $this->addOption(self::SILENT_OPTION, null, InputOption::VALUE_NONE, 'Dont echo outputs in the console (only in the admin job logs)');
     }

--- a/EMS/common-bundle/src/Command/ClearLogsCommand.php
+++ b/EMS/common-bundle/src/Command/ClearLogsCommand.php
@@ -7,13 +7,18 @@ namespace EMS\CommonBundle\Command;
 use EMS\CommonBundle\Commands;
 use EMS\CommonBundle\Common\Command\AbstractCommand;
 use EMS\CommonBundle\Repository\LogRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::CLEAR_LOGS,
+    description: 'Clear doctrine logs.',
+    hidden: false
+)]
 class ClearLogsCommand extends AbstractCommand
 {
-    protected static $defaultName = Commands::CLEAR_LOGS;
     private \DateTime $before;
     /** @var string[] */
     private array $channels = [];
@@ -28,7 +33,6 @@ class ClearLogsCommand extends AbstractCommand
 
     protected function configure(): void
     {
-        $this->setDescription('Clear doctrine logs');
         $this
             ->addOption(self::OPTION_BEFORE, null, InputOption::VALUE_OPTIONAL, 'CLear logs older than the strtotime (-1day, -5min, now)', '-1week')
             ->addOption(self::OPTION_CHANNEL, null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Define channels default [app]', ['app'])

--- a/EMS/common-bundle/src/Command/CurlCommand.php
+++ b/EMS/common-bundle/src/Command/CurlCommand.php
@@ -10,6 +10,7 @@ use EMS\CommonBundle\Helper\EmsFields;
 use EMS\CommonBundle\Storage\Service\StorageInterface;
 use EMS\CommonBundle\Storage\StorageManager;
 use EMS\CommonBundle\Twig\AssetRuntime;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -24,6 +25,11 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
+#[AsCommand(
+    name: Commands::CURL,
+    description: 'Curl an internal resource.',
+    hidden: false
+)]
 class CurlCommand extends AbstractCommand
 {
     final public const ARGUMENT_URL = 'url';
@@ -31,7 +37,6 @@ class CurlCommand extends AbstractCommand
     final public const OPTION_METHOD = 'method';
     final public const OPTION_BASE_URL = 'base-url';
     final public const OPTION_SAVE = 'save';
-    protected static $defaultName = Commands::CURL;
     private ?SessionInterface $session = null;
 
     private string $url;
@@ -47,7 +52,6 @@ class CurlCommand extends AbstractCommand
 
     protected function configure(): void
     {
-        $this->setDescription('Curl an internal resource');
         $this->addArgument(self::ARGUMENT_URL, InputArgument::REQUIRED, 'Absolute url to the resource');
         $this->addArgument(self::ARGUMENT_FILENAME, InputArgument::REQUIRED, 'Filename where to save the ouput');
         $this->addOption(self::OPTION_METHOD, null, InputOption::VALUE_OPTIONAL, 'HTTP method (GET, POST)', 'GET');

--- a/EMS/common-bundle/src/Command/StatusCommand.php
+++ b/EMS/common-bundle/src/Command/StatusCommand.php
@@ -8,13 +8,18 @@ use EMS\CommonBundle\Commands;
 use EMS\CommonBundle\Common\Command\AbstractCommand;
 use EMS\CommonBundle\Service\ElasticaService;
 use EMS\CommonBundle\Storage\StorageManager;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::STATUS,
+    description: 'Returns the health status of the elasticsearch cluster and of the different storage services.',
+    hidden: false
+)]
 class StatusCommand extends AbstractCommand
 {
-    protected static $defaultName = Commands::STATUS;
     private const OPTION_TIMEOUT = 'timeout';
     private const OPTION_SILENT = 'silent';
     private const OPTION_WAIT_FOR_STATUS = 'wait-for-status';
@@ -26,7 +31,7 @@ class StatusCommand extends AbstractCommand
 
     protected function configure(): void
     {
-        $this->setDescription('Returns the health status of the elasticsearch cluster and of the different storage services.')
+        $this
             ->addOption(
                 self::OPTION_SILENT,
                 null,

--- a/EMS/core-bundle/src/Command/ActivateContentTypeCommand.php
+++ b/EMS/core-bundle/src/Command/ActivateContentTypeCommand.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace EMS\CoreBundle\Command;
 
 use EMS\CommonBundle\Helper\EmsFields;
+use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Service\ContentTypeService;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputArgument;
@@ -16,9 +18,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(
+    name: Commands::CONTENT_TYPE_ACTIVATE,
+    description: 'Activate a content type.',
+    hidden: false,
+    aliases: ['ems:contenttype:activate']
+)]
 class ActivateContentTypeCommand extends Command
 {
-    protected static $defaultName = 'ems:contenttype:activate';
     private ?SymfonyStyle $io = null;
     private ?bool $deactivate = null;
 

--- a/EMS/core-bundle/src/Command/AlignManagedAliases.php
+++ b/EMS/core-bundle/src/Command/AlignManagedAliases.php
@@ -2,17 +2,23 @@
 
 namespace EMS\CoreBundle\Command;
 
+use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Service\AliasService;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::MANAGED_ALIAS_ALIGN,
+    description: 'Align a managed alias to another.',
+    hidden: false,
+    aliases: ['ems:managedalias:align']
+)]
 class AlignManagedAliases extends Command
 {
-    protected static $defaultName = 'ems:managedalias:align';
-
     public function __construct(protected LoggerInterface $logger, protected AliasService $aliasService)
     {
         parent::__construct();
@@ -20,7 +26,7 @@ class AlignManagedAliases extends Command
 
     protected function configure(): void
     {
-        $this->setDescription('Align a managed alias to another')
+        $this
             ->addArgument(
                 'source',
                 InputArgument::REQUIRED,

--- a/EMS/core-bundle/src/Command/Asset/HeadAssetCommand.php
+++ b/EMS/core-bundle/src/Command/Asset/HeadAssetCommand.php
@@ -4,27 +4,29 @@ declare(strict_types=1);
 
 namespace EMS\CoreBundle\Command\Asset;
 
+use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Entity\UploadedAsset;
 use EMS\CoreBundle\Service\FileService;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(
+    name: Commands::ASSET_HEAD,
+    description: 'Loop over all known uploaded assets and update the seen information if the file is connected.',
+    hidden: false,
+    aliases: ['ems:asset:head']
+)]
 final class HeadAssetCommand extends Command
 {
-    protected static $defaultName = 'ems:asset:head';
     private SymfonyStyle $io;
 
     public function __construct(protected LoggerInterface $logger, protected FileService $fileService)
     {
         parent::__construct();
-    }
-
-    protected function configure(): void
-    {
-        $this->setDescription('Loop over all known uploaded assets and update the seen information if the file is connected');
     }
 
     protected function initialize(InputInterface $input, OutputInterface $output): void

--- a/EMS/core-bundle/src/Command/Check/AliasesCheckCommand.php
+++ b/EMS/core-bundle/src/Command/Check/AliasesCheckCommand.php
@@ -4,21 +4,26 @@ declare(strict_types=1);
 
 namespace EMS\CoreBundle\Command\Check;
 
-use EMS\CoreBundle\Command\RebuildCommand;
+use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Entity\User;
 use EMS\CoreBundle\Service\AliasService;
 use EMS\CoreBundle\Service\EnvironmentService;
 use EMS\CoreBundle\Service\JobService;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(
+    name: Commands::MANAGED_ALIAS_CHECK,
+    description: 'Checks that all managed environments have their corresponding alias and index present in the cluster.',
+    hidden: false,
+    aliases: ['ems:check:aliases']
+)]
 final class AliasesCheckCommand extends Command
 {
-    protected static $defaultName = self::COMMAND;
-    public const COMMAND = 'ems:check:aliases';
     private const OPTION_REPAIR = 'repair';
     private SymfonyStyle $io;
     private bool $repair = false;
@@ -30,7 +35,7 @@ final class AliasesCheckCommand extends Command
 
     protected function configure(): void
     {
-        $this->setDescription('Checks that all managed environments have their corresponding alias and index present in the cluster.')
+        $this
             ->addOption(self::OPTION_REPAIR, null, InputOption::VALUE_NONE, 'If an environment does not have its alias present and if they are no pending job a rebuild job is queued.');
     }
 
@@ -63,9 +68,9 @@ final class AliasesCheckCommand extends Command
             }
 
             $fakeUser = new User();
-            $fakeUser->setUsername(self::COMMAND);
+            $fakeUser->setUsername(Commands::MANAGED_ALIAS_CHECK);
             $command = \join(' ', [
-                RebuildCommand::COMMAND,
+                Commands::ENVIRONMENT_REBUILD,
                 $environment->getName(),
             ]);
             $this->jobService->createCommand($fakeUser, $command);

--- a/EMS/core-bundle/src/Command/CleanAssetCommand.php
+++ b/EMS/core-bundle/src/Command/CleanAssetCommand.php
@@ -4,28 +4,29 @@ namespace EMS\CoreBundle\Command;
 
 use Doctrine\Bundle\DoctrineBundle\Registry;
 use Doctrine\ORM\EntityManager;
+use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Entity\Revision;
 use EMS\CoreBundle\Entity\UploadedAsset;
 use EMS\CoreBundle\Repository\RevisionRepository;
 use EMS\CoreBundle\Repository\UploadedAssetRepository;
 use EMS\CoreBundle\Service\FileService;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::ASSET_CLEAN,
+    description: 'Unreference useless assets (no files are deleted from storages).',
+    hidden: false,
+    aliases: ['ems:asset:clean']
+)]
 class CleanAssetCommand extends EmsCommand
 {
-    protected static $defaultName = 'ems:asset:clean';
-
     public function __construct(protected LoggerInterface $logger, protected Registry $doctrine, protected FileService $fileService)
     {
         parent::__construct();
-    }
-
-    protected function configure(): void
-    {
-        $this->setDescription('Unreference useless assets (no files are deleted from storages)');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/EMS/core-bundle/src/Command/CleanDeletedContentTypeCommand.php
+++ b/EMS/core-bundle/src/Command/CleanDeletedContentTypeCommand.php
@@ -4,6 +4,7 @@ namespace EMS\CoreBundle\Command;
 
 use Doctrine\Bundle\DoctrineBundle\Registry;
 use Doctrine\ORM\EntityManager;
+use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Entity\ContentType;
 use EMS\CoreBundle\Entity\FieldType;
 use EMS\CoreBundle\Entity\Revision;
@@ -16,23 +17,23 @@ use EMS\CoreBundle\Repository\TemplateRepository;
 use EMS\CoreBundle\Repository\ViewRepository;
 use EMS\CoreBundle\Service\Mapping;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
+#[AsCommand(
+    name: Commands::CONTENT_TYPE_CLEAN,
+    description: 'Clean all deleted content types.',
+    hidden: false,
+    aliases: ['ems:contenttype:clean']
+)]
 class CleanDeletedContentTypeCommand extends Command
 {
-    protected static $defaultName = 'ems:contenttype:clean';
-
     public function __construct(protected Registry $doctrine, protected LoggerInterface $logger, protected Mapping $mapping, protected ContainerInterface $container)
     {
         parent::__construct();
-    }
-
-    protected function configure(): void
-    {
-        $this->setDescription('Clean all deleted content types');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/EMS/core-bundle/src/Command/ContentType/SwitchDefaultCommand.php
+++ b/EMS/core-bundle/src/Command/ContentType/SwitchDefaultCommand.php
@@ -8,14 +8,19 @@ use EMS\CoreBundle\Entity\ContentType;
 use EMS\CoreBundle\Entity\Environment;
 use EMS\CoreBundle\Service\ContentTypeService;
 use EMS\CoreBundle\Service\EnvironmentService;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::CONTENT_TYPE_SWITCH_DEFAULT_ENV,
+    description: 'Switch the default environment for a given content type.',
+    hidden: false
+)]
 class SwitchDefaultCommand extends AbstractCommand
 {
     final public const CONTENT_TYPE_SWITCH_DEFAULT_ENV_USERNAME = 'CONTENT_TYPE_SWITCH_DEFAULT_ENV_USERNAME';
-    protected static $defaultName = Commands::CONTENT_TYPE_SWITCH_DEFAULT_ENV;
 
     private ContentType $contentType;
     private Environment $target;
@@ -31,7 +36,6 @@ class SwitchDefaultCommand extends AbstractCommand
     protected function configure(): void
     {
         $this
-            ->setDescription('Switch the default environment for a given content type')
             ->addArgument(self::ARGUMENT_CONTENT_TYPE, InputArgument::REQUIRED, 'ContentType')
             ->addArgument(self::ARGUMENT_TARGET_ENVIRONMENT, InputArgument::REQUIRED, 'Target environment');
     }

--- a/EMS/core-bundle/src/Command/ContentType/TransformCommand.php
+++ b/EMS/core-bundle/src/Command/ContentType/TransformCommand.php
@@ -11,11 +11,16 @@ use EMS\CoreBundle\Core\ContentType\Transformer\ContentTransformerInterface;
 use EMS\CoreBundle\Core\Revision\Search\RevisionSearcher;
 use EMS\CoreBundle\Entity\ContentType;
 use EMS\CoreBundle\Service\ContentTypeService;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::CONTENT_TYPE_TRANSFORM,
+    hidden: false
+)]
 final class TransformCommand extends AbstractCommand
 {
     private ContentType $contentType;
@@ -28,8 +33,6 @@ final class TransformCommand extends AbstractCommand
     public const OPTION_SEARCH_QUERY = 'search-query';
     public const OPTION_DRY_RUN = 'dry-run';
     public const OPTION_USER = 'user';
-
-    protected static $defaultName = Commands::CONTENT_TYPE_TRANSFORM;
 
     public function __construct(
         private readonly RevisionSearcher $revisionSearcher,

--- a/EMS/core-bundle/src/Command/CreateEnvironmentCommand.php
+++ b/EMS/core-bundle/src/Command/CreateEnvironmentCommand.php
@@ -2,9 +2,11 @@
 
 namespace EMS\CoreBundle\Command;
 
+use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Service\DataService;
 use EMS\CoreBundle\Service\EnvironmentService;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -12,10 +14,14 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(
+    name: Commands::ENVIRONMENT_CREATE,
+    description: 'Create a new environment.',
+    hidden: false,
+    aliases: ['ems:environment:create']
+)]
 class CreateEnvironmentCommand extends Command
 {
-    protected static $defaultName = 'ems:environment:create';
-
     private ?SymfonyStyle $io = null;
 
     final public const ARGUMENT_ENV_NAME = 'name';
@@ -30,7 +36,6 @@ class CreateEnvironmentCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setDescription('Create a new environment')
             ->addArgument(
                 self::ARGUMENT_ENV_NAME,
                 InputArgument::REQUIRED,

--- a/EMS/core-bundle/src/Command/DeleteOrphanIndexesCommand.php
+++ b/EMS/core-bundle/src/Command/DeleteOrphanIndexesCommand.php
@@ -2,22 +2,23 @@
 
 namespace EMS\CoreBundle\Command;
 
+use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Service\IndexService;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::DELETE_ORPHANS,
+    description: 'Removes all orphan indexes.',
+    hidden: false,
+    aliases: ['ems:delete:orphans']
+)]
 class DeleteOrphanIndexesCommand extends EmsCommand
 {
-    protected static $defaultName = 'ems:delete:orphans';
-
     public function __construct(protected IndexService $indexService)
     {
         parent::__construct();
-    }
-
-    protected function configure(): void
-    {
-        $this->setDescription('Removes all orphan indexes');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/EMS/core-bundle/src/Command/DocumentCommand.php
+++ b/EMS/core-bundle/src/Command/DocumentCommand.php
@@ -2,6 +2,7 @@
 
 namespace EMS\CoreBundle\Command;
 
+use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Entity\ContentType;
 use EMS\CoreBundle\Exception\CantBeFinalizedException;
 use EMS\CoreBundle\Exception\NotLockedException;
@@ -9,6 +10,7 @@ use EMS\CoreBundle\Helper\Archive;
 use EMS\CoreBundle\Service\ContentTypeService;
 use EMS\CoreBundle\Service\DataService;
 use EMS\CoreBundle\Service\DocumentService;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -17,6 +19,12 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Finder\Finder;
 
+#[AsCommand(
+    name: Commands::CONTENT_TYPE_IMPORT,
+    description: 'Import json files from a zip file as content type\'s documents.',
+    hidden: false,
+    aliases: ['ems:contenttype:import']
+)]
 class DocumentCommand extends Command
 {
     final public const COMMAND = 'ems:contenttype:import';
@@ -44,7 +52,6 @@ class DocumentCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setDescription('Import json files from a zip file as content type\'s documents')
             ->addArgument(
                 self::ARGUMENT_CONTENT_TYPE,
                 InputArgument::REQUIRED,

--- a/EMS/core-bundle/src/Command/DocumentCommand.php
+++ b/EMS/core-bundle/src/Command/DocumentCommand.php
@@ -37,9 +37,6 @@ class DocumentCommand extends Command
     private const OPTION_FORCE = 'force';
     private const OPTION_DONT_FINALIZE = 'dont-finalize';
     private const OPTION_BUSINESS_KEY = 'business-key';
-
-    /** @var string */
-    protected static $defaultName = self::COMMAND;
     private ?SymfonyStyle $io = null;
     private ?ContentType $contentType = null;
     private ?string $archiveFilename = null;

--- a/EMS/core-bundle/src/Command/EmailSubmissionsCommand.php
+++ b/EMS/core-bundle/src/Command/EmailSubmissionsCommand.php
@@ -3,19 +3,25 @@
 namespace EMS\CoreBundle\Command;
 
 use EMS\CommonBundle\Command\CommandInterface;
+use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Core\Mail\MailerService;
 use EMS\CoreBundle\Service\Form\Submission\FormSubmissionService;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::SUBMISSIONS_EMAIL,
+    description: 'Send a list of form submissions to the specified email address or addresses.',
+    hidden: false,
+    aliases: ['ems:submissions:email']
+)]
 class EmailSubmissionsCommand extends Command implements CommandInterface
 {
-    protected static $defaultName = 'ems:submissions:email';
-
     private const TITLE = 'Form submissions';
 
     public function __construct(protected FormSubmissionService $formSubmissionService, protected LoggerInterface $logger, protected MailerService $mailerService)
@@ -25,7 +31,7 @@ class EmailSubmissionsCommand extends Command implements CommandInterface
 
     protected function configure(): void
     {
-        $this->setDescription('Send a list of form submissions to the specified email address or addresses')
+        $this
             ->addArgument(
                 'emails',
                 InputArgument::IS_ARRAY | InputArgument::REQUIRED,

--- a/EMS/core-bundle/src/Command/Environment/AlignCommand.php
+++ b/EMS/core-bundle/src/Command/Environment/AlignCommand.php
@@ -6,11 +6,17 @@ namespace EMS\CoreBundle\Command\Environment;
 
 use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Entity\Environment;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::ENVIRONMENT_ALIGN,
+    description: 'Align an environment from another one.',
+    hidden: false
+)]
 class AlignCommand extends AbstractEnvironmentCommand
 {
     private Environment $source;
@@ -23,8 +29,6 @@ class AlignCommand extends AbstractEnvironmentCommand
     final public const OPTION_PUBLICATION_TEMPLATE = 'publication-template';
 
     private const LOCK_USER = 'SYSTEM_ALIGN';
-
-    protected static $defaultName = Commands::ENVIRONMENT_ALIGN;
 
     /** @var array<string, int> */
     private array $counters = [
@@ -44,7 +48,6 @@ class AlignCommand extends AbstractEnvironmentCommand
     protected function configure(): void
     {
         $this
-            ->setDescription('Align an environment from another one')
             ->addArgument(self::ARGUMENT_SOURCE, InputArgument::REQUIRED, 'Environment source name')
             ->addArgument(self::ARGUMENT_TARGET, InputArgument::REQUIRED, 'Environment target name')
             ->addOption(self::OPTION_SNAPSHOT, null, InputOption::VALUE_NONE, 'If set, the target environment will be tagged as a snapshot after the alignment')

--- a/EMS/core-bundle/src/Command/Environment/UnpublishCommand.php
+++ b/EMS/core-bundle/src/Command/Environment/UnpublishCommand.php
@@ -6,10 +6,16 @@ namespace EMS\CoreBundle\Command\Environment;
 
 use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Entity\Environment;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::ENVIRONMENT_UNPUBLISH,
+    description: 'Unpublish revision from an environment.',
+    hidden: false
+)]
 final class UnpublishCommand extends AbstractEnvironmentCommand
 {
     private Environment $environment;
@@ -21,12 +27,9 @@ final class UnpublishCommand extends AbstractEnvironmentCommand
 
     private const LOCK_USER = 'SYSTEM_UNPUBLISH';
 
-    protected static $defaultName = Commands::ENVIRONMENT_UNPUBLISH;
-
     protected function configure(): void
     {
         $this
-            ->setDescription('Unpublish revision from an environment')
             ->addArgument(self::ARGUMENT_ENVIRONMENT, InputArgument::REQUIRED, 'Environment name')
         ;
 

--- a/EMS/core-bundle/src/Command/EnvironmentCommand.php
+++ b/EMS/core-bundle/src/Command/EnvironmentCommand.php
@@ -2,17 +2,23 @@
 
 namespace EMS\CoreBundle\Command;
 
+use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Entity\Environment;
 use EMS\CoreBundle\Service\EnvironmentService;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::ENVIRONMENT_LIST,
+    description: 'List the environments defined.',
+    hidden: false,
+    aliases: ['ems:environment:list']
+)]
 class EnvironmentCommand extends Command
 {
-    protected static $defaultName = 'ems:environment:list';
-
     public function __construct(private readonly EnvironmentService $environmentService)
     {
         parent::__construct();
@@ -20,7 +26,7 @@ class EnvironmentCommand extends Command
 
     protected function configure(): void
     {
-        $this->setDescription('List the environments defined')
+        $this
             ->addOption(
                 'all',
                 null,

--- a/EMS/core-bundle/src/Command/ExportDocumentsCommand.php
+++ b/EMS/core-bundle/src/Command/ExportDocumentsCommand.php
@@ -6,6 +6,7 @@ use EMS\CommonBundle\Elasticsearch\Document\Document;
 use EMS\CommonBundle\Helper\EmsFields;
 use EMS\CommonBundle\Service\ElasticaService;
 use EMS\CommonBundle\Twig\AssetRuntime;
+use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Entity\ContentType;
 use EMS\CoreBundle\Service\ContentTypeService;
 use EMS\CoreBundle\Service\DataService;
@@ -13,6 +14,7 @@ use EMS\CoreBundle\Service\EnvironmentService;
 use EMS\CoreBundle\Service\TemplateService;
 use EMS\Helpers\Standard\Json;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -21,9 +23,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig\Error\Error;
 
+#[AsCommand(
+    name: Commands::CONTENT_TYPE_EXPORT,
+    description: 'Export a search result of a content type to a specific format.',
+    hidden: false,
+    aliases: ['ems:contenttype:export']
+)]
 class ExportDocumentsCommand extends EmsCommand
 {
-    protected static $defaultName = 'ems:contenttype:export';
     final public const OUTPUT_FILE_ARGUMENT = 'outputFile';
 
     public function __construct(protected LoggerInterface $logger, protected TemplateService $templateService, protected DataService $dataService, protected ContentTypeService $contentTypeService, protected EnvironmentService $environmentService, protected AssetRuntime $runtime, private readonly ElasticaService $elasticaService, protected string $instanceId)
@@ -33,7 +40,7 @@ class ExportDocumentsCommand extends EmsCommand
 
     protected function configure(): void
     {
-        $this->setDescription('Export a search result of a content type to a specific format')
+        $this
             ->addArgument(
                 'contentTypeName',
                 InputArgument::REQUIRED,

--- a/EMS/core-bundle/src/Command/ExtractAssetCommand.php
+++ b/EMS/core-bundle/src/Command/ExtractAssetCommand.php
@@ -3,8 +3,10 @@
 namespace EMS\CoreBundle\Command;
 
 use EMS\CommonBundle\Storage\StorageManager;
+use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Service\AssetExtractorService;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -12,10 +14,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
+#[AsCommand(
+    name: Commands::ASSET_EXTRACT,
+    description: 'Will extract data from all files found and load it in cache of the asset extractor service.',
+    hidden: false,
+    aliases: ['ems:asset:extract']
+)]
 class ExtractAssetCommand extends EmsCommand
 {
-    protected static $defaultName = 'ems:asset:extract';
-
     public function __construct(protected LoggerInterface $logger, protected AssetExtractorService $extractorService, protected StorageManager $storageManager)
     {
         parent::__construct();
@@ -23,12 +29,11 @@ class ExtractAssetCommand extends EmsCommand
 
     protected function configure(): void
     {
-        $this->setDescription('Will extract data from all files found and load it in cache of the asset extractor service')
-            ->addArgument(
-                'path',
-                InputArgument::REQUIRED,
-                'Path to the files to extract data from'
-            )
+        $this->addArgument(
+            'path',
+            InputArgument::REQUIRED,
+            'Path to the files to extract data from'
+        )
             ->addArgument(
                 'name',
                 InputArgument::OPTIONAL,

--- a/EMS/core-bundle/src/Command/IndexFileCommand.php
+++ b/EMS/core-bundle/src/Command/IndexFileCommand.php
@@ -6,12 +6,14 @@ use Doctrine\Bundle\DoctrineBundle\Registry;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManager;
 use EMS\CommonBundle\Helper\EmsFields;
+use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Entity\Revision;
 use EMS\CoreBundle\Repository\RevisionRepository;
 use EMS\CoreBundle\Service\AssetExtractorService;
 use EMS\CoreBundle\Service\ContentTypeService;
 use EMS\CoreBundle\Service\FileService;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputArgument;
@@ -20,6 +22,12 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
+#[AsCommand(
+    name: Commands::REVISIONS_INDEX_FILE_FIELDS,
+    description: 'Migrate an ingested file field from an elasticsearch index.',
+    hidden: false,
+    aliases: ['ems:revisions:index-file-fields']
+)]
 class IndexFileCommand extends EmsCommand
 {
     protected static $defaultName = 'ems:revisions:index-file-fields';
@@ -37,7 +45,7 @@ class IndexFileCommand extends EmsCommand
 
     protected function configure(): void
     {
-        $this->setDescription('Migrate an ingested file field from an elasticsearch index')
+        $this
             ->addArgument(
                 'contentType',
                 InputArgument::REQUIRED,

--- a/EMS/core-bundle/src/Command/IndexFileCommand.php
+++ b/EMS/core-bundle/src/Command/IndexFileCommand.php
@@ -30,7 +30,6 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 )]
 class IndexFileCommand extends EmsCommand
 {
-    protected static $defaultName = 'ems:revisions:index-file-fields';
     /** @var string */
     private const SYSTEM_USERNAME = 'SYSTEM_FILE_INDEXER';
     /** @var string */

--- a/EMS/core-bundle/src/Command/JobCommand.php
+++ b/EMS/core-bundle/src/Command/JobCommand.php
@@ -3,17 +3,24 @@
 namespace EMS\CoreBundle\Command;
 
 use EMS\CommonBundle\Common\Command\AbstractCommand;
+use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Entity\Job;
 use EMS\CoreBundle\Service\JobService;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::JOB_RUN,
+    description: 'Execute the next pending job if exists. If not execute the oldest due scheduled job if exists.',
+    hidden: false,
+    aliases: ['ems:job:run']
+)]
 class JobCommand extends AbstractCommand
 {
     private const OPTION_DUMP = 'dump';
     private const OPTION_TAG = 'tag';
-    protected static $defaultName = 'ems:job:run';
     private const USER_JOB_COMMAND = 'User-Job-Command';
     private bool $dump = false;
     private ?string $tag = null;
@@ -28,7 +35,7 @@ class JobCommand extends AbstractCommand
 
     protected function configure(): void
     {
-        $this->setDescription('Execute the next pending job if exists. If not execute the oldest due scheduled job if exists.')
+        $this
             ->addOption(
                 self::OPTION_DUMP,
                 null,

--- a/EMS/core-bundle/src/Command/LockCommand.php
+++ b/EMS/core-bundle/src/Command/LockCommand.php
@@ -8,9 +8,11 @@ use EMS\CommonBundle\Elasticsearch\Document\Document;
 use EMS\CommonBundle\Elasticsearch\Document\DocumentInterface;
 use EMS\CommonBundle\Search\Search;
 use EMS\CommonBundle\Service\ElasticaService;
+use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Entity\ContentType;
 use EMS\CoreBundle\Repository\ContentTypeRepository;
 use EMS\CoreBundle\Repository\RevisionRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -18,6 +20,12 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(
+    name: Commands::CONTENT_TYPE_LOCK,
+    description: 'Lock a content type.',
+    hidden: false,
+    aliases: ['ems:contenttype:lock']
+)]
 final class LockCommand extends Command
 {
     private string $by;
@@ -37,9 +45,6 @@ final class LockCommand extends Command
 
     public const RESULT_SUCCESS = 0;
 
-    public const name = 'ems:contenttype:lock';
-    protected static $defaultName = self::name;
-
     public function __construct(private readonly ContentTypeRepository $contentTypeRepository, private readonly ElasticaService $elasticaService, private readonly RevisionRepository $revisionRepository)
     {
         parent::__construct();
@@ -48,7 +53,6 @@ final class LockCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setDescription('Lock a content type')
             ->addArgument(self::ARGUMENT_CONTENT_TYPE, InputArgument::REQUIRED, 'content type to recompute')
             ->addArgument(self::ARGUMENT_TIME, InputArgument::REQUIRED, 'lock until (+1day, +5min, now)')
             ->addOption(self::OPTION_QUERY, null, InputOption::VALUE_OPTIONAL, 'ES query', '{}')

--- a/EMS/core-bundle/src/Command/ManageAlias/AddEnvironmentIndexCommand.php
+++ b/EMS/core-bundle/src/Command/ManageAlias/AddEnvironmentIndexCommand.php
@@ -9,18 +9,22 @@ use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Core\ManagedAlias\ManagedAliasManager;
 use EMS\CoreBundle\Service\EnvironmentService;
 use EMS\CoreBundle\Service\IndexService;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::MANAGED_ALIAS_ADD_ENVIRONMENT,
+    description: 'Add an environment\'s index to a managed alias.',
+    hidden: false
+)]
 final class AddEnvironmentIndexCommand extends AbstractCommand
 {
     public const ARGUMENT_MANAGED_ALIAS_NAME = 'managed-alias-name';
     public const ARGUMENT_ENVIRONMENT_NAME = 'environment-name';
     public const OPTION_CLEAR_ALIAS = 'clear-alias';
-
-    protected static $defaultName = Commands::MANAGED_ALIAS_ADD_ENVIRONMENT;
     private string $managedAliasName;
     private string $environmentName;
     private bool $clearAlias;

--- a/EMS/core-bundle/src/Command/ManageAlias/CreateCommand.php
+++ b/EMS/core-bundle/src/Command/ManageAlias/CreateCommand.php
@@ -8,16 +8,21 @@ use EMS\CommonBundle\Common\Command\AbstractCommand;
 use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Core\ManagedAlias\ManagedAliasManager;
 use EMS\CoreBundle\Entity\ManagedAlias;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::MANAGED_ALIAS_CREATE,
+    description: 'Create a managed alias.',
+    hidden: false,
+    aliases: ['ems:managed-alias:create']
+)]
 final class CreateCommand extends AbstractCommand
 {
     public const ARGUMENT_NAME = 'name';
     public const ARGUMENT_LABEL = 'label';
-
-    protected static $defaultName = Commands::MANAGED_ALIAS_CREATE;
     private string $name;
     private string $label;
 

--- a/EMS/core-bundle/src/Command/ManagedAliases.php
+++ b/EMS/core-bundle/src/Command/ManagedAliases.php
@@ -2,18 +2,24 @@
 
 namespace EMS\CoreBundle\Command;
 
+use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Entity\ManagedAlias;
 use EMS\CoreBundle\Service\AliasService;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::MANAGED_ALIAS_LIST,
+    description: 'List managed aliases.',
+    hidden: false,
+    aliases: ['ems:managedalias:list']
+)]
 class ManagedAliases extends Command
 {
-    protected static $defaultName = 'ems:managedalias:list';
-
     public function __construct(protected LoggerInterface $logger, protected AliasService $aliasService)
     {
         parent::__construct();
@@ -21,7 +27,7 @@ class ManagedAliases extends Command
 
     protected function configure(): void
     {
-        $this->setDescription('List managed aliases')
+        $this->setDescription('')
             ->addOption('detailed', null, InputOption::VALUE_NONE, 'List all indexes in each managed alias');
     }
 

--- a/EMS/core-bundle/src/Command/MigrateCommand.php
+++ b/EMS/core-bundle/src/Command/MigrateCommand.php
@@ -14,15 +14,20 @@ use EMS\CoreBundle\Exception\CantBeFinalizedException;
 use EMS\CoreBundle\Exception\NotLockedException;
 use EMS\CoreBundle\Repository\ContentTypeRepository;
 use EMS\CoreBundle\Service\DocumentService;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::CONTENT_TYPE_MIGRATE,
+    description: 'Migrate a content type from an elasticsearch index.',
+    hidden: false,
+    aliases: ['ems:contenttype:migrate']
+)]
 class MigrateCommand extends AbstractCommand
 {
-    protected static $defaultName = 'ems:contenttype:migrate';
-
     private string $elasticsearchIndex;
     private string $contentTypeNameFrom;
     private string $contentTypeNameTo;
@@ -75,7 +80,6 @@ class MigrateCommand extends AbstractCommand
     protected function configure(): void
     {
         $this
-            ->setDescription('Migrate a content type from an elasticsearch index')
             ->addArgument(
                 self::ARGUMENT_ELASTICSEARCH_INDEX,
                 InputArgument::REQUIRED,

--- a/EMS/core-bundle/src/Command/Notification/BulkActionCommand.php
+++ b/EMS/core-bundle/src/Command/Notification/BulkActionCommand.php
@@ -8,10 +8,12 @@ use EMS\CommonBundle\Elasticsearch\Document\Document;
 use EMS\CommonBundle\Elasticsearch\Document\DocumentInterface;
 use EMS\CommonBundle\Search\Search;
 use EMS\CommonBundle\Service\ElasticaService;
+use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Service\ContentTypeService;
 use EMS\CoreBundle\Service\EnvironmentService;
 use EMS\CoreBundle\Service\NotificationService;
 use EMS\CoreBundle\Service\Revision\RevisionService;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -19,9 +21,14 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(
+    name: Commands::NOTIFICATION_BULK_ACTION,
+    description: 'Bulk all notifications actions for the passed query.',
+    hidden: false,
+    aliases: ['ems:notification:bulk-action']
+)]
 final class BulkActionCommand extends Command
 {
-    protected static $defaultName = 'ems:notification:bulk-action';
     private const CONTENT_TYPE_NAME = 'contentTypeName';
     private SymfonyStyle $io;
 
@@ -37,7 +44,7 @@ final class BulkActionCommand extends Command
 
     protected function configure(): void
     {
-        $this->setDescription('Bulk all notifications actions for the passed query')
+        $this
             ->addArgument(self::CONTENT_TYPE_NAME, InputArgument::REQUIRED, 'Content type name')
             ->addArgument('actionName', InputArgument::REQUIRED, 'Notification action name')
             ->addArgument('query', InputArgument::REQUIRED, 'ES query')

--- a/EMS/core-bundle/src/Command/Notification/SendAllCommand.php
+++ b/EMS/core-bundle/src/Command/Notification/SendAllCommand.php
@@ -5,19 +5,25 @@ declare(strict_types=1);
 namespace EMS\CoreBundle\Command\Notification;
 
 use Doctrine\Bundle\DoctrineBundle\Registry;
+use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Entity\Notification;
 use EMS\CoreBundle\Repository\NotificationRepository;
 use EMS\CoreBundle\Service\NotificationService;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::NOTIFICATION_SEND,
+    description: 'Send all notifications and notification\'s responses emails.',
+    hidden: false,
+    aliases: ['ems:notification:send']
+)]
 final class SendAllCommand extends Command
 {
-    protected static $defaultName = 'ems:notification:send';
-
     public function __construct(private readonly Registry $doctrine, private readonly NotificationService $notificationService, private readonly string $notificationPendingTimeout)
     {
         parent::__construct();
@@ -25,7 +31,7 @@ final class SendAllCommand extends Command
 
     protected function configure(): void
     {
-        $this->setDescription('Send all notifications and notification\'s responses emails')
+        $this
             ->addOption(
                 'dry-run',
                 null,

--- a/EMS/core-bundle/src/Command/RebuildCommand.php
+++ b/EMS/core-bundle/src/Command/RebuildCommand.php
@@ -5,6 +5,7 @@ namespace EMS\CoreBundle\Command;
 use Doctrine\Bundle\DoctrineBundle\Registry;
 use Doctrine\Persistence\ObjectManager;
 use EMS\CommonBundle\Service\ElasticaService;
+use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Entity\ContentType;
 use EMS\CoreBundle\Entity\Environment;
 use EMS\CoreBundle\Repository\ContentTypeRepository;
@@ -14,16 +15,21 @@ use EMS\CoreBundle\Service\ContentTypeService;
 use EMS\CoreBundle\Service\EnvironmentService;
 use EMS\CoreBundle\Service\Mapping;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::ENVIRONMENT_REBUILD,
+    description: 'Rebuild an environment in a brand new index.',
+    hidden: false,
+    aliases: ['ems:environment:rebuild']
+)]
 class RebuildCommand extends EmsCommand
 {
     final public const ALL = 'all';
-    protected static $defaultName = self::COMMAND;
-    final public const COMMAND = 'ems:environment:rebuild';
     private bool $signData;
     private int $bulkSize;
     private ObjectManager $em;
@@ -37,7 +43,7 @@ class RebuildCommand extends EmsCommand
 
     protected function configure(): void
     {
-        $this->setDescription('Rebuild an environment in a brand new index')
+        $this
             ->addArgument(
                 'name',
                 InputArgument::OPTIONAL,

--- a/EMS/core-bundle/src/Command/RecomputeCommand.php
+++ b/EMS/core-bundle/src/Command/RecomputeCommand.php
@@ -7,6 +7,7 @@ namespace EMS\CoreBundle\Command;
 use Doctrine\Bundle\DoctrineBundle\Registry;
 use Doctrine\ORM\EntityManager;
 use EMS\CommonBundle\Elasticsearch\Exception\NotFoundException;
+use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Entity\ContentType;
 use EMS\CoreBundle\Entity\Notification;
 use EMS\CoreBundle\Entity\Revision;
@@ -19,6 +20,7 @@ use EMS\CoreBundle\Service\IndexService;
 use EMS\CoreBundle\Service\PublishService;
 use EMS\CoreBundle\Service\SearchService;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
@@ -28,9 +30,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Form\FormFactoryInterface;
 
+#[AsCommand(
+    name: Commands::CONTENT_TYPE_RECOMPUTE,
+    description: 'Recompute a content type.',
+    hidden: false,
+    aliases: ['ems:contenttype:recompute']
+)]
 final class RecomputeCommand extends Command
 {
-    protected static $defaultName = 'ems:contenttype:recompute';
     private ContentType $contentType;
     private bool $optionDeep;
     private bool $forceFlag;
@@ -72,7 +79,7 @@ final class RecomputeCommand extends Command
 
     protected function configure(): void
     {
-        $this->setDescription('Recompute a content type')
+        $this
             ->addArgument(self::ARGUMENT_CONTENT_TYPE, InputArgument::REQUIRED, 'content type to recompute')
             ->addOption(self::OPTION_FORCE, null, InputOption::VALUE_NONE, 'do not check for already locked revisions')
             ->addOption(self::OPTION_MISSING, null, InputOption::VALUE_NONE, 'will recompute the objects that are missing in their default environment only')

--- a/EMS/core-bundle/src/Command/ReindexCommand.php
+++ b/EMS/core-bundle/src/Command/ReindexCommand.php
@@ -5,6 +5,7 @@ namespace EMS\CoreBundle\Command;
 use Doctrine\Bundle\DoctrineBundle\Registry;
 use Doctrine\ORM\EntityManager;
 use EMS\CommonBundle\Helper\EmsFields;
+use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Elasticsearch\Bulker;
 use EMS\CoreBundle\Entity\ContentType;
 use EMS\CoreBundle\Entity\Environment;
@@ -16,15 +17,21 @@ use EMS\CoreBundle\Service\DataService;
 use EMS\CoreBundle\Service\Mapping;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::ENVIRONMENT_REINDEX,
+    description: 'Reindex an environment in it\'s existing index.',
+    hidden: false,
+    aliases: ['ems:environment:reindex']
+)]
 class ReindexCommand extends EmsCommand
 {
-    protected static $defaultName = 'ems:environment:reindex';
     private int $count = 0;
     private int $deleted = 0;
     private int $reloaded = 0;
@@ -37,7 +44,7 @@ class ReindexCommand extends EmsCommand
 
     protected function configure(): void
     {
-        $this->setDescription('Reindex an environment in it\'s existing index')
+        $this
             ->addArgument(
                 'name',
                 InputArgument::REQUIRED,

--- a/EMS/core-bundle/src/Command/Release/CreateReleaseCommand.php
+++ b/EMS/core-bundle/src/Command/Release/CreateReleaseCommand.php
@@ -20,15 +20,19 @@ use EMS\CoreBundle\Service\EnvironmentService;
 use EMS\CoreBundle\Service\ReleaseService;
 use EMS\CoreBundle\Service\Revision\RevisionService;
 use EMS\Helpers\Standard\Json;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::RELEASE_CREATE,
+    description: 'Add documents for a given contenttype in a release.',
+    hidden: false
+)]
 class CreateReleaseCommand extends AbstractCommand
 {
-    protected static $defaultName = Commands::RELEASE_CREATE;
-
     private ContentType $contentType;
     private Environment $target;
     /** @var array<mixed> */
@@ -46,7 +50,6 @@ class CreateReleaseCommand extends AbstractCommand
     protected function configure(): void
     {
         $this
-            ->setDescription('Add documents for a given contenttype in a release')
             ->addArgument(self::ARGUMENT_CONTENT_TYPE, InputArgument::REQUIRED, 'ContentType')
             ->addArgument(self::ARGUMENT_TARGET, InputArgument::REQUIRED, 'Target managed alias name')
             ->addOption(self::OPTION_QUERY, null, InputOption::VALUE_OPTIONAL, 'ES query', '{}');

--- a/EMS/core-bundle/src/Command/Release/PublishReleaseCommand.php
+++ b/EMS/core-bundle/src/Command/Release/PublishReleaseCommand.php
@@ -7,21 +7,20 @@ namespace EMS\CoreBundle\Command\Release;
 use EMS\CommonBundle\Common\Command\AbstractCommand;
 use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Service\ReleaseService;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::RELEASE_PUBLISH,
+    description: 'Publish scheduled releases.',
+    hidden: false
+)]
 class PublishReleaseCommand extends AbstractCommand
 {
-    protected static $defaultName = Commands::RELEASE_PUBLISH;
-
     public function __construct(private readonly ReleaseService $releaseService)
     {
         parent::__construct();
-    }
-
-    protected function configure(): void
-    {
-        $this->setDescription('Publish scheduled releases');
     }
 
     protected function initialize(InputInterface $input, OutputInterface $output): void

--- a/EMS/core-bundle/src/Command/RemoveExpiredSubmissionsCommand.php
+++ b/EMS/core-bundle/src/Command/RemoveExpiredSubmissionsCommand.php
@@ -3,24 +3,25 @@
 namespace EMS\CoreBundle\Command;
 
 use EMS\CommonBundle\Command\CommandInterface;
+use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Service\Form\Submission\FormSubmissionService;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::SUBMISSIONS_REMOVE_EXPIRED,
+    description: 'Removes all form submissions that are expired.',
+    hidden: false,
+    aliases: ['ems:submissions:remove-expired']
+)]
 class RemoveExpiredSubmissionsCommand extends Command implements CommandInterface
 {
-    protected static $defaultName = 'ems:submissions:remove-expired';
-
     public function __construct(protected FormSubmissionService $formSubmissionService, protected LoggerInterface $logger)
     {
         parent::__construct();
-    }
-
-    protected function configure(): void
-    {
-        $this->setDescription('Removes all form submissions that are expired');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/EMS/core-bundle/src/Command/Revision/ArchiveCommand.php
+++ b/EMS/core-bundle/src/Command/Revision/ArchiveCommand.php
@@ -11,18 +11,22 @@ use EMS\CoreBundle\Core\Revision\Search\RevisionSearcher;
 use EMS\CoreBundle\Entity\ContentType;
 use EMS\CoreBundle\Service\ContentTypeService;
 use EMS\CoreBundle\Service\Revision\RevisionService;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::REVISION_ARCHIVE,
+    description: 'Archive documents for a given content type.',
+    hidden: false
+)]
 final class ArchiveCommand extends AbstractCommand
 {
     private ContentType $contentType;
     private string $searchQuery;
     private ?\DateTimeInterface $modifiedBefore = null;
-
-    protected static $defaultName = Commands::REVISION_ARCHIVE;
     private const USER = 'SYSTEM_ARCHIVE';
 
     public const ARGUMENT_CONTENT_TYPE = 'content-type';

--- a/EMS/core-bundle/src/Command/Revision/CopyCommand.php
+++ b/EMS/core-bundle/src/Command/Revision/CopyCommand.php
@@ -11,11 +11,17 @@ use EMS\CoreBundle\Entity\Environment;
 use EMS\CoreBundle\Service\EnvironmentService;
 use EMS\CoreBundle\Service\Revision\RevisionService;
 use EMS\Helpers\Standard\Json;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::REVISION_COPY,
+    description: 'Copy revisions from search query.',
+    hidden: false
+)]
 final class CopyCommand extends AbstractCommand
 {
     private Environment $environment;
@@ -29,8 +35,6 @@ final class CopyCommand extends AbstractCommand
     public const OPTION_SCROLL_SIZE = 'scroll-size';
     public const OPTION_SCROLL_TIMEOUT = 'scroll-timeout';
 
-    protected static $defaultName = Commands::REVISION_COPY;
-
     public function __construct(
         private readonly RevisionSearcher $revisionSearcher,
         private readonly EnvironmentService $environmentService,
@@ -42,7 +46,6 @@ final class CopyCommand extends AbstractCommand
     protected function configure(): void
     {
         $this
-            ->setDescription('Copy revisions from search query')
             ->addArgument(self::ARGUMENT_ENVIRONMENT, InputArgument::REQUIRED, 'environment name')
             ->addArgument(self::ARGUMENT_SEARCH_QUERY, InputArgument::REQUIRED, 'search query')
             ->addArgument(self::ARGUMENT_MERGE_RAW_DATA, InputArgument::OPTIONAL, 'json merge raw data')

--- a/EMS/core-bundle/src/Command/Revision/DeleteCommand.php
+++ b/EMS/core-bundle/src/Command/Revision/DeleteCommand.php
@@ -11,14 +11,19 @@ use EMS\CoreBundle\Service\ContentTypeService;
 use EMS\CoreBundle\Service\PublishService;
 use EMS\CoreBundle\Service\Revision\RevisionService;
 use EMS\Helpers\Standard\Json;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::REVISION_DELETE,
+    description: 'Delete all/oldest revisions for content type(s).',
+    hidden: false
+)]
 class DeleteCommand extends AbstractCommand
 {
-    protected static $defaultName = Commands::REVISION_DELETE;
     private const ARGUMENT_CONTENT_TYPES = 'content-types';
     private const OPTION_MODE = 'mode';
     private const OPTION_QUERY = 'query';
@@ -45,7 +50,6 @@ class DeleteCommand extends AbstractCommand
     protected function configure(): void
     {
         $this
-            ->setDescription('Delete all/oldest revisions for content type(s)')
             ->addArgument(self::ARGUMENT_CONTENT_TYPES, InputArgument::IS_ARRAY, 'contentType names or "all"')
             ->addOption(self::OPTION_MODE, null, InputOption::VALUE_REQUIRED, 'mode for deletion [all,oldest,by-query]', 'all')
             ->addOption(self::OPTION_QUERY, null, InputOption::VALUE_OPTIONAL, 'query to use in by-query mode')

--- a/EMS/core-bundle/src/Command/Revision/DiscardDraftCommand.php
+++ b/EMS/core-bundle/src/Command/Revision/DiscardDraftCommand.php
@@ -9,18 +9,23 @@ use EMS\CommonBundle\Common\Standard\DateTime;
 use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Service\DataService;
 use EMS\CoreBundle\Service\Revision\RevisionService;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::REVISION_DISCARD_DRAFT,
+    description: 'Discard drafts for content types.',
+    hidden: false
+)]
 class DiscardDraftCommand extends AbstractCommand
 {
     private const ARGUMENT_CONTENT_TYPES = 'content-types';
     private const OPTION_FORCE = 'force';
     private const OPTION_OLDER = 'older';
     private const DISCARD_DRAFT_COMMAND_USER = 'DISCARD_DRAFT_COMMAND_USER';
-    protected static $defaultName = Commands::REVISION_DISCARD_DRAFT;
     /**
      * @var string[]
      */
@@ -35,7 +40,7 @@ class DiscardDraftCommand extends AbstractCommand
 
     protected function configure(): void
     {
-        $this->setDescription('Discard drafts for content types')
+        $this
             ->addArgument(self::ARGUMENT_CONTENT_TYPES, InputArgument::IS_ARRAY, 'ContentType names')
             ->addOption(self::OPTION_FORCE, null, InputOption::VALUE_NONE, 'Also discard drafts with auto-saved content')
             ->addOption(self::OPTION_OLDER, null, InputOption::VALUE_REQUIRED, 'Discard revision that are older than this  (time format)', '-5minutes');

--- a/EMS/core-bundle/src/Command/Revision/TaskCreateCommand.php
+++ b/EMS/core-bundle/src/Command/Revision/TaskCreateCommand.php
@@ -16,11 +16,16 @@ use EMS\CoreBundle\Entity\Revision;
 use EMS\CoreBundle\Service\EnvironmentService;
 use EMS\CoreBundle\Service\UserService;
 use EMS\Helpers\Standard\Json;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::REVISION_TASK_CREATE,
+    hidden: false
+)]
 final class TaskCreateCommand extends AbstractCommand
 {
     private Environment $environment;
@@ -44,8 +49,6 @@ final class TaskCreateCommand extends AbstractCommand
     public const OPTION_SCROLL_SIZE = 'scroll-size';
     public const OPTION_SCROLL_TIMEOUT = 'scroll-timeout';
     public const OPTION_SEARCH_QUERY = 'search-query';
-
-    protected static $defaultName = Commands::REVISION_TASK_CREATE;
 
     public function __construct(
         private readonly RevisionSearcher $revisionSearcher,

--- a/EMS/core-bundle/src/Command/Revision/TimeMachineCommand.php
+++ b/EMS/core-bundle/src/Command/Revision/TimeMachineCommand.php
@@ -8,21 +8,27 @@ use Doctrine\Bundle\DoctrineBundle\Registry;
 use Doctrine\Persistence\ObjectManager;
 use EMS\CommonBundle\Common\EMSLink;
 use EMS\CommonBundle\Common\Standard\DateTime;
+use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Service\DataService;
 use EMS\CoreBundle\Service\IndexService;
 use EMS\CoreBundle\Service\Revision\RevisionService;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(
+    name: Commands::REVISIONS_TIME_MACHINE,
+    description: 'Revert to a copy of the revision wich was the current one for a given timestamp.',
+    hidden: false,
+    aliases: ['ems:revision:time-machine']
+)]
 final class TimeMachineCommand extends Command
 {
     private SymfonyStyle $style;
     private readonly ObjectManager $em;
-
-    protected static $defaultName = 'ems:revision:time-machine';
 
     private const SYSTEM_TIME_MACHINE = 'SYSTEM_TIME_MACHINE';
     public const RESULT_NOT_FOUND = 1;

--- a/EMS/core-bundle/src/Command/SynchronizeAssetCommand.php
+++ b/EMS/core-bundle/src/Command/SynchronizeAssetCommand.php
@@ -5,19 +5,26 @@ namespace EMS\CoreBundle\Command;
 use Doctrine\Bundle\DoctrineBundle\Registry;
 use Doctrine\ORM\EntityManager;
 use EMS\CommonBundle\Storage\NotFoundException;
+use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Entity\UploadedAsset;
 use EMS\CoreBundle\Repository\UploadedAssetRepository;
 use EMS\CoreBundle\Service\AssetExtractorService;
 use EMS\CoreBundle\Service\ContentTypeService;
 use EMS\CoreBundle\Service\FileService;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::ASSET_SYNCHRONIZE,
+    description: 'Synchronize registered assets on storage services.',
+    hidden: false,
+    aliases: ['ems:asset:synchronize']
+)]
 class SynchronizeAssetCommand extends EmsCommand
 {
-    protected static $defaultName = 'ems:asset:synchronize';
     /** @var string */
     protected $databaseName;
     /** @var string */
@@ -26,11 +33,6 @@ class SynchronizeAssetCommand extends EmsCommand
     public function __construct(protected LoggerInterface $logger, protected Registry $doctrine, protected ContentTypeService $contentTypeService, protected AssetExtractorService $extractorService, protected FileService $fileService)
     {
         parent::__construct();
-    }
-
-    protected function configure(): void
-    {
-        $this->setDescription('Synchronize registered assets on storage services');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/EMS/core-bundle/src/Command/UnlockRevisionsCommand.php
+++ b/EMS/core-bundle/src/Command/UnlockRevisionsCommand.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace EMS\CoreBundle\Command;
 
+use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Entity\ContentType;
 use EMS\CoreBundle\Service\ContentTypeService;
 use EMS\CoreBundle\Service\DataService;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -15,15 +17,18 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(
+    name: Commands::REVISIONS_UNLOCK,
+    description: 'Unlock all content-types revisions.',
+    hidden: false,
+    aliases: ['ems:revisions:unlock']
+)]
 final class UnlockRevisionsCommand extends Command
 {
     private ?SymfonyStyle $io = null;
     private ?string $user = null;
     private ?ContentType $contentType = null;
     private ?bool $all = null;
-
-    public const name = 'ems:revisions:unlock';
-    protected static $defaultName = self::name;
 
     private const ARGUMENT_USER = 'user';
     private const ARGUMENT_CONTENT_TYPE = 'contentType';
@@ -38,7 +43,6 @@ final class UnlockRevisionsCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setDescription('Unlock all content-types revisions.')
             ->addArgument(
                 self::ARGUMENT_USER,
                 InputArgument::REQUIRED,

--- a/EMS/core-bundle/src/Command/UpdateMetaFieldCommand.php
+++ b/EMS/core-bundle/src/Command/UpdateMetaFieldCommand.php
@@ -26,7 +26,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 )]
 class UpdateMetaFieldCommand extends EmsCommand
 {
-    protected static $defaultName = 'ems:environment:updatemetafield';
 
     public function __construct(protected Registry $doctrine, protected LoggerInterface $logger, protected DataService $dataService)
     {

--- a/EMS/core-bundle/src/Command/UpdateMetaFieldCommand.php
+++ b/EMS/core-bundle/src/Command/UpdateMetaFieldCommand.php
@@ -4,6 +4,7 @@ namespace EMS\CoreBundle\Command;
 
 use Doctrine\Bundle\DoctrineBundle\Registry;
 use Doctrine\ORM\EntityManager;
+use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Entity\Environment;
 use EMS\CoreBundle\Entity\Revision;
 use EMS\CoreBundle\Exception\NotLockedException;
@@ -11,11 +12,18 @@ use EMS\CoreBundle\Repository\EnvironmentRepository;
 use EMS\CoreBundle\Repository\RevisionRepository;
 use EMS\CoreBundle\Service\DataService;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::ENVIRONMENT_UPDATE_META_FIELD,
+    description: 'Update meta fields for all revisions of an environment.',
+    hidden: false,
+    aliases: ['ems:environment:updatemetafield']
+)]
 class UpdateMetaFieldCommand extends EmsCommand
 {
     protected static $defaultName = 'ems:environment:updatemetafield';
@@ -27,7 +35,7 @@ class UpdateMetaFieldCommand extends EmsCommand
 
     protected function configure(): void
     {
-        $this->setDescription('Update meta fields for all revisions of an environment')
+        $this
             ->addArgument(
                 'name',
                 InputArgument::REQUIRED,

--- a/EMS/core-bundle/src/Command/UpdateMetaFieldCommand.php
+++ b/EMS/core-bundle/src/Command/UpdateMetaFieldCommand.php
@@ -26,7 +26,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 )]
 class UpdateMetaFieldCommand extends EmsCommand
 {
-
     public function __construct(protected Registry $doctrine, protected LoggerInterface $logger, protected DataService $dataService)
     {
         parent::__construct();

--- a/EMS/core-bundle/src/Command/User/ActivateUserCommand.php
+++ b/EMS/core-bundle/src/Command/User/ActivateUserCommand.php
@@ -5,20 +5,23 @@ declare(strict_types=1);
 namespace EMS\CoreBundle\Command\User;
 
 use EMS\CoreBundle\Commands;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 
+#[AsCommand(
+    name: Commands::USER_ACTIVATE,
+    description: 'Activate a user.',
+    hidden: false
+)]
 class ActivateUserCommand extends AbstractUserCommand
 {
-    protected static $defaultName = Commands::USER_ACTIVATE;
-
     protected function configure(): void
     {
         $this
-            ->setDescription('Activate a user')
             ->setDefinition([
                 new InputArgument('username', InputArgument::REQUIRED, 'The username'),
             ])

--- a/EMS/core-bundle/src/Command/User/ChangePasswordCommand.php
+++ b/EMS/core-bundle/src/Command/User/ChangePasswordCommand.php
@@ -5,20 +5,23 @@ declare(strict_types=1);
 namespace EMS\CoreBundle\Command\User;
 
 use EMS\CoreBundle\Commands;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 
+#[AsCommand(
+    name: Commands::USER_CHANGE_PASSWORD,
+    description: 'Change the password of a user.',
+    hidden: false
+)]
 class ChangePasswordCommand extends AbstractUserCommand
 {
-    protected static $defaultName = Commands::USER_CHANGE_PASSWORD;
-
     protected function configure(): void
     {
         $this
-            ->setDescription('Change the password of a user.')
             ->setDefinition([
                 new InputArgument('username', InputArgument::REQUIRED, 'The username'),
                 new InputArgument('password', InputArgument::REQUIRED, 'The password'),

--- a/EMS/core-bundle/src/Command/User/CreateUserCommand.php
+++ b/EMS/core-bundle/src/Command/User/CreateUserCommand.php
@@ -20,8 +20,6 @@ use Symfony\Component\Console\Question\Question;
 )]
 class CreateUserCommand extends AbstractUserCommand
 {
-    protected static $defaultName = Commands::USER_CREATE;
-
     protected function configure(): void
     {
         $this

--- a/EMS/core-bundle/src/Command/User/CreateUserCommand.php
+++ b/EMS/core-bundle/src/Command/User/CreateUserCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace EMS\CoreBundle\Command\User;
 
 use EMS\CoreBundle\Commands;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -12,6 +13,11 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 
+#[AsCommand(
+    name: Commands::USER_CREATE,
+    description: 'Create a user.',
+    hidden: false
+)]
 class CreateUserCommand extends AbstractUserCommand
 {
     protected static $defaultName = Commands::USER_CREATE;
@@ -19,7 +25,6 @@ class CreateUserCommand extends AbstractUserCommand
     protected function configure(): void
     {
         $this
-            ->setDescription('Create a user.')
             ->setDefinition([
                 new InputArgument('username', InputArgument::REQUIRED, 'The username'),
                 new InputArgument('email', InputArgument::REQUIRED, 'The email'),

--- a/EMS/core-bundle/src/Command/User/DeactivateUserCommand.php
+++ b/EMS/core-bundle/src/Command/User/DeactivateUserCommand.php
@@ -5,20 +5,23 @@ declare(strict_types=1);
 namespace EMS\CoreBundle\Command\User;
 
 use EMS\CoreBundle\Commands;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 
+#[AsCommand(
+    name: Commands::USER_DEACTIVATE,
+    description: 'Deactivate a user.',
+    hidden: false
+)]
 class DeactivateUserCommand extends AbstractUserCommand
 {
-    protected static $defaultName = Commands::USER_DEACTIVATE;
-
     protected function configure(): void
     {
         $this
-            ->setDescription('Deactivate a user')
             ->setDefinition([
                 new InputArgument('username', InputArgument::REQUIRED, 'The username'),
             ])

--- a/EMS/core-bundle/src/Command/User/DemoteUserCommand.php
+++ b/EMS/core-bundle/src/Command/User/DemoteUserCommand.php
@@ -5,17 +5,20 @@ declare(strict_types=1);
 namespace EMS\CoreBundle\Command\User;
 
 use EMS\CoreBundle\Commands;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(
+    name: Commands::USER_DEMOTE,
+    description: 'Demote a user by removing a role.',
+    hidden: false
+)]
 class DemoteUserCommand extends RoleCommand
 {
-    protected static $defaultName = Commands::USER_DEMOTE;
-
     protected function configure(): void
     {
         parent::configure();
 
         $this
-            ->setDescription('Demote a user by removing a role')
             ->setHelp(<<<'EOT'
 The <info>emsco:user:demote</info> command demotes a user by removing a role
 

--- a/EMS/core-bundle/src/Command/User/PromoteUserCommand.php
+++ b/EMS/core-bundle/src/Command/User/PromoteUserCommand.php
@@ -5,17 +5,20 @@ declare(strict_types=1);
 namespace EMS\CoreBundle\Command\User;
 
 use EMS\CoreBundle\Commands;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(
+    name: Commands::USER_PROMOTE,
+    description: 'Promotes a user by adding a role.',
+    hidden: false
+)]
 class PromoteUserCommand extends RoleCommand
 {
-    protected static $defaultName = Commands::USER_PROMOTE;
-
     protected function configure(): void
     {
         parent::configure();
 
         $this
-            ->setDescription('Promotes a user by adding a role')
             ->setHelp(<<<'EOT'
 The <info>emsco:user:promote</info> command promotes a user by adding a role
 

--- a/EMS/core-bundle/src/Command/User/UpdateUserOptionCommand.php
+++ b/EMS/core-bundle/src/Command/User/UpdateUserOptionCommand.php
@@ -7,32 +7,35 @@ namespace EMS\CoreBundle\Command\User;
 use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Core\User\UserOptions;
 use EMS\Helpers\Standard\Json;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::USER_UPDATE_OPTION,
+    description: 'Update a user option.',
+    hidden: false
+)]
 class UpdateUserOptionCommand extends AbstractUserCommand
 {
-    protected static $defaultName = Commands::USER_UPDATE_OPTION;
-
     protected function configure(): void
     {
         $this
-            ->setDescription('Update a user option.')
             ->addArgument('option', InputArgument::REQUIRED, \implode('|', UserOptions::ALL_MEMBERS))
             ->addArgument('value', InputArgument::REQUIRED, 'value for updating')
             ->addOption('email', null, InputOption::VALUE_OPTIONAL, 'use wildcard % (%@example.dev)')
             ->setHelp(<<<'EOT'
 The <info>emsco:user:update-option</info> command changes an option of a user(s):
 
-  Enable "simplified_ui" for all users  
+  Enable "simplified_ui" for all users
   <info>php %command.full_name% simplified_ui true</info>
-  
-  Enable "allowed_configure_wysiwyg" for all users  
+
+  Enable "allowed_configure_wysiwyg" for all users
   <info>php %command.full_name% allowed_configure_wysiwyg true</info>
-  
-  Set country "Belgium" for all users with a .be email address  
+
+  Set country "Belgium" for all users with a .be email address
   <info>php %command.full_name% custom_options '{"country":"Belgium"}' --email='%.be'</info>
 
 EOT

--- a/EMS/core-bundle/src/Command/Xliff/ExtractCommand.php
+++ b/EMS/core-bundle/src/Command/Xliff/ExtractCommand.php
@@ -19,12 +19,17 @@ use EMS\CoreBundle\Service\EnvironmentService;
 use EMS\CoreBundle\Service\Internationalization\XliffService;
 use EMS\Helpers\Standard\Json;
 use EMS\Xliff\Xliff\Extractor;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
+#[AsCommand(
+    name: Commands::XLIFF_EXTRACT,
+    hidden: false
+)]
 final class ExtractCommand extends AbstractCommand
 {
     private string $sourceLocale;
@@ -57,8 +62,6 @@ final class ExtractCommand extends AbstractCommand
     public const OPTION_MAIL_TO = 'mail-to';
     public const OPTION_MAIL_CC = 'mail-cc';
     private const MAIL_TEMPLATE = '@EMSCore/email/xliff/extract.email.html.twig';
-
-    protected static $defaultName = Commands::XLIFF_EXTRACT;
     private string $xliffFilename;
     private ?string $baseUrl = null;
     private string $xliffVersion;

--- a/EMS/core-bundle/src/Command/Xliff/UpdateCommand.php
+++ b/EMS/core-bundle/src/Command/Xliff/UpdateCommand.php
@@ -14,15 +14,20 @@ use EMS\CoreBundle\Service\PublishService;
 use EMS\CoreBundle\Service\Revision\RevisionService;
 use EMS\Xliff\Xliff\Entity\InsertReport;
 use EMS\Xliff\Xliff\Inserter;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::XLIFF_UPDATE,
+    description: 'Update documents from a given XLIFF file.',
+    hidden: false
+)]
 final class UpdateCommand extends AbstractCommand
 {
     private const XLIFF_UPLOAD_COMMAND = 'XLIFF_UPLOAD_COMMAND';
-    protected static $defaultName = Commands::XLIFF_UPDATE;
     public const ARGUMENT_XLIFF_FILE = 'xliff-file';
     public const OPTION_PUBLISH_TO = 'publish-to';
     public const OPTION_ARCHIVE = 'archive';

--- a/EMS/core-bundle/src/Commands.php
+++ b/EMS/core-bundle/src/Commands.php
@@ -13,6 +13,7 @@ final class Commands
     public const CONTENT_TYPE_TRANSFORM = 'emsco:contenttype:transform';
     public const CONTENT_TYPE_SWITCH_DEFAULT_ENV = 'emsco:contenttype:switch-default-env';
     public const CONTENT_TYPE_RECOMPUTE = 'emsco:contenttype:recompute';
+    public const CONTENT_TYPE_CLEAN = 'emsco:contenttype:clean';
     public const DELETE_ORPHANS = 'emsco:delete:orphans';
 
     public const ENVIRONMENT_ALIGN = 'emsco:environment:align';
@@ -22,6 +23,7 @@ final class Commands
     public const ENVIRONMENT_LIST = 'emsco:environment:list';
     public const ENVIRONMENT_UPDATE_META_FIELD = 'emsco:environment:update-meta-field';
     public const ENVIRONMENT_REBUILD = 'emsco:environment:rebuild';
+    public const JOB_RUN = 'emsco:job:run';
 
     public const MANAGED_ALIAS_CREATE = 'emsco:managed-alias:create';
     public const MANAGED_ALIAS_ADD_ENVIRONMENT = 'emsco:managed-alias:add-environment';
@@ -38,6 +40,7 @@ final class Commands
     public const REVISION_TASK_CREATE = 'emsco:revision:task:create';
     public const REVISION_DISCARD_DRAFT = 'emsco:revision:discard-draft';
     public const REVISIONS_UNLOCK = 'emsco:revisions:unlock';
+    public const SUBMISSIONS_EMAIL = 'emsco:submissions:email';
 
     public const USER_ACTIVATE = 'emsco:user:activate';
     public const USER_CHANGE_PASSWORD = 'emsco:user:change-password';

--- a/EMS/core-bundle/src/Commands.php
+++ b/EMS/core-bundle/src/Commands.php
@@ -14,6 +14,7 @@ final class Commands
     public const CONTENT_TYPE_SWITCH_DEFAULT_ENV = 'emsco:contenttype:switch-default-env';
     public const CONTENT_TYPE_RECOMPUTE = 'emsco:contenttype:recompute';
     public const CONTENT_TYPE_CLEAN = 'emsco:contenttype:clean';
+    public const CONTENT_TYPE_ACTIVATE = 'emsco:contenttype:activate';
     public const DELETE_ORPHANS = 'emsco:delete:orphans';
 
     public const ENVIRONMENT_ALIGN = 'emsco:environment:align';
@@ -40,7 +41,9 @@ final class Commands
     public const REVISION_TASK_CREATE = 'emsco:revision:task:create';
     public const REVISION_DISCARD_DRAFT = 'emsco:revision:discard-draft';
     public const REVISIONS_UNLOCK = 'emsco:revisions:unlock';
+    public const REVISIONS_INDEX_FILE_FIELDS = 'emsco:revisions:index-file-fields';
     public const SUBMISSIONS_EMAIL = 'emsco:submissions:email';
+    public const SUBMISSIONS_REMOVE_EXPIRED = 'emsco:submissions:remove-expired';
 
     public const USER_ACTIVATE = 'emsco:user:activate';
     public const USER_CHANGE_PASSWORD = 'emsco:user:change-password';

--- a/EMS/core-bundle/src/Commands.php
+++ b/EMS/core-bundle/src/Commands.php
@@ -21,10 +21,13 @@ final class Commands
     public const ENVIRONMENT_REINDEX = 'emsco:environment:reindex';
     public const ENVIRONMENT_LIST = 'emsco:environment:list';
     public const ENVIRONMENT_UPDATE_META_FIELD = 'emsco:environment:update-meta-field';
+    public const ENVIRONMENT_REBUILD = 'emsco:environment:rebuild';
 
     public const MANAGED_ALIAS_CREATE = 'emsco:managed-alias:create';
     public const MANAGED_ALIAS_ADD_ENVIRONMENT = 'emsco:managed-alias:add-environment';
     public const MANAGED_ALIAS_LIST = 'emsco:managed-alias:list';
+    public const MANAGED_ALIAS_ALIGN = 'emsco:managed-alias:align';
+    public const MANAGED_ALIAS_CHECK = 'emsco:managed-alias:check';
 
     public const RELEASE_PUBLISH = 'emsco:release:publish';
     public const RELEASE_CREATE = 'emsco:release:create';

--- a/EMS/core-bundle/src/Commands.php
+++ b/EMS/core-bundle/src/Commands.php
@@ -15,6 +15,7 @@ final class Commands
     public const CONTENT_TYPE_RECOMPUTE = 'emsco:contenttype:recompute';
     public const CONTENT_TYPE_CLEAN = 'emsco:contenttype:clean';
     public const CONTENT_TYPE_ACTIVATE = 'emsco:contenttype:activate';
+    public const CONTENT_TYPE_MIGRATE = 'emsco:contenttype:migrate';
     public const DELETE_ORPHANS = 'emsco:delete:orphans';
 
     public const ENVIRONMENT_ALIGN = 'emsco:environment:align';

--- a/EMS/core-bundle/src/Commands.php
+++ b/EMS/core-bundle/src/Commands.php
@@ -34,4 +34,5 @@ final class Commands
 
     public const MANAGED_ALIAS_CREATE = 'ems:managed-alias:create';
     public const MANAGED_ALIAS_ADD_ENVIRONMENT = 'emsco:managed-alias:add-environment';
+    public const ASSET_SYNCHRONIZE = 'emsco:asset:synchronize';
 }

--- a/EMS/core-bundle/src/Commands.php
+++ b/EMS/core-bundle/src/Commands.php
@@ -8,6 +8,8 @@ final class Commands
 {
     public const ASSET_SYNCHRONIZE = 'emsco:asset:synchronize';
     public const ASSET_EXTRACT = 'emsco:asset:extract';
+    public const ASSET_CLEAN = 'emsco:asset:clean';
+    public const ASSET_HEAD = 'emsco:asset:head';
     public const CONTENT_TYPE_TRANSFORM = 'emsco:contenttype:transform';
     public const CONTENT_TYPE_SWITCH_DEFAULT_ENV = 'emsco:contenttype:switch-default-env';
     public const CONTENT_TYPE_RECOMPUTE = 'emsco:contenttype:recompute';
@@ -18,6 +20,7 @@ final class Commands
     public const ENVIRONMENT_CREATE = 'emsco:environment:create';
     public const ENVIRONMENT_REINDEX = 'emsco:environment:reindex';
     public const ENVIRONMENT_LIST = 'emsco:environment:list';
+    public const ENVIRONMENT_UPDATE_META_FIELD = 'emsco:environment:update-meta-field';
 
     public const MANAGED_ALIAS_CREATE = 'emsco:managed-alias:create';
     public const MANAGED_ALIAS_ADD_ENVIRONMENT = 'emsco:managed-alias:add-environment';

--- a/EMS/core-bundle/src/Commands.php
+++ b/EMS/core-bundle/src/Commands.php
@@ -10,14 +10,16 @@ final class Commands
     public const ASSET_EXTRACT = 'emsco:asset:extract';
     public const CONTENT_TYPE_TRANSFORM = 'emsco:contenttype:transform';
     public const CONTENT_TYPE_SWITCH_DEFAULT_ENV = 'emsco:contenttype:switch-default-env';
+    public const CONTENT_TYPE_RECOMPUTE = 'emsco:contenttype:recompute';
+    public const DELETE_ORPHANS = 'emsco:delete:orphans';
 
     public const ENVIRONMENT_ALIGN = 'emsco:environment:align';
     public const ENVIRONMENT_UNPUBLISH = 'emsco:environment:unpublish';
     public const ENVIRONMENT_CREATE = 'emsco:environment:create';
-    public const ENVIRONMENT_REINDEX = 'ems:environment:reindex';
-    public const ENVIRONMENT_LIST = 'ems:environment:list';
+    public const ENVIRONMENT_REINDEX = 'emsco:environment:reindex';
+    public const ENVIRONMENT_LIST = 'emsco:environment:list';
 
-    public const MANAGED_ALIAS_CREATE = 'ems:managed-alias:create';
+    public const MANAGED_ALIAS_CREATE = 'emsco:managed-alias:create';
     public const MANAGED_ALIAS_ADD_ENVIRONMENT = 'emsco:managed-alias:add-environment';
     public const MANAGED_ALIAS_LIST = 'emsco:managed-alias:list';
 

--- a/EMS/core-bundle/src/Commands.php
+++ b/EMS/core-bundle/src/Commands.php
@@ -35,4 +35,7 @@ final class Commands
     public const MANAGED_ALIAS_CREATE = 'ems:managed-alias:create';
     public const MANAGED_ALIAS_ADD_ENVIRONMENT = 'emsco:managed-alias:add-environment';
     public const ASSET_SYNCHRONIZE = 'emsco:asset:synchronize';
+    public const ASSET_EXTRACT = 'emsco:asset:extract';
+    public const ENVIRONMENT_CREATE = 'emsco:environment:create';
+    public const REVISIONS_UNLOCK = 'emsco:revisions:unlock';
 }

--- a/EMS/core-bundle/src/Commands.php
+++ b/EMS/core-bundle/src/Commands.php
@@ -18,6 +18,7 @@ final class Commands
     public const CONTENT_TYPE_MIGRATE = 'emsco:contenttype:migrate';
     public const CONTENT_TYPE_LOCK = 'emsco:contenttype:lock';
     public const CONTENT_TYPE_IMPORT = 'emsco:contenttype:import';
+    public const CONTENT_TYPE_EXPORT = 'emsco:contenttype:export';
     public const DELETE_ORPHANS = 'emsco:delete:orphans';
 
     public const ENVIRONMENT_ALIGN = 'emsco:environment:align';
@@ -34,6 +35,8 @@ final class Commands
     public const MANAGED_ALIAS_LIST = 'emsco:managed-alias:list';
     public const MANAGED_ALIAS_ALIGN = 'emsco:managed-alias:align';
     public const MANAGED_ALIAS_CHECK = 'emsco:managed-alias:check';
+    public const NOTIFICATION_BULK_ACTION = 'emsco:notification:bulk-action';
+    public const NOTIFICATION_SEND = 'emsco:notification:send';
 
     public const RELEASE_PUBLISH = 'emsco:release:publish';
     public const RELEASE_CREATE = 'emsco:release:create';
@@ -45,6 +48,7 @@ final class Commands
     public const REVISION_DISCARD_DRAFT = 'emsco:revision:discard-draft';
     public const REVISIONS_UNLOCK = 'emsco:revisions:unlock';
     public const REVISIONS_INDEX_FILE_FIELDS = 'emsco:revisions:index-file-fields';
+    public const REVISIONS_TIME_MACHINE = 'emsco:revisions:time-machine';
     public const SUBMISSIONS_EMAIL = 'emsco:submissions:email';
     public const SUBMISSIONS_REMOVE_EXPIRED = 'emsco:submissions:remove-expired';
 

--- a/EMS/core-bundle/src/Commands.php
+++ b/EMS/core-bundle/src/Commands.php
@@ -6,11 +6,20 @@ namespace EMS\CoreBundle;
 
 final class Commands
 {
+    public const ASSET_SYNCHRONIZE = 'emsco:asset:synchronize';
+    public const ASSET_EXTRACT = 'emsco:asset:extract';
     public const CONTENT_TYPE_TRANSFORM = 'emsco:contenttype:transform';
     public const CONTENT_TYPE_SWITCH_DEFAULT_ENV = 'emsco:contenttype:switch-default-env';
 
     public const ENVIRONMENT_ALIGN = 'emsco:environment:align';
     public const ENVIRONMENT_UNPUBLISH = 'emsco:environment:unpublish';
+    public const ENVIRONMENT_CREATE = 'emsco:environment:create';
+    public const ENVIRONMENT_REINDEX = 'ems:environment:reindex';
+    public const ENVIRONMENT_LIST = 'ems:environment:list';
+
+    public const MANAGED_ALIAS_CREATE = 'ems:managed-alias:create';
+    public const MANAGED_ALIAS_ADD_ENVIRONMENT = 'emsco:managed-alias:add-environment';
+    public const MANAGED_ALIAS_LIST = 'emsco:managed-alias:list';
 
     public const RELEASE_PUBLISH = 'emsco:release:publish';
     public const RELEASE_CREATE = 'emsco:release:create';
@@ -20,6 +29,7 @@ final class Commands
     public const REVISION_DELETE = 'emsco:revision:delete';
     public const REVISION_TASK_CREATE = 'emsco:revision:task:create';
     public const REVISION_DISCARD_DRAFT = 'emsco:revision:discard-draft';
+    public const REVISIONS_UNLOCK = 'emsco:revisions:unlock';
 
     public const USER_ACTIVATE = 'emsco:user:activate';
     public const USER_CHANGE_PASSWORD = 'emsco:user:change-password';
@@ -31,11 +41,4 @@ final class Commands
 
     public const XLIFF_EXTRACT = 'emsco:xliff:extract';
     public const XLIFF_UPDATE = 'emsco:xliff:update';
-
-    public const MANAGED_ALIAS_CREATE = 'ems:managed-alias:create';
-    public const MANAGED_ALIAS_ADD_ENVIRONMENT = 'emsco:managed-alias:add-environment';
-    public const ASSET_SYNCHRONIZE = 'emsco:asset:synchronize';
-    public const ASSET_EXTRACT = 'emsco:asset:extract';
-    public const ENVIRONMENT_CREATE = 'emsco:environment:create';
-    public const REVISIONS_UNLOCK = 'emsco:revisions:unlock';
 }

--- a/EMS/core-bundle/src/Commands.php
+++ b/EMS/core-bundle/src/Commands.php
@@ -16,6 +16,8 @@ final class Commands
     public const CONTENT_TYPE_CLEAN = 'emsco:contenttype:clean';
     public const CONTENT_TYPE_ACTIVATE = 'emsco:contenttype:activate';
     public const CONTENT_TYPE_MIGRATE = 'emsco:contenttype:migrate';
+    public const CONTENT_TYPE_LOCK = 'emsco:contenttype:lock';
+    public const CONTENT_TYPE_IMPORT = 'emsco:contenttype:import';
     public const DELETE_ORPHANS = 'emsco:delete:orphans';
 
     public const ENVIRONMENT_ALIGN = 'emsco:environment:align';

--- a/EMS/submission-bundle/src/Command/DatabaseStatsCommand.php
+++ b/EMS/submission-bundle/src/Command/DatabaseStatsCommand.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace EMS\SubmissionBundle\Command;
 
+use EMS\SubmissionBundle\Commands;
 use EMS\SubmissionBundle\Repository\FormSubmissionRepository;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputArgument;
@@ -16,10 +18,12 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Mailer\Mailer;
 use Symfony\Component\Mime\Address;
 
+#[AsCommand(
+    name: Commands::DATABASE_STATS,
+    hidden: false
+)]
 final class DatabaseStatsCommand extends Command
 {
-    protected static $defaultName = 'emss:database:stats';
-
     public function __construct(private readonly Mailer $mailer, private readonly FormSubmissionRepository $repository)
     {
         parent::__construct();

--- a/EMS/submission-bundle/src/Commands.php
+++ b/EMS/submission-bundle/src/Commands.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\SubmissionBundle;
+
+final class Commands
+{
+    public const DATABASE_STATS = 'emss:database:stats';
+}

--- a/elasticms-cli/src/Command/Document/DocumentUpdateCommand.php
+++ b/elasticms-cli/src/Command/Document/DocumentUpdateCommand.php
@@ -11,11 +11,17 @@ use App\CLI\Commands;
 use EMS\CommonBundle\Common\Admin\AdminHelper;
 use EMS\CommonBundle\Common\Command\AbstractCommand;
 use EMS\CommonBundle\Contracts\File\FileReaderInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::DOCUMENTS_UPDATE,
+    description: 'Update documents from excel or csv file with custom configuration.',
+    hidden: false
+)]
 final class DocumentUpdateCommand extends AbstractCommand
 {
     private string $configFile;
@@ -25,8 +31,6 @@ final class DocumentUpdateCommand extends AbstractCommand
     private ?int $dataLength = null;
     private bool $dataSkipFirstRow;
     private bool $dryRun;
-
-    protected static $defaultName = Commands::DOCUMENTS_UPDATE;
 
     private const ARGUMENT_DATA_FILE = 'data-file';
     private const ARGUMENT_CONFIG_FILE = 'config-file';
@@ -43,7 +47,6 @@ final class DocumentUpdateCommand extends AbstractCommand
     protected function configure(): void
     {
         $this
-            ->setDescription('Update documents from excel or csv file with custom configuration')
             ->addArgument(self::ARGUMENT_CONFIG_FILE, InputArgument::REQUIRED, 'Config file (json)')
             ->addArgument(self::ARGUMENT_DATA_FILE, InputArgument::REQUIRED, 'Data file (excel or csv)')
             ->addOption(self::OPTION_DATA_OFFSET, null, InputOption::VALUE_REQUIRED, 'Offset data', 0)

--- a/elasticms-cli/src/Command/File/AuditFileCommand.php
+++ b/elasticms-cli/src/Command/File/AuditFileCommand.php
@@ -8,6 +8,7 @@ use App\CLI\Client\File\Report;
 use App\CLI\Commands;
 use EMS\CommonBundle\Common\Command\AbstractCommand;
 use EMS\Helpers\File\File;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Logger\ConsoleLogger;
@@ -15,9 +16,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Mime\MimeTypes;
 
+#[AsCommand(
+    name: Commands::FILE_AUDIT,
+    description: 'Audit files in a folder structure.',
+    hidden: false
+)]
 class AuditFileCommand extends AbstractCommand
 {
-    protected static $defaultName = Commands::FILE_AUDIT;
     final public const UPPERCASE_EXTENSION = 'ExtensionWithUppercase';
     final public const EXTENSION_MISMATCH = 'ExtensionMismatch';
 
@@ -37,7 +42,6 @@ class AuditFileCommand extends AbstractCommand
     protected function configure(): void
     {
         $this
-            ->setDescription('Audit files in a folder structure')
             ->addArgument(
                 self::ARG_FOLDER,
                 InputArgument::REQUIRED,

--- a/elasticms-cli/src/Command/FileReader/FileReaderImportCommand.php
+++ b/elasticms-cli/src/Command/FileReader/FileReaderImportCommand.php
@@ -9,16 +9,20 @@ use EMS\CommonBundle\Common\Admin\AdminHelper;
 use EMS\CommonBundle\Common\Command\AbstractCommand;
 use EMS\CommonBundle\Contracts\File\FileReaderInterface;
 use EMS\CommonBundle\Search\Search;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
+#[AsCommand(
+    name: Commands::FILE_READER_IMPORT,
+    description: 'Import an Excel file or a CSV file, one document per row.',
+    hidden: false
+)]
 final class FileReaderImportCommand extends AbstractCommand
 {
-    protected static $defaultName = Commands::FILE_READER_IMPORT;
-
     private const ARGUMENT_FILE = 'file';
     private const ARGUMENT_CONTENT_TYPE = 'content-type';
     private const OPTION_OUUID_EXPRESSION = 'ouuid-expression';
@@ -44,7 +48,6 @@ final class FileReaderImportCommand extends AbstractCommand
     protected function configure(): void
     {
         $this
-            ->setDescription('Import an Excel file or a CSV file, one document per row')
             ->addArgument(self::ARGUMENT_FILE, InputArgument::REQUIRED, 'File path (xlsx or csv)')
             ->addArgument(self::ARGUMENT_CONTENT_TYPE, InputArgument::REQUIRED, 'Content type target')
             ->addOption(self::OPTION_DRY_RUN, null, InputOption::VALUE_NONE, 'Just do a dry run')

--- a/elasticms-cli/src/Command/MediaLibrary/LoadTikaCache.php
+++ b/elasticms-cli/src/Command/MediaLibrary/LoadTikaCache.php
@@ -7,15 +7,19 @@ namespace App\CLI\Command\MediaLibrary;
 use App\CLI\Commands;
 use App\CLI\Helper\Tika\TikaHelper;
 use EMS\CommonBundle\Common\Command\AbstractCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Finder\Finder;
 
+#[AsCommand(
+    name: Commands::MEDIA_LIBRARY_TIKA_CACHE,
+    description: 'Generate a tika cache from files in a given folder.',
+    hidden: false
+)]
 final class LoadTikaCache extends AbstractCommand
 {
-    protected static $defaultName = Commands::MEDIA_LIBRARY_TIKA_CACHE;
-
     private const ARGUMENT_FOLDER = 'folder';
     private const ARGUMENT_TIKA_CACHE_FOLDER = 'tika-cache-folder';
     private string $folder;
@@ -24,7 +28,6 @@ final class LoadTikaCache extends AbstractCommand
     protected function configure(): void
     {
         $this
-            ->setDescription('Generate a tika cache from files in a given folder')
             ->addArgument(self::ARGUMENT_FOLDER, InputArgument::REQUIRED, 'Folder path')
             ->addArgument(self::ARGUMENT_TIKA_CACHE_FOLDER, InputArgument::REQUIRED, 'Folder where tika extraction can be cached')
         ;

--- a/elasticms-cli/src/Command/MediaLibrary/MediaLibrarySyncCommand.php
+++ b/elasticms-cli/src/Command/MediaLibrary/MediaLibrarySyncCommand.php
@@ -12,15 +12,19 @@ use EMS\CommonBundle\Common\Admin\AdminHelper;
 use EMS\CommonBundle\Common\Command\AbstractCommand;
 use EMS\CommonBundle\Contracts\ExpressionServiceInterface;
 use EMS\CommonBundle\Contracts\File\FileReaderInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::MEDIA_LIBRARY_SYNC,
+    description: 'Synchronization files on media library for a given folder.',
+    hidden: false
+)]
 final class MediaLibrarySyncCommand extends AbstractCommand
 {
-    protected static $defaultName = Commands::MEDIA_LIBRARY_SYNC;
-
     private const ARGUMENT_FOLDER = 'folder';
     private const OPTION_CONTENT_TYPE = 'content-type';
     private const OPTION_FOLDER_FIELD = 'folder-field';
@@ -56,7 +60,6 @@ final class MediaLibrarySyncCommand extends AbstractCommand
     protected function configure(): void
     {
         $this
-            ->setDescription('Synchronization files on media library for a given folder')
             ->addArgument(self::ARGUMENT_FOLDER, InputArgument::REQUIRED, 'Folder path')
             ->addOption(self::OPTION_CONTENT_TYPE, null, InputOption::VALUE_OPTIONAL, 'Media Library content type (default: media_file)', 'media_file')
             ->addOption(self::OPTION_FOLDER_FIELD, null, InputOption::VALUE_OPTIONAL, 'Media Library folder field (default: media_folder)', 'media_folder')

--- a/elasticms-cli/src/Command/Photos/ApplePhotosMigrationCommand.php
+++ b/elasticms-cli/src/Command/Photos/ApplePhotosMigrationCommand.php
@@ -6,14 +6,18 @@ use App\CLI\Client\Photos\ApplePhotosLibrary;
 use App\CLI\Client\Photos\PhotosLibraryInterface;
 use App\CLI\Commands;
 use EMS\CommonBundle\Common\Admin\AdminHelper;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::APPLE_PHOTOS_MIGRATION,
+    description: 'Migrate Apple Photo library to elaticms documents.',
+    hidden: false
+)]
 class ApplePhotosMigrationCommand extends AbstractPhotosMigrationCommand
 {
-    protected static $defaultName = Commands::APPLE_PHOTOS_MIGRATION;
-
     final public const ARG_PHOTOS_LIBRARY_PATH = 'photos-library-path';
     private string $applePhotosPathPath;
 
@@ -25,7 +29,6 @@ class ApplePhotosMigrationCommand extends AbstractPhotosMigrationCommand
     protected function configure(): void
     {
         $this
-            ->setDescription('Migrate Apple Photo library to elaticms documents')
             ->addArgument(
                 self::ARG_PHOTOS_LIBRARY_PATH,
                 InputArgument::REQUIRED,

--- a/elasticms-cli/src/Command/Web/AuditCommand.php
+++ b/elasticms-cli/src/Command/Web/AuditCommand.php
@@ -22,16 +22,20 @@ use EMS\CommonBundle\Common\Command\AbstractCommand;
 use EMS\CommonBundle\Contracts\CoreApi\Endpoint\Data\DataInterface;
 use EMS\CommonBundle\Elasticsearch\Document\EMSSource;
 use EMS\Helpers\Standard\Json;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::WEB_AUDIT,
+    description: 'Audit (security headers, content, locale, accessibility) website.',
+    hidden: false
+)]
 class AuditCommand extends AbstractCommand
 {
-    protected static $defaultName = Commands::WEB_AUDIT;
-
     private const ARG_URL = 'url';
     private const OPTION_CONTINUE = 'continue';
     private const OPTION_CACHE_FOLDER = 'cache-folder';
@@ -77,7 +81,6 @@ class AuditCommand extends AbstractCommand
     protected function configure(): void
     {
         $this
-            ->setDescription('Audit (security headers, content, locale, accessibility) website')
             ->addArgument(
                 self::ARG_URL,
                 InputArgument::REQUIRED,

--- a/elasticms-cli/src/Command/Web/MigrationCommand.php
+++ b/elasticms-cli/src/Command/Web/MigrationCommand.php
@@ -13,16 +13,20 @@ use App\CLI\Commands;
 use EMS\CommonBundle\Common\Admin\AdminHelper;
 use EMS\CommonBundle\Common\Command\AbstractCommand;
 use EMS\Helpers\Standard\Json;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::WEB_MIGRATION,
+    description: 'Migration web resources to elaticms documents.',
+    hidden: false
+)]
 class MigrationCommand extends AbstractCommand
 {
-    protected static $defaultName = Commands::WEB_MIGRATION;
-
     private const ARG_CONFIG_FILE_PATH = 'json-path';
     private const OPTION_CONTINUE = 'continue';
     private const ARG_OUUID = 'OUUID';
@@ -51,7 +55,6 @@ class MigrationCommand extends AbstractCommand
     protected function configure(): void
     {
         $this
-            ->setDescription('Migration web resources to elaticms documents')
             ->addArgument(
                 self::ARG_CONFIG_FILE_PATH,
                 InputArgument::REQUIRED,


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | n  |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  | y  |
| Fixed tickets? |  n |
| Documentation? | n  |


