### PR TITLE
build(symfony/6.4): update composer dependencies 

### DIFF
--- a/demo/.env
+++ b/demo/.env
@@ -1,7 +1,7 @@
 # Project namespace (defaults to the current folder name if not set)
 COMPOSE_PROJECT_NAME=elasticms_demo
 
-EMS_VERSION=5.12.0
+EMS_VERSION=6.0.0
 INSTANCE_ID='ems_promo_v2_'
 EMS_BACKEND_URL=http://local.ems-demo-admin:9000
 EMS_ADMIN_URL=http://local.ems-demo-admin.localhost

--- a/elasticms-admin/composer.json
+++ b/elasticms-admin/composer.json
@@ -1,18 +1,18 @@
 {
   "name": "ems-project/elasticms-admin",
   "description": "A preconfigured elasticms application",
-  "type": "project",
-  "license": "MIT",
   "authors": [
     {
       "name": "EMS Community",
       "homepage": "https://github.com/ems-project/EMSClientHelperBundle/contributors"
     }
   ],
+  "type": "project",
+  "license": "MIT",
   "minimum-stability": "stable",
   "prefer-stable": true,
   "require": {
-    "php": "^8.1",
+    "php": "^8.2",
     "ext-ctype": "*",
     "ext-gd": "*",
     "ext-iconv": "*",
@@ -20,24 +20,24 @@
     "ext-openssl": "*",
     "ext-tidy": "*",
     "doctrine/annotations": "^1.14",
-    "doctrine/doctrine-bundle": "^2.8",
+    "doctrine/doctrine-bundle": "^2.11",
     "doctrine/doctrine-migrations-bundle": "^3.2",
-    "doctrine/orm": "^2.6",
-    "elasticms/core-bundle": "~5.12.0",
-    "elasticms/admin-ui-bundle": "~5.12.0",
-    "symfony/console": "^5.4",
-    "symfony/dotenv": "^5.4",
-    "symfony/expression-language": "^6.2",
-    "symfony/flex": "^1.6",
-    "symfony/form": "^5.4",
-    "symfony/framework-bundle": "^5.4",
-    "symfony/mailer": "^5.4",
+    "doctrine/orm": "^2.17",
+    "elasticms/core-bundle": "~6.0.0",
+    "elasticms/admin-ui-bundle": "~6.0.0",
+    "symfony/console": "^6.4",
+    "symfony/dotenv": "^6.4",
+    "symfony/expression-language": "^6.4",
+    "symfony/flex": "^2.4",
+    "symfony/form": "^6.4",
+    "symfony/framework-bundle": "^6.4",
+    "symfony/mailer": "^6.4",
     "symfony/monolog-bundle": "^3.8",
-    "symfony/runtime": "^5.4",
-    "symfony/security-bundle": "^5.4",
-    "symfony/twig-bundle": "^5.4",
-    "symfony/var-exporter": "^5.4",
-    "symfony/web-link": "^5.4"
+    "symfony/runtime": "^6.4",
+    "symfony/security-bundle": "^6.4",
+    "symfony/twig-bundle": "^6.4",
+    "symfony/var-exporter": "^6.4",
+    "symfony/web-link": "^6.4"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5",
@@ -88,9 +88,9 @@
       "@auto-scripts"
     ],
     "phpcs": "php-cs-fixer fix",
-    "phpstan": "phpstan analyse",
+    "phpstan": "phpstan analyse --memory-limit 1G",
     "phpunit": "phpunit",
-    "phpall": "phpunit && php-cs-fixer fix && phpstan analyse"
+    "phpall": "php-cs-fixer fix && phpunit && phpstan analyse --memory-limit 1G"
   },
   "conflict": {
     "symfony/symfony": "*"
@@ -98,7 +98,7 @@
   "extra": {
     "symfony": {
       "allow-contrib": false,
-      "require": "^5.4"
+      "require": "^6.4"
     }
   }
 }

--- a/elasticms-web/composer.json
+++ b/elasticms-web/composer.json
@@ -1,53 +1,53 @@
 {
   "name": "ems-project/elasticms-web",
   "description": "A preconfigured elasticms website",
-  "type": "project",
-  "license": "MIT",
   "authors": [
     {
       "name": "EMS Community",
       "homepage": "https://github.com/ems-project/EMSClientHelperBundle/contributors"
     }
   ],
+  "type": "project",
+  "license": "MIT",
   "minimum-stability": "stable",
   "prefer-stable": true,
   "require": {
-    "php": "^8.1",
+    "php": "^8.2",
     "ext-ctype": "*",
     "ext-iconv": "*",
     "ext-json": "*",
     "doctrine/annotations": "^1.14",
-    "doctrine/doctrine-bundle": "^2.8",
+    "doctrine/doctrine-bundle": "^2.11",
     "doctrine/doctrine-migrations-bundle": "^3.2",
-    "doctrine/orm": "^2.6",
-    "elasticms/client-helper-bundle": "~5.12.0",
-    "elasticms/form-bundle": "~5.12.0",
-    "elasticms/submission-bundle": "~5.12.0",
-    "endroid/qr-code-bundle": "^4.0",
+    "doctrine/orm": "^2.17",
+    "elasticms/client-helper-bundle": "~6.0.0",
+    "elasticms/form-bundle": "~6.0.0",
+    "elasticms/submission-bundle": "~6.0.0",
+    "endroid/qr-code-bundle": "^4.3",
     "sensio/framework-extra-bundle": "^6.2",
-    "symfony/console": "^5.4",
-    "symfony/dotenv": "^5.4",
-    "symfony/expression-language": "^6.2",
-    "symfony/flex": "^1.6",
-    "symfony/form": "^5.4",
-    "symfony/framework-bundle": "^5.4",
-    "symfony/mailer": "^5.4",
+    "symfony/console": "^6.4",
+    "symfony/dotenv": "^6.4",
+    "symfony/expression-language": "^6.4",
+    "symfony/flex": "^2.4",
+    "symfony/form": "^6.4",
+    "symfony/framework-bundle": "^6.4",
+    "symfony/mailer": "^6.4",
     "symfony/monolog-bundle": "^3.8",
-    "symfony/runtime": "^5.4",
-    "symfony/security-bundle": "^5.4",
-    "symfony/twig-bundle": "^5.4",
-    "symfony/web-link": "^5.4",
-    "symfony/var-exporter": "^5.4",
-    "twig/extra-bundle": "^3.4",
-    "twig/intl-extra": "^3.4"
+    "symfony/runtime": "^6.4",
+    "symfony/security-bundle": "^6.4",
+    "symfony/twig-bundle": "^6.4",
+    "symfony/web-link": "^6.4",
+    "symfony/var-exporter": "^6.4",
+    "twig/extra-bundle": "^3.8",
+    "twig/intl-extra": "^3.8"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5",
-    "symfony/browser-kit": "^5.4",
-    "symfony/css-selector": "^5.4",
-    "symfony/debug-bundle": "^5.4",
-    "symfony/phpunit-bridge": "^5.4",
-    "symfony/web-profiler-bundle": "^5.4"
+    "symfony/browser-kit": "^6.4",
+    "symfony/css-selector": "^6.4",
+    "symfony/debug-bundle": "^6.4",
+    "symfony/phpunit-bridge": "^6.4",
+    "symfony/web-profiler-bundle": "^6.4"
   },
   "config": {
     "allow-plugins": {
@@ -91,9 +91,9 @@
       "@auto-scripts"
     ],
     "phpcs": "php-cs-fixer fix",
-    "phpstan": "phpstan analyse",
+    "phpstan": "phpstan analyse --memory-limit 1G",
     "phpunit": "phpunit",
-    "phpall": "phpunit && php-cs-fixer fix && phpstan analyse"
+    "phpall": "php-cs-fixer fix && phpunit && phpstan analyse --memory-limit 1G"
   },
   "conflict": {
     "symfony/symfony": "*"
@@ -101,7 +101,7 @@
   "extra": {
     "symfony": {
       "allow-contrib": false,
-      "require": "^5.4"
+      "require": "^6.4"
     }
   }
 }


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | n  |
| New feature?   |  n |
| BC breaks?     | y  |
| Deprecations?  | n  |
| Fixed tickets? |  n |
| Documentation? |  n |

It's not clear to me how we ensure that the composer.lock are using the same version of bundles/librairies that the monorepo. E.g. the monorepo is using aws/aws-sdk-php@3.294.4 if we do a composer upgrade now in elasticms/admin we'll have the version 3.295.1
