### PR TITLE
fix(symfony/6.4): log_message formatted column can not be null

### DIFF
--- a/EMS/common-bundle/src/Common/Log/DoctrineHandler.php
+++ b/EMS/common-bundle/src/Common/Log/DoctrineHandler.php
@@ -31,7 +31,7 @@ class DoctrineHandler extends AbstractProcessingHandler
         $token = $this->tokenStorage->getToken();
         $logArray['username'] = $token instanceof TokenInterface ? $token->getUserIdentifier() : null;
         $logArray['impersonator'] = $token instanceof SwitchUserToken ? $token->getOriginalToken()->getUserIdentifier() : null;
-
+        $logArray['formatted'] = $record->formatted ?? $record->message;
         $logArray['context'] = DoctrineHandler::secretContext($logArray['context']);
 
         $this->logRepository->insertRecord($logArray);


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  |  n |
| Fixed tickets? |  n |
| Documentation? |  n |

When creating a new environment: 

SQLSTATE[23502]: Not null violation: 7 ERROR: null value in column "formatted" violates not-null constraint

Comes from: https://github.com/ems-project/elasticms/pull/685

The toArray function on the LogRecord is not returing the formatted value, we should set it our self.