### PR TITLE
build(6.x): enable monorepo splitter for 6.x branch

### DIFF
--- a/.github/workflows/splitter.yml
+++ b/.github/workflows/splitter.yml
@@ -3,7 +3,7 @@ name: 'Split up the monorepo into subrepositories'
 on:
     push:
         branches:
-            - '5.*'
+            - '6.*'
         tags-ignore:
             - '*'
 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | n  |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? |  n |
