### PR TITLE
fix(symfony/6.4): deprecations web/admin & cli

### DIFF
--- a/elasticms-admin/config/packages/doctrine.yaml
+++ b/elasticms-admin/config/packages/doctrine.yaml
@@ -17,8 +17,9 @@ doctrine:
             2: '%env(int:DB_CONNECTION_TIMEOUT)%' #const PDO:ATTR_TIMEOUT = 2 , minimum value is 2 https://pracucci.com/php-pdo-pgsql-connection-timeout.html
     orm:
         auto_generate_proxy_classes: true
-        naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware
         auto_mapping: true
+        enable_lazy_ghost_objects: true
+        naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware
 
 when@prod: &doctrine_prod
     doctrine:

--- a/elasticms-admin/config/packages/framework.yaml
+++ b/elasticms-admin/config/packages/framework.yaml
@@ -3,14 +3,16 @@ parameters:
     env(ELASTICMS_PATH): '%kernel.project_dir%/vendor/elasticms'
 
 framework:
-    secret: '%env(APP_SECRET)%'
     default_locale: '%env(DEFAULT_LOCAL)%'
+    http_method_override: false
+    handle_all_throwables: true
+    secret: '%env(APP_SECRET)%'
 
     session:
         handler_id: ~
-        storage_factory_id: session.storage.factory.native
         cookie_secure: auto
         cookie_samesite: strict
+        storage_factory_id: session.storage.factory.native
 
     esi: true
     fragments: true
@@ -20,8 +22,6 @@ framework:
     validation:
         email_validation_mode: html5
 
-    http_method_override: false
-    handle_all_throwables: true
 when@redis:
     framework:
         session:

--- a/elasticms-admin/config/packages/twig.yaml
+++ b/elasticms-admin/config/packages/twig.yaml
@@ -8,4 +8,3 @@ twig:
   exception_controller: null
   globals:
     ems_hash_algo: '%env(string:EMS_HASH_ALGO)%'
-

--- a/elasticms-cli/config/packages/doctrine.yaml
+++ b/elasticms-cli/config/packages/doctrine.yaml
@@ -8,8 +8,9 @@ doctrine:
         server_version: '%env(resolve:DB_SERVER_VERSION)%'
     orm:
         auto_generate_proxy_classes: true
-        naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware
         auto_mapping: true
+        enable_lazy_ghost_objects: true
+        naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware
         mappings:
             App:
               is_bundle: false

--- a/elasticms-cli/config/packages/framework.yaml
+++ b/elasticms-cli/config/packages/framework.yaml
@@ -1,19 +1,15 @@
 # see https://symfony.com/doc/current/reference/configuration/framework.html
 framework:
     secret: '%env(APP_SECRET)%'
-    #csrf_protection: true
     http_method_override: false
+    handle_all_throwables: true
 
-    # Enables session support. Note that the session will ONLY be started if you read or write from it.
-    # Remove or comment this section to explicitly disable session support.
     session:
         handler_id: null
         cookie_secure: auto
         cookie_samesite: lax
         storage_factory_id: session.storage.factory.native
 
-    #esi: true
-    #fragments: true
     php_errors:
         log: true
 

--- a/elasticms-web/config/packages/doctrine.yaml
+++ b/elasticms-web/config/packages/doctrine.yaml
@@ -17,8 +17,9 @@ doctrine:
             2: '%env(int:DB_CONNECTION_TIMEOUT)%' #const PDO:ATTR_TIMEOUT = 2 , minimum value is 2 https://pracucci.com/php-pdo-pgsql-connection-timeout.html
     orm:
         auto_generate_proxy_classes: true
-        naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware
         auto_mapping: true
+        enable_lazy_ghost_objects: true
+        naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware
 
 when@prod: &doctrine_prod
     doctrine:

--- a/elasticms-web/config/packages/framework.yaml
+++ b/elasticms-web/config/packages/framework.yaml
@@ -2,11 +2,15 @@ parameters:
     env(DEFAULT_LOCAL): 'en'
 
 framework:
-    secret: '%env(APP_SECRET)%'
     default_locale: '%env(DEFAULT_LOCAL)%'
+    http_method_override: false
+    handle_all_throwables: true
+    secret: '%env(APP_SECRET)%'
 
     session:
         handler_id: ~
+        cookie_secure: auto
+        cookie_samesite: strict
         storage_factory_id: session.storage.factory.native
 
     esi: true

--- a/elasticms-web/config/packages/security.yaml
+++ b/elasticms-web/config/packages/security.yaml
@@ -1,6 +1,4 @@
 security:
-    enable_authenticator_manager: true
-
     providers:
         core_api:
             id: emsch.security.core_api.user_provider


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

- fix deprecations framework.yaml for admin/cli & web
- remove enable_authenticator_manager for security.yaml in web
- set enable_lazy_ghost_objects to true in doctrine.yaml for admin/cli & web