### PR TITLE
fix(core/search): legacy search not working on overviews

### DIFF
--- a/EMS/core-bundle/src/Entity/Form/Search.php
+++ b/EMS/core-bundle/src/Entity/Form/Search.php
@@ -88,6 +88,7 @@ class Search implements \JsonSerializable
     public function __construct()
     {
         $this->filters = new ArrayCollection();
+        $this->filters->add(new SearchFilter());
     }
 
     /**

--- a/EMS/core-bundle/src/Entity/Form/SearchFilter.php
+++ b/EMS/core-bundle/src/Entity/Form/SearchFilter.php
@@ -86,7 +86,7 @@ class SearchFilter implements \JsonSerializable
                             $field ?: '_all' => [
                                 'query' => $this->pattern ?? '',
                                 'operator' => 'AND',
-                                'boost' => $this->boost ?? 1,
+                                'boost' => $this->boost ?? '1.0',
                             ],
                         ],
                     ];
@@ -111,7 +111,7 @@ class SearchFilter implements \JsonSerializable
                                 $field ?? '_all' => [
                                 'query' => $this->pattern ?: '',
                                 'operator' => 'OR',
-                                'boost' => $this->boost ?? 1,
+                                'boost' => $this->boost ?? '1.0',
                                 ],
                         ],
                     ];
@@ -121,7 +121,7 @@ class SearchFilter implements \JsonSerializable
                         'query_string' => [
                             'query' => $this->pattern ?? '*',
                             'default_operator' => 'AND',
-                            'boost' => $this->boost ?? 1,
+                            'boost' => $this->boost ?? '1.0',
                         ],
                     ];
                     if (!empty($field)) {
@@ -133,7 +133,7 @@ class SearchFilter implements \JsonSerializable
                         'query_string' => [
                             'query' => $this->pattern ?? '*',
                             'default_operator' => 'OR',
-                            'boost' => $this->boost ?? 1,
+                            'boost' => $this->boost ?? '1.0',
                         ],
                     ];
                     if (!empty($field)) {
@@ -145,7 +145,7 @@ class SearchFilter implements \JsonSerializable
                         'term' => [
                             $field ?: '_all' => [
                                 'value' => $this->pattern ?? '*',
-                                'boost' => $this->boost ?? 1,
+                                'boost' => $this->boost ?? '1.0',
                             ],
                         ],
                     ];
@@ -244,7 +244,7 @@ class SearchFilter implements \JsonSerializable
 
     public function setBoost(?float $boost): self
     {
-        $this->boost = (string) $boost;
+        $this->boost = $boost ? (string) $boost : null;
 
         return $this;
     }


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   |  n |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? |  n |
| Documentation? | n  |

The boost value is not passed correctly, plus add default empty filter
