### PR TITLE
fix(core/choice): multiple choice fields do not work

### DIFF
--- a/EMS/core-bundle/src/Form/DataField/ChoiceFieldType.php
+++ b/EMS/core-bundle/src/Form/DataField/ChoiceFieldType.php
@@ -17,8 +17,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class ChoiceFieldType extends DataFieldType
 {
     private ?int $fakeIndex = null;
-    /** @var array<string, string|int> */
-    private array $choices;
 
     public function getLabel(): string
     {

--- a/EMS/core-bundle/src/Form/DataField/ChoiceFieldType.php
+++ b/EMS/core-bundle/src/Form/DataField/ChoiceFieldType.php
@@ -65,13 +65,13 @@ class ChoiceFieldType extends DataFieldType
     {
         /** @var FieldType $fieldType */
         $fieldType = $builder->getOptions()['metadata'];
-        $this->choices = $this->buildChoices($options);
+        $choices = $this->buildChoices($options);
 
         $builder->add('value', ChoiceType::class, [
                 'label' => ($options['label'] ?? $fieldType->getName()),
                 'required' => false,
                 'disabled' => $this->isDisabled($options),
-                'choices' => $this->choices,
+                'choices' => $choices,
                 'empty_data' => $options['multiple'] ? [] : null,
                 'multiple' => $options['multiple'],
                 'expanded' => $options['expanded'],
@@ -172,7 +172,9 @@ class ChoiceFieldType extends DataFieldType
     {
         $value = $data['value'] ?? null;
         if (\is_array($value)) {
-            $value = \array_values(\array_filter($this->choices, fn ($v) => \in_array($v, $value)));
+            $choices = $fieldType->getDisplayOption('choices', '');
+            $values = \explode("\n", \str_replace("\r", '', (string) $choices));
+            $value = \array_values(\array_filter($values, static fn ($v) => \in_array($v, $value, true)));
         }
 
         return parent::reverseViewTransform($value, $fieldType);


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   |  n |
| BC breaks?     |  n |
| Deprecations?  |  n |
| Fixed tickets? |  n |
| Documentation? | n  |

Defining multiple choices field does not work. Because choices are build and stored into a private property. So the choices of the last build choice field are used inside the reverse transform.

Broken in: https://github.com/ems-project/elasticms/pull/674

Broken since [5.12.2](https://github.com/ems-project/elasticms/blob/5.x/CHANGELOG-5.x.md#5122-2023-12-21)
