### PR TITLE
fix(core/user): find users for role broken

### DIFF
--- a/EMS/core-bundle/src/Repository/UserRepository.php
+++ b/EMS/core-bundle/src/Repository/UserRepository.php
@@ -94,13 +94,13 @@ final class UserRepository extends ServiceEntityRepository implements UserReposi
      */
     public function findForRoleAndCircles(string $role, array $circles): array
     {
-        $resultSet = $this->createQueryBuilder('u')
-            ->where('u.roles like :role')
-            ->andWhere('u.enabled = :enabled')
-            ->setParameters([
-                    'role' => '%"'.$role.'"%',
-                    'enabled' => true,
-            ])->getQuery()->getResult();
+        $qb = $this->createQueryBuilder('u');
+        $resultSet = $qb
+            ->andWhere($qb->expr()->eq('u.enabled', $qb->expr()->literal(true)))
+            ->getQuery()
+            ->getResult();
+
+        $resultSet = \array_filter($resultSet, static fn (User $user) => \in_array($role, $user->getRoles()));
 
         if (!empty($circles)) {
             /** @var UserInterface $user */


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? |  n |
| Documentation? | n  |

Broken since 5.13.0 with this pr: https://github.com/ems-project/elasticms/pull/696
The `roles` column was changed to true json type.
