### PR TITLE
test(helpers): support by AI

### DIFF
--- a/EMS/helpers/src/Image/SmartCrop.php
+++ b/EMS/helpers/src/Image/SmartCrop.php
@@ -316,7 +316,7 @@ class SmartCrop
 
     private function thirds(float $x): float
     {
-        $x = (($x - (1 / 3) + 1.0) % 2.0 * 0.5 - 0.5) * 16;
+        $x = ((int) ($x - (1 / 3) + 1.0) % 2.0 * 0.5 - 0.5) * 16;
 
         return \max(1.0 - $x * $x, 0.0);
     }

--- a/EMS/helpers/tests/Unit/File/FileAiTest.php
+++ b/EMS/helpers/tests/Unit/File/FileAiTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\Helpers\Tests\Unit\File;
+
+use EMS\Helpers\File\File;
+use PHPUnit\Framework\TestCase;
+
+class FileAiTest extends TestCase
+{
+    private const TEST_FILE_PATH = __DIR__.'/file.txt';
+
+    protected function setUp(): void
+    {
+        \file_put_contents(self::TEST_FILE_PATH, \str_repeat('Test content', 1000));
+    }
+
+    protected function tearDown(): void
+    {
+        \unlink(self::TEST_FILE_PATH);
+    }
+
+    public function testConstruct()
+    {
+        $file = new File(new \SplFileInfo(self::TEST_FILE_PATH));
+        $this->assertInstanceOf(File::class, $file);
+        $this->assertEquals('file.txt', $file->name);
+        $this->assertEquals('txt', $file->extension);
+        $this->assertIsInt($file->size);
+        $this->assertEquals('text/plain', $file->mimeType);
+    }
+
+    public function testFromFilename()
+    {
+        $file = File::fromFilename(self::TEST_FILE_PATH);
+        $this->assertInstanceOf(File::class, $file);
+    }
+
+    public function testChunk()
+    {
+        $file = new File(new \SplFileInfo(self::TEST_FILE_PATH));
+        $chunks = $file->chunk(0, 1024);
+
+        foreach ($chunks as $chunk) {
+            $this->assertLessThanOrEqual(1024, \strlen($chunk));
+        }
+    }
+}

--- a/EMS/helpers/tests/Unit/File/FolderAiTest.php
+++ b/EMS/helpers/tests/Unit/File/FolderAiTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\Helpers\Tests\Unit\File;
+
+use EMS\Helpers\File\Folder;
+use PHPUnit\Framework\TestCase;
+
+class FolderAiTest extends TestCase
+{
+    private string $testFolderPath;
+
+    protected function setUp(): void
+    {
+        $this->testFolderPath = \sys_get_temp_dir().DIRECTORY_SEPARATOR.'/path/to/test/folder';
+    }
+
+    public function testGetRealPathWithExistingDirectory()
+    {
+        \mkdir($this->testFolderPath, 0777, true);
+        $realPath = Folder::getRealPath($this->testFolderPath);
+        $this->assertEquals(\realpath($this->testFolderPath), $realPath);
+    }
+
+    public function testGetRealPathWithNonExistingDirectory()
+    {
+        $realPath = Folder::getRealPath($this->testFolderPath);
+        $this->assertEquals(\realpath($this->testFolderPath), $realPath);
+    }
+
+    protected function tearDown(): void
+    {
+        \rmdir($this->testFolderPath);
+    }
+}

--- a/EMS/helpers/tests/Unit/File/TempFileAiTest.php
+++ b/EMS/helpers/tests/Unit/File/TempFileAiTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\Helpers\Tests\Unit\File;
+
+use EMS\Helpers\File\TempFile;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\StreamInterface;
+
+class TempFileAiTest extends TestCase
+{
+    public function testCreate()
+    {
+        $tempFile = TempFile::create();
+        $this->assertInstanceOf(TempFile::class, $tempFile);
+        $this->assertTrue(\file_exists($tempFile->path));
+    }
+
+    public function testCreateNamed()
+    {
+        $name = 'testfile.txt';
+        $tempFile = TempFile::createNamed($name);
+        $this->assertInstanceOf(TempFile::class, $tempFile);
+        $this->assertEquals(\sys_get_temp_dir().DIRECTORY_SEPARATOR.'EMS_temp_file_'.$name, $tempFile->path);
+    }
+
+    public function testLoadFromStream()
+    {
+        $tempFile = TempFile::create();
+        $stream = $this->createMock(StreamInterface::class);
+        $stream->method('eof')->willReturnOnConsecutiveCalls(false, true);
+        $stream->method('read')->willReturn('Test content');
+
+        $tempFile->loadFromStream($stream);
+        $this->assertTrue(\file_exists($tempFile->path));
+        $this->assertEquals('Test content', \file_get_contents($tempFile->path));
+    }
+
+    public function testClean()
+    {
+        $tempFile = TempFile::create();
+        $tempFile->clean();
+        $this->assertFalse(\file_exists($tempFile->path));
+    }
+}

--- a/EMS/helpers/tests/Unit/Html/Sanitizer/HtmlSanitizerLinkAiTest.php
+++ b/EMS/helpers/tests/Unit/Html/Sanitizer/HtmlSanitizerLinkAiTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\Helpers\Tests\Unit\Html\Sanitizer;
+
+use EMS\Helpers\Html\Sanitizer\HtmlSanitizerLink;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig;
+
+class HtmlSanitizerLinkAiTest extends TestCase
+{
+    private HtmlSanitizerLink $sanitizer;
+
+    protected function setUp(): void
+    {
+        $this->sanitizer = new HtmlSanitizerLink();
+    }
+
+    public function testSanitizeAttributeWithEmsScheme()
+    {
+        $element = 'a';
+        $attribute = 'href';
+        $value = 'ems://some-resource';
+        $config = new HtmlSanitizerConfig();
+
+        $sanitizedValue = $this->sanitizer->sanitizeAttribute($element, $attribute, $value, $config);
+        $this->assertEquals('ems://some-resource', $sanitizedValue);
+    }
+
+    public function testSanitizeAttributeWithHttpScheme()
+    {
+        $element = 'a';
+        $attribute = 'href';
+        $value = 'http://example.com';
+        $config = new HtmlSanitizerConfig();
+
+        $sanitizedValue = $this->sanitizer->sanitizeAttribute($element, $attribute, $value, $config);
+        $this->assertEquals('http://example.com', $sanitizedValue);
+    }
+
+    public function testSanitizeAttributeWithJavascriptScheme()
+    {
+        $element = 'a';
+        $attribute = 'href';
+        $value = 'javascript:alert(1)';
+        $config = new HtmlSanitizerConfig();
+
+        $sanitizedValue = $this->sanitizer->sanitizeAttribute($element, $attribute, $value, $config);
+        $this->assertNull($sanitizedValue);
+    }
+
+    public function testGetSupportedElements()
+    {
+        $this->assertNull($this->sanitizer->getSupportedElements());
+    }
+
+    public function testGetSupportedAttributes()
+    {
+        $this->assertEquals(['src', 'href', 'lowsrc', 'background', 'ping'], $this->sanitizer->getSupportedAttributes());
+    }
+}

--- a/EMS/helpers/tests/Unit/Image/SmartCropAiTest.php
+++ b/EMS/helpers/tests/Unit/Image/SmartCropAiTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\Helpers\Tests\Unit\Image;
+
+use EMS\Helpers\Image\SmartCrop;
+use PHPUnit\Framework\TestCase;
+
+class SmartCropAiTest extends TestCase
+{
+    private \GdImage $image;
+    private int $cropWidth = 100;
+    private int $cropHeight = 100;
+
+    protected function setUp(): void
+    {
+        $this->image = \imagecreatetruecolor(200, 200);
+    }
+
+    protected function tearDown(): void
+    {
+        \imagedestroy($this->image);
+    }
+
+    public function testConstructor()
+    {
+        $smartCrop = new SmartCrop($this->image, $this->cropWidth, $this->cropHeight);
+        $this->assertInstanceOf(SmartCrop::class, $smartCrop);
+    }
+
+    public function testAnalyse()
+    {
+        $smartCrop = new SmartCrop($this->image, $this->cropWidth, $this->cropHeight);
+        $result = $smartCrop->analyse();
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('topCrop', $result);
+    }
+
+    public function testCrop()
+    {
+        $smartCrop = new SmartCrop($this->image, $this->cropWidth, $this->cropHeight);
+        $cropped = $smartCrop->crop(50, 50, $this->cropWidth, $this->cropHeight);
+        $this->assertInstanceOf(SmartCrop::class, $cropped);
+    }
+
+    public function testGet()
+    {
+        $smartCrop = new SmartCrop($this->image, $this->cropWidth, $this->cropHeight);
+        $resultImage = $smartCrop->get();
+        $this->assertInstanceOf(\GdImage::class, $resultImage);
+    }
+}

--- a/EMS/helpers/tests/Unit/Standard/AccessorAiTest.php
+++ b/EMS/helpers/tests/Unit/Standard/AccessorAiTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\Helpers\Tests\Unit\Standard;
+
+use EMS\Helpers\Standard\Accessor;
+use PHPUnit\Framework\TestCase;
+
+class AccessorAiTest extends TestCase
+{
+    public function testFieldPathToPropertyPath(): void
+    {
+        $this->assertSame('[field][subfield]', Accessor::fieldPathToPropertyPath('field.subfield'));
+        $this->assertSame('[field][0]', Accessor::fieldPathToPropertyPath('field[0]'));
+        $this->assertSame('[field][subfield][0]', Accessor::fieldPathToPropertyPath('field.subfield[0]'));
+        $this->assertSame('[field][sub][0]', Accessor::fieldPathToPropertyPath('field.sub[0]'));
+    }
+}

--- a/EMS/helpers/tests/Unit/Standard/Base64AiTest.php
+++ b/EMS/helpers/tests/Unit/Standard/Base64AiTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\Helpers\Tests\Unit\Standard;
+
+use EMS\Helpers\Standard\Base64;
+use PHPUnit\Framework\TestCase;
+
+class Base64AiTest extends TestCase
+{
+    public function testEncode()
+    {
+        $originalString = 'Test String';
+        $encodedString = Base64::encode($originalString);
+        $this->assertEquals(\base64_encode($originalString), $encodedString);
+    }
+
+    public function testDecode()
+    {
+        $encodedString = \base64_encode('Test String');
+        $decodedString = Base64::decode($encodedString);
+        $this->assertEquals('Test String', $decodedString);
+    }
+
+    public function testDecodeThrowsRuntimeExceptionOnInvalidBase64()
+    {
+        $this->expectException(\RuntimeException::class);
+        Base64::decode('@');
+    }
+}

--- a/EMS/helpers/tests/Unit/Standard/ColorAiTest.php
+++ b/EMS/helpers/tests/Unit/Standard/ColorAiTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\Helpers\Tests\Unit\Standard;
+
+use EMS\Helpers\Standard\Color;
+use PHPUnit\Framework\TestCase;
+
+class ColorAiTest extends TestCase
+{
+    public function testConstructorWithEMSColor()
+    {
+        $color = new Color('ems-blue');
+        $this->assertEquals(60, $color->getRed());
+        $this->assertEquals(141, $color->getGreen());
+        $this->assertEquals(188, $color->getBlue());
+    }
+
+    public function testConstructorWithStandardHtmlColor()
+    {
+        $color = new Color('blue');
+        $this->assertEquals(0, $color->getRed());
+        $this->assertEquals(0, $color->getGreen());
+        $this->assertEquals(255, $color->getBlue());
+    }
+
+    public function testConstructorWithHexColor()
+    {
+        $color = new Color('#FF5733');
+        $this->assertEquals(255, $color->getRed());
+        $this->assertEquals(87, $color->getGreen());
+        $this->assertEquals(51, $color->getBlue());
+    }
+
+    public function testGetSetRed()
+    {
+        $color = new Color('#000000');
+        $color->setRed(123);
+        $this->assertEquals(123, $color->getRed());
+    }
+
+    public function testGetSetGreen()
+    {
+        $color = new Color('#000000');
+        $color->setGreen(123);
+        $this->assertEquals(123, $color->getGreen());
+    }
+
+    public function testGetSetBlue()
+    {
+        $color = new Color('#000000');
+        $color->setBlue(123);
+        $this->assertEquals(123, $color->getBlue());
+    }
+
+    public function testGetSetAlpha()
+    {
+        $color = new Color('#000000');
+        $color->setAlpha(123);
+        $this->assertEquals(123, $color->getAlpha());
+    }
+
+    public function testGetColorId()
+    {
+        $color = new Color('#000000');
+        $image = \imagecreatetruecolor(100, 100);
+        $colorId = $color->getColorId($image);
+        $this->assertIsInt($colorId);
+        \imagedestroy($image);
+    }
+
+    public function testRelativeLuminance()
+    {
+        $color = new Color('#FFFFFF');
+        $this->assertEquals(1.0, $color->relativeLuminance(), '', 0.01);
+    }
+
+    public function testContrastRatio()
+    {
+        $color1 = new Color('#FFFFFF');
+        $color2 = new Color('#000000');
+        $this->assertEquals(21, $color1->contrastRatio($color2), '', 0.01);
+    }
+
+    public function testGetComplementary()
+    {
+        $color = new Color('#FFFFFF');
+        $complementary = $color->getComplementary();
+        $this->assertEquals(0, $complementary->getRed());
+        $this->assertEquals(0, $complementary->getGreen());
+        $this->assertEquals(0, $complementary->getBlue());
+    }
+
+    public function testGetRGB()
+    {
+        $color = new Color('#FF5733');
+        $this->assertEquals('#FF5733', $color->getRGB());
+    }
+
+    public function testGetRGBA()
+    {
+        $color = new Color('#FF5733');
+        $color->setAlpha(127);
+        $this->assertEquals('#FF57337F', $color->getRGBA());
+    }
+}

--- a/EMS/helpers/tests/Unit/Standard/DateTimeAiTest.php
+++ b/EMS/helpers/tests/Unit/Standard/DateTimeAiTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\Helpers\Tests\Unit\Standard;
+
+use EMS\Helpers\Standard\DateTime;
+use PHPUnit\Framework\TestCase;
+
+class DateTimeAiTest extends TestCase
+{
+    public function testCreate()
+    {
+        $timeString = '2024-01-01 00:00:00';
+        $dateTime = DateTime::create($timeString);
+        $this->assertInstanceOf(\DateTimeImmutable::class, $dateTime);
+        $this->assertEquals('2024-01-01T00:00:00+00:00', $dateTime->format(\DateTimeInterface::ATOM));
+    }
+
+    public function testCreateThrowsRuntimeExceptionOnInvalidTime()
+    {
+        $this->expectException(\RuntimeException::class);
+        DateTime::create('invalid-time-string');
+    }
+
+    public function testCreateFromFormat()
+    {
+        $timeString = '2024-01-01T00:00:00+00:00';
+        $dateTime = DateTime::createFromFormat($timeString, \DateTimeInterface::ATOM);
+        $this->assertInstanceOf(\DateTimeImmutable::class, $dateTime);
+        $this->assertEquals($timeString, $dateTime->format(\DateTimeInterface::ATOM));
+    }
+
+    public function testCreateFromFormatThrowsRuntimeExceptionOnInvalidFormat()
+    {
+        $this->expectException(\RuntimeException::class);
+        DateTime::createFromFormat('2024-01-01 00:00:00', 'invalid-format');
+    }
+}

--- a/EMS/helpers/tests/Unit/Standard/HashAiTest.php
+++ b/EMS/helpers/tests/Unit/Standard/HashAiTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\Helpers\Tests\Unit\Standard;
+
+use EMS\Helpers\Standard\Hash;
+use PHPUnit\Framework\TestCase;
+
+class HashAiTest extends TestCase
+{
+    public function testStringHash()
+    {
+        $originalString = 'Test String';
+        $hashedString = Hash::string($originalString);
+        $this->assertEquals(\sha1($originalString), $hashedString);
+    }
+
+    public function testStringHashWithPrefix()
+    {
+        $originalString = 'Test String';
+        $prefix = 'prefix_';
+        $hashedString = Hash::string($originalString, $prefix);
+        $this->assertEquals($prefix.\sha1($originalString), $hashedString);
+    }
+
+    public function testArrayHash()
+    {
+        $array = ['key' => 'value'];
+        $hashedArray = Hash::array($array);
+        $this->assertEquals(\sha1(\json_encode($array)), $hashedArray);
+    }
+
+    public function testArrayHashWithPrefix()
+    {
+        $array = ['key' => 'value'];
+        $prefix = 'prefix_';
+        $hashedArray = Hash::array($array, $prefix);
+        $this->assertEquals($prefix.\sha1(\json_encode($array)), $hashedArray);
+    }
+}

--- a/EMS/helpers/tests/Unit/Standard/TypeAiTest.php
+++ b/EMS/helpers/tests/Unit/Standard/TypeAiTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\Helpers\Tests\Unit\Standard;
+
+use EMS\Helpers\Standard\Type;
+use PHPUnit\Framework\TestCase;
+
+class TypeAiTest extends TestCase
+{
+    public function testStringWithValidString()
+    {
+        $this->assertEquals('test', Type::string('test'));
+    }
+
+    public function testStringWithInvalidType()
+    {
+        $this->expectException(\RuntimeException::class);
+        Type::string(123);
+    }
+
+    public function testIntegerWithValidInteger()
+    {
+        $this->assertEquals(123, Type::integer(123));
+    }
+
+    public function testIntegerWithInvalidType()
+    {
+        $this->expectException(\RuntimeException::class);
+        Type::integer('test');
+    }
+
+    public function testArrayWithValidArray()
+    {
+        $this->assertEquals(['key' => 'value'], Type::array(['key' => 'value']));
+    }
+
+    public function testArrayWithInvalidType()
+    {
+        $this->expectException(\RuntimeException::class);
+        Type::array('not an array');
+    }
+
+    public function testGdImageWithValidGdImage()
+    {
+        $image = \imagecreatetruecolor(100, 100);
+        $this->assertInstanceOf(\GdImage::class, Type::gdImage($image));
+        \imagedestroy($image);
+    }
+
+    public function testGdImageWithInvalidType()
+    {
+        $this->expectException(\RuntimeException::class);
+        Type::gdImage('not a gd image');
+    }
+}


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | Y  |
| New feature?   |   |
| BC breaks?     |   |
| Deprecations?  |   |
| Fixed tickets? |   |
| Documentation? |   |

Add tests for :
/File/*
/Image/*
/Standard/*
/Sanitizer/HtmlSanitizerLink

@theus77 I needed to fix : https://github.com/ems-project/elasticms/pull/743/commits/efbd79a778bd67a2ee7a6e9bf51d7d047d02131c to avoid deprecation notices :

>   24x: Implicit conversion from float 1.6666666666666667 to int loses precision
>     24x in SmartCropAiTest::testAnalyse from EMS\Helpers\Tests\Unit\Image