### PR TITLE
fix(core/choice):  duplicate helptext in choice block

### DIFF
--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/form/fields.html.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/form/fields.html.twig
@@ -455,15 +455,6 @@
 	{{ parent() }}
 {% endblock form_errors %}
 
-{% block choice_errors %}
-    {% if form.parent is defined and form.parent.vars.helptext is defined and form.parent.vars.helptext %}
-        <div class="help-block">{{ form.parent.vars.helptext|raw }}</div>
-    {% endif %}
-    {{ block('form_errors') }}
-{% endblock choice_errors %}
-
-
-
 {% block tabsfieldtype_row -%}
 {# <div class="form-group{% if class %} {{ class }}{% else %} col-xs-12 {% endif %}{% if (not compound or force_error|default(false)) and not valid %} has-error{% endif %}">#}
 {# 	<div class="panel panel-default">#}

--- a/EMS/core-bundle/src/Resources/views/form/fields.html.twig
+++ b/EMS/core-bundle/src/Resources/views/form/fields.html.twig
@@ -457,15 +457,6 @@
 	{{ parent() }}
 {% endblock form_errors %}
 
-{% block choice_errors %}
-    {% if form.parent is defined and form.parent.vars.helptext is defined and form.parent.vars.helptext %}
-        <div class="help-block">{{ form.parent.vars.helptext|raw }}</div>
-    {% endif %}
-    {{ block('form_errors') }}
-{% endblock choice_errors %}
-
-
-
 {% block tabsfieldtype_row -%}
 {# <div class="form-group{% if class %} {{ class }}{% else %} col-xs-12 {% endif %}{% if (not compound or force_error|default(false)) and not valid %} has-error{% endif %}">#}
 {# 	<div class="panel panel-default">#}


### PR DESCRIPTION
choice_errors is directly calling form_errors and both render the helptext

| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  |  n |
| Fixed tickets? |  n |
| Documentation? | n  |

