### PR TITLE
fix(helpers): HTML sanitizer

### DIFF
--- a/EMS/helpers/src/Html/Sanitizer/HtmlSanitizerClass.php
+++ b/EMS/helpers/src/Html/Sanitizer/HtmlSanitizerClass.php
@@ -31,16 +31,16 @@ class HtmlSanitizerClass implements AttributeSanitizerInterface
         $classes = \explode(' ', $value);
         $classNames = \array_filter($classes, 'trim');
 
+        if (\count($this->settings['replace']) > 0) {
+            $classNames = \array_map(fn (string $className) => $this->settings['replace'][$className] ?? $className, $classNames);
+        }
+
         if (\count($this->settings['allow']) > 0) {
             $classNames = \array_filter($classNames, fn (string $className) => \in_array($className, $this->settings['allow']));
         }
 
         if (\count($this->settings['drop']) > 0) {
             $classNames = \array_filter($classNames, fn (string $className) => !\in_array($className, $this->settings['drop']));
-        }
-
-        if (\count($this->settings['replace']) > 0) {
-            $classNames = \array_map(fn (string $className) => $this->settings['replace'][$className] ?? $className, $classNames);
         }
 
         return \count($classNames) > 0 ? \implode(' ', $classNames) : null;

--- a/EMS/helpers/tests/Unit/Html/Sanitizer/HtmlSanitizerClassAiTest.php
+++ b/EMS/helpers/tests/Unit/Html/Sanitizer/HtmlSanitizerClassAiTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\Helpers\Tests\Unit\Html\Sanitizer;
+
+use EMS\Helpers\Html\Sanitizer\HtmlSanitizerClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig;
+
+class HtmlSanitizerClassAiTest extends TestCase
+{
+    private HtmlSanitizerClass $sanitizer;
+
+    protected function setUp(): void
+    {
+        $this->sanitizer = new HtmlSanitizerClass([
+            'allow' => ['allowed-class', 'new-class'],
+            'drop' => ['dropped-class'],
+            'replace' => ['old-class' => 'new-class'],
+        ]);
+    }
+
+    public function testGetSupportedElements(): void
+    {
+        $this->assertNull($this->sanitizer->getSupportedElements());
+    }
+
+    public function testGetSupportedAttributes(): void
+    {
+        $expectedAttributes = ['class'];
+        $this->assertEquals($expectedAttributes, $this->sanitizer->getSupportedAttributes());
+    }
+
+    public function testSanitizeAttribute(): void
+    {
+        $config = $this->createMock(HtmlSanitizerConfig::class);
+        $element = 'div';
+        $attribute = 'class';
+
+        // Test allow
+        $value = 'allowed-class';
+        $this->assertEquals('allowed-class', $this->sanitizer->sanitizeAttribute($element, $attribute, $value, $config));
+
+        // Test drop
+        $value = 'dropped-class';
+        $this->assertNull($this->sanitizer->sanitizeAttribute($element, $attribute, $value, $config));
+
+        // Test replace
+        $value = 'old-class';
+        $this->assertEquals('new-class', $this->sanitizer->sanitizeAttribute($element, $attribute, $value, $config));
+
+        // Test multiple classes
+        $value = 'allowed-class dropped-class old-class';
+        $this->assertEquals('allowed-class new-class', $this->sanitizer->sanitizeAttribute($element, $attribute, $value, $config));
+    }
+}

--- a/docs/dev/helpers/standard.md
+++ b/docs/dev/helpers/standard.md
@@ -97,9 +97,9 @@ $settings = [
     ],
     'drop_elements' => [ 'iframe' ], // remove all `iframe` elements and content
     'classes' => [
-        'allow' => ['my-class', 'my-second-class'],
+        'allow' => ['my-class', 'my-second-class', 'new-class'],
         'drop' => ['delete', 'remove'],
-        'replace' => ['test' => 'example'], 
+        'replace' => ['old-class' => 'new-class'], // IMPORTANT: add new-class in the 'allow' array
     ]
 ]
 ```


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  Y  |
| New feature?   |   |
| BC breaks?     |   |
| Deprecations?  |   |
| Fixed tickets? |   |
| Documentation? |   |

When we use "replace" classes, we first need to replace classes and then check if the classes are allowed. 
