### PR TITLE
fix(core/ldap): config contains empty strings

### DIFF
--- a/EMS/core-bundle/src/Security/Ldap/LdapConfig.php
+++ b/EMS/core-bundle/src/Security/Ldap/LdapConfig.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace EMS\CoreBundle\Security\Ldap;
 
 use EMS\CoreBundle\Roles;
+use EMS\Helpers\Standard\Type;
 
 final class LdapConfig
 {
@@ -46,14 +47,14 @@ final class LdapConfig
         $this->searchDn = $config['search_dn'] ?? '';
         $this->searchPassword = $config['search_password'] ?? '';
 
-        $this->passwordAttribute = $config['password_attribute'] ?? null;
-        $this->filter = $config['filter'] ?? null;
+        $this->passwordAttribute = ($config['password_attribute'] ?? '') !== '' ? $config['password_attribute'] : null;
+        $this->filter = ($config['filter'] ?? '') !== '' ? $config['filter'] : null;
 
         $this->defaultRoles = $config['default_roles'] ?? [Roles::ROLE_USER];
         $this->extraFields = $config['extra_fields'] ?? [];
 
-        $this->emailField = $config['email_field'] ?? null;
-        $this->displayNameField = $config['display_name_field'] ?? null;
-        $this->uidKey = $config['uid_key'] ?? null;
+        $this->emailField = ($config['email_field'] ?? '') !== '' ? $config['email_field'] : null;
+        $this->displayNameField = ($config['display_name_field'] ?? '') !== '' ? $config['display_name_field'] : null;
+        $this->uidKey = ($config['uid_key'] ?? '') !== '' ? $config['uid_key'] : null;
     }
 }

--- a/EMS/core-bundle/src/Security/Ldap/LdapConfig.php
+++ b/EMS/core-bundle/src/Security/Ldap/LdapConfig.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace EMS\CoreBundle\Security\Ldap;
 
 use EMS\CoreBundle\Roles;
-use EMS\Helpers\Standard\Type;
 
 final class LdapConfig
 {

--- a/EMS/core-bundle/src/Security/Ldap/LdapCoreUserFactory.php
+++ b/EMS/core-bundle/src/Security/Ldap/LdapCoreUserFactory.php
@@ -40,6 +40,12 @@ final class LdapCoreUserFactory
      */
     private static function getExtraField(array $extraFields, ?string $field): ?string
     {
-        return $field ? $extraFields[$field] : null;
+        $extraFieldValue = $field ? $extraFields[$field] : null;
+
+        if (is_array($extraFieldValue) && count($extraFieldValue) === 1) {
+            $extraFieldValue = array_values($extraFieldValue)[0];
+        }
+
+        return $extraFieldValue;
     }
 }

--- a/EMS/core-bundle/src/Security/Ldap/LdapCoreUserFactory.php
+++ b/EMS/core-bundle/src/Security/Ldap/LdapCoreUserFactory.php
@@ -42,8 +42,8 @@ final class LdapCoreUserFactory
     {
         $extraFieldValue = $field ? $extraFields[$field] : null;
 
-        if (is_array($extraFieldValue) && count($extraFieldValue) === 1) {
-            $extraFieldValue = array_values($extraFieldValue)[0];
+        if (\is_array($extraFieldValue) && 1 === \count($extraFieldValue)) {
+            $extraFieldValue = \array_values($extraFieldValue)[0];
         }
 
         return $extraFieldValue;


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   |  n |
| BC breaks?     |  n |
| Deprecations?  |  n |
| Fixed tickets? |  n |
| Documentation? | n  |

Ldap configuration not working because not defining `EMSCO_LDAP_PASSWORD_ATTRIBUTE` will pass an empty string to ldap library.

Plus the extraFields can return an array of emails
