### PR TITLE
fix(core/ldap): ldap not configured should through error

### DIFF
--- a/EMS/core-bundle/src/Resources/config/security/ldap.xml
+++ b/EMS/core-bundle/src/Resources/config/security/ldap.xml
@@ -18,6 +18,7 @@
 
         <service id="emsco.security.authenticator.form_login_ldap" class="EMS\CoreBundle\Security\Ldap\LdapFormLoginAuthenticator">
             <argument type="service" id="ems_core.security.ldap.config" />
+            <argument type="service" id="emsco.security.provider.user_ldap" />
             <argument type="service" id="router" />
         </service>
 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? |  n |
| Documentation? | n  |

By default the elasticms-admin has ldap enabled ```env(EMSCO_LDAP_ENABLED): true```.

If we only provide APP_LDAP_* and *not* the EMSCO_LDAP_* settings, we can authenticate with just a username and a random password. 


