### PR TITLE
refactor(actions-button): move logic to identify if actions are not available

### DIFF
--- a/EMS/core-bundle/src/Resources/translations/EMSCoreBundle.en.yml
+++ b/EMS/core-bundle/src/Resources/translations/EMSCoreBundle.en.yml
@@ -1015,6 +1015,7 @@ views:
             raw-view: 'Raw view'
             raw-view-icon-class: 'fa fa-th'
             action-dropdown-label: 'Actions in %environment%'
+            publish-label: 'Publish in %environment%'
         revision-toolbar-html:
             add-to-release: 'Add to release'
 wysiwyg:

--- a/EMS/core-bundle/src/Resources/views/elements/object-views-button.html.twig
+++ b/EMS/core-bundle/src/Resources/views/elements/object-views-button.html.twig
@@ -2,108 +2,165 @@
 {%- set ouuid = object.ouuid|default(object._id is defined ? object._id : '') -%}
 {%- set source = object.source|default(object._source is defined ? object._source : []) -%}
 {%- if contentType -%}
-	<div class="btn-group">
-		<button type="button" class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
-			<i class="{{ 'views.elements.object-views-button.action-dropdown-icon-class'|trans }}"></i>
-			{{ 'views.elements.object-views-button.action-dropdown-label'|trans({'%environment%': environment.label}) }}
-			<span class="caret"></span>
-			<span class="sr-only">{{ 'views.elements.object-views-button.action-dropdown-sr-only'|trans({'%environment%': environment.label}) }}</span>
-		</button>
-		<ul class="dropdown-menu" role="menu">
-				{% for template in contentType.templates %}
-					{%  if currentTemplate is not defined or template != currentTemplate %}
-					{%if template.role == "not-defined" or is_granted(template.role) and (template.environments is empty or environment in template.environments or template.isEnvironmentExist(environment.name)) %}
-					
-						{% if template.renderOption is constant('EMS\\CoreBundle\\Form\\Field\\RenderOptionType::EXTERNALLINK') %}
-							{% set link = template.body|generate_from_template({
-									environment: environment,
-									contentType: contentType,
-									object: object,
-									source: source
-								}) %}
+    {% set contentTypeActions = [] %}
 
-    							<li class="{% if not link %}disabled{% endif %}"><a href="{{ link }}" target="_blank">
-    								<i class="{{ template.icon|raw }}"></i>
-    								{{ template.label}}
-    								<i class="fa fa-external-link pull-right"></i>
-    							</a></li>
+    {% for template in contentType.templates %}
+        {% if currentTemplate is not defined or template != currentTemplate %}
+            {% if template.role == "not-defined" or is_granted(template.role) and (template.environments is empty or environment in template.environments or template.isEnvironmentExist(environment.name)) %}
+                {% if template.renderOption is constant('EMS\\CoreBundle\\Form\\Field\\RenderOptionType::EXTERNALLINK') %}
+                    {% set link = template.body|generate_from_template({
+                        environment: environment,
+                        contentType: contentType,
+                        object: object,
+                        source: source
+                    }) %}
 
-						{% elseif template.renderOption is constant('EMS\\CoreBundle\\Form\\Field\\RenderOptionType::RAW_HTML') %}
-							{%- if (is_granted(template.role)) or template.role == "not-defined" -%}
-								{%- set rawHTML = template.body|generate_from_template({
-									environment: environment,
-									contentType: contentType,
-									object: object,
-									source: source
-								}) -%}
-								{%- if rawHTML != '' -%}<li>{{ rawHTML|raw  }}</li>{%- endif -%}
-							{%- endif -%}
-						{% elseif template.renderOption is constant('EMS\\CoreBundle\\Form\\Field\\RenderOptionType::NOTIFICATION') %}
-							{% if ( is_granted(template.role) and ((attribute(source, contentType.circlesField) is not defined) or (source and attribute(source, contentType.circlesField)|in_my_circles) or (environment.circles|in_my_circles and is_granted('ROLE_PUBLISHER')) ) ) %}
-								<li><a href='#' class="request_notification" onclick="requestNotification(this, {{template.id}}, '{{environment.name}}', '{{contentType.id}}' , '{{ouuid}}'); return false;" href="#" data-url="{{ path('notification.ajaxnotification', {'objectId' : ouuid}) }}">
-									<i class="{{ template.icon|raw }}"></i>
-									{{ template.label }}
-								</a></li>
-							{% endif %}
-                        {% elseif template.renderOption is constant('EMS\\CoreBundle\\Form\\Field\\RenderOptionType::JOB') %}
-            				{% if (is_granted(template.role)) or template.role == "not-defined" %}
-								<li><a href="#" class="request_job" data-url="{{ path('ems_job_custom_view', {'environmentName': environment.name, 'templateId': template.id, 'ouuid': ouuid}) }}">
-									<i class="{{ template.icon|raw }}"></i>
-									{{ template.label }}
-								</a></li>
-							{% endif %}
-						{% elseif template.renderOption is constant('EMS\\CoreBundle\\Form\\Field\\RenderOptionType::IMPORT') %}
-							{%- if (is_granted(template.role)) or template.role == "not-defined" -%}
-								{%- set importModalUrl = path('emsco_data_action_import',  { 'actionId': template.id, 'ouuid': ouuid})  -%}
-								<li><a href="#" data-ajax-modal-url="{{ importModalUrl }}" data-ajax-modal-size="md"><i class="{{ template.icon|raw }}"></i>{{ template.label }}</a></li>
-							{%- endif -%}
-						{% else %}
-							<li><a href="{{ path(template.public?'ems_data_custom_template_public':'ems_data_custom_template_protected', {
-										environmentName: environment.name,
-										ouuid: ouuid,
-										templateId: template.id}) }}" >
-								<i class="{{ template.icon|raw }}"></i>
-								{{ template.label }}
-							</a></li>
-						{% endif %}						
-							
-					
-					{% endif %}	
-					{% endif %}					
-				{% endfor %}
-				{% if is_granted('ROLE_COPY_PASTE') %}
-					<li>
-						<a href="{{ path('revision.copy', {'environment': environment.name, 'type': contentType.name, 'ouuid': ouuid} ) }}">
-							<i class="{{ 'views.elements.object-views-button.copy-data-icon-class'|trans }}"></i>
-							{{ 'views.elements.object-views-button.copy-data'|trans }}
-						</a>
-					</li>
-					{% if not contentType.askForOuuid  %}
-						<li>
-							{% include '@EMSCore/elements/post-button.html.twig' with {
-								'url': path('emsco_duplicate_revision', {'environment': environment.name, 'type': contentType.name, 'ouuid': ouuid}),
-								'label': 'Duplicate',
-								'icon': 'clone',
-								'btnClass': ''
-							}%}
-						</li>
-					{% endif %}
-					<li>
-						<a href="{{ path('data.view', {'environmentName': environment.name, 'type': contentType.name, 'ouuid': ouuid} ) }}">
-							<i class="{{ 'views.elements.object-views-button.raw-view-icon-class'|trans }}"></i>
-							{{ 'views.elements.object-views-button.raw-view'|trans }}
-						</a>
-					</li>
+                    {% set action = {
+                        link: link,
+                        link_attributes: [ { name: 'target', value: '_blank' } ],
+                        icon: template.icon,
+                        label: template.label,
+                        suffix_icon: 'fa fa-external-link pull-right'
+                    } %}
+                    {% if not link %}
+                        {% set action = action|merge({ list_item_classes: ['disabled'] }) %}
+                    {% endif %}
+                    {% set contentTypeActions = contentTypeActions|merge([action]) %}
+                {% elseif template.renderOption is constant('EMS\\CoreBundle\\Form\\Field\\RenderOptionType::RAW_HTML') %}
+                    {%- if (is_granted(template.role)) or template.role == "not-defined" -%}
+                        {%- set rawHTML = template.body|generate_from_template({
+                            environment: environment,
+                            contentType: contentType,
+                            object: object,
+                            source: source
+                        }) -%}
+                        {%- if rawHTML != '' -%}
+                            {% set contentTypeActions = contentTypeActions|merge([{ label: rawHTML|raw }]) %}
+                        {%- endif -%}
+                    {%- endif -%}
+                {% elseif template.renderOption is constant('EMS\\CoreBundle\\Form\\Field\\RenderOptionType::NOTIFICATION') %}
+                    {% if ( is_granted(template.role) and ((attribute(source, contentType.circlesField) is not defined) or (source and attribute(source, contentType.circlesField)|in_my_circles) or (environment.circles|in_my_circles and is_granted('ROLE_PUBLISHER')) ) ) %}
+                        {% set action = {
+                            link: '#',
+                            link_attributes: [
+                                { name: 'class', value: 'request_notification' },
+                                { name: 'onclick', value: "requestNotification(this, #{template.id}, '#{environment.name}', '#{contentType.id}' , '#{ouuid}'); return false;" },
+                                { name: 'data-url', value: path('notification.ajaxnotification', {'objectId' : ouuid}) }
+                            ],
+                            icon: template.icon,
+                            label: template.label
+                        } %}
+                        {% set contentTypeActions = contentTypeActions|merge([action]) %}
+                    {% endif %}
+                {% elseif template.renderOption is constant('EMS\\CoreBundle\\Form\\Field\\RenderOptionType::JOB') %}
+                    {% if (is_granted(template.role)) or template.role == "not-defined" %}
+                        {% set action = {
+                            link: '#',
+                            link_attributes: [
+                                { name: 'class', value: 'request_job' },
+                                { name: 'data-url', value: path('ems_job_custom_view', {'environmentName': environment.name, 'templateId': template.id, 'ouuid': ouuid}) }
+                            ],
+                            icon: template.icon,
+                            label: template.label
+                        } %}
+                        {% set contentTypeActions = contentTypeActions|merge([action]) %}
+                    {% endif %}
+                {% elseif template.renderOption is constant('EMS\\CoreBundle\\Form\\Field\\RenderOptionType::IMPORT') %}
+                    {%- if (is_granted(template.role)) or template.role == "not-defined" -%}
+                        {%- set importModalUrl = path('emsco_data_action_import', { 'actionId': template.id, 'ouuid': ouuid}) -%}
+                        {% set action = {
+                            link: '#',
+                            link_attributes: [
+                                { name: 'data-ajax-modal-url', value: importModalUrl },
+                                { name: 'data-ajax-modal-size', value: 'md' },
+                            ],
+                            icon: template.icon,
+                            label: template.label
+                        } %}
+                        {% set contentTypeActions = contentTypeActions|merge([action]) %}
+                    {%- endif -%}
+                {% else %}
+                    {% set action = {
+                        link: path(template.public?'ems_data_custom_template_public':'ems_data_custom_template_protected', {
+                            environmentName: environment.name,
+                            ouuid: ouuid,
+                            templateId: template.id
+                        }),
+                        icon: template.icon,
+                        label: template.label
+                    } %}
+                    {% set contentTypeActions = contentTypeActions|merge([action]) %}
+                {% endif %}
+            {% endif %}
+        {% endif %}
+    {% endfor %}
 
-				{% endif %}
-		</ul>
-	</div>
+    {% if is_granted('ROLE_COPY_PASTE') %}
+        {% set contentTypeActions = contentTypeActions|merge([{
+            link: path('revision.copy', {'environment': environment.name, 'type': contentType.name, 'ouuid': ouuid} ),
+            icon: 'views.elements.object-views-button.copy-data-icon-class'|trans,
+            label: 'views.elements.object-views-button.copy-data'|trans
+        }]) %}
+        {% if not contentType.askForOuuid  %}
+            {% set contentTypeActions = contentTypeActions|merge([{
+                link: path('emsco_duplicate_revision', {'environment': environment.name, 'type': contentType.name, 'ouuid': ouuid}),
+                icon: 'clone',
+                label: 'Duplicate',
+                post_button: true
+            }]) %}
+        {% endif %}
+        {% set contentTypeActions = contentTypeActions|merge([{
+            link: path('data.view', {'environmentName': environment.name, 'type': contentType.name, 'ouuid': ouuid} ),
+            icon: 'views.elements.object-views-button.raw-view-icon-class'|trans,
+            label: 'views.elements.object-views-button.raw-view'|trans
+        }]) %}
+    {% endif %}
+
+    <div class="btn-group">
+        {% if contentTypeActions|default([])|length > 0 %}
+            <button type="button" class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
+                <i class="{{ 'views.elements.object-views-button.action-dropdown-icon-class'|trans }}"></i>
+                {{ 'views.elements.object-views-button.action-dropdown-label'|trans({'%environment%': environment.label}) }}
+                <span class="caret"></span>
+                <span class="sr-only">{{ 'views.elements.object-views-button.action-dropdown-sr-only'|trans({'%environment%': environment.label}) }}</span>
+            </button>
+            <ul class="dropdown-menu" role="menu">
+                {% for a in contentTypeActions %}
+                    <li class="{{ a.list_item_classes|default([])|length > 0 ? a.list_item_classes|join(' ') }}">
+                        {% if a.post_button|default %}
+                            {% include '@EMSCore/elements/post-button.html.twig' with {
+                                'url': a.link,
+                                'label': a.label,
+                                'icon': a.icon,
+                                'btnClass': ''
+                            }%}
+                        {% else %}
+                            {% if a.link|default %}
+                                <a href="{{ a.link }}" {% for attribute in a.link_attributes|default([]) %}{{ attribute.name }}="{{ attribute.value }}" {% endfor %}>
+                            {% endif %}
+                                {% if a.icon|default %}<i class="{{ a.icon|raw }}"></i>{% endif %}
+                                {% if a.label|default %}{{ a.label|raw }}{% endif %}
+                                {% if a.suffix_icon|default %}<i class="{{ a.suffix_icon }}"></i>{% endif %}
+                            {% if a.link|default %}
+                                </a>
+                            {% endif %}
+                        {% endif %}
+                    </li>
+                {% endfor %}
+            </ul>
+        {% else %}
+            <button type="button" class="btn btn-default btn-sm" style="cursor: default">
+                <i class="{{ 'views.elements.object-views-button.action-dropdown-icon-class'|trans }}"></i>
+                {{ 'views.elements.object-views-button.publish-label'|trans({'%environment%': environment.label}) }}
+            </button>
+        {% endif %}
+    </div>
 {% else %}
 
-		<a class="btn btn-sm btn-default " href="{{ path('data.view', {'environmentName': environment.name, 'type': contentType.name, 'ouuid': object.ouuid} ) }}">
-			<i class="{{ 'views.elements.object-views-button.raw-view-icon-class'|trans }}"></i>
-			{{ 'views.elements.object-views-button.raw-view'|trans }}
-		</a>
-{% endif %}	
-	
+    <a class="btn btn-sm btn-default " href="{{ path('data.view', {'environmentName': environment.name, 'type': contentType.name, 'ouuid': object.ouuid} ) }}">
+        <i class="{{ 'views.elements.object-views-button.raw-view-icon-class'|trans }}"></i>
+        {{ 'views.elements.object-views-button.raw-view'|trans }}
+    </a>
+{% endif %}
+
 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | N  |
| New feature?   |  Y |
| BC breaks?     | N  |
| Deprecations?  | N  |
| Fixed tickets? |  N |
| Documentation? | N  |

The goal was to remove dropdown of the button actions if it empty for any reasons (no actions or permission)

![image](https://github.com/ems-project/elasticms/assets/832641/a2d1e336-7c9f-43ae-a062-cd6b5c45e6d9)
->
![image](https://github.com/ems-project/elasticms/assets/832641/d513c3b7-3cd2-4cc5-81f6-4a94afc1b2f8)
