### PR TITLE
feat(core/release): add unpublish documents in release

### DIFF
--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/release/columns/release-revisions.html.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/release/columns/release-revisions.html.twig
@@ -2,14 +2,16 @@
 
 {% block label %}
     {% if data.revision %}
-        {{ data.revision.label }}
+        {{ data.revision|emsco_display }}
     {% else %}
         {% set info = data.emsId|emsco_document_info %}
-        {% set release = info.getRevision(data.release.environmentSource.name) %}
-        {% if release %}
-            {{ release.label }}
+        {% set revisionSource = info.getRevision(data.release.environmentSource.name) %}
+        {% set revisionTarget = info.getRevision(data.release.environmentTarget.name) %}
+
+        {% if revisionTarget %}
+            {{ revisionTarget|emsco_display }}
         {% else %}
-            {{ 'release.release-revisison.missing-revision'|trans({'%ouuid%': data.revisionOuuid, '%environment%': data.release.environmentSource.label}) }}
+            {{ 'release.release-revisison.missing-revision'|trans({'%label%': revisionSource|emsco_display, '%environment%': data.release.environmentTarget.name}) }}
         {% endif %}
     {% endif %}
 {% endblock label %}
@@ -25,8 +27,12 @@
         </a>
     {% else %}
         {% set info = data.emsId|emsco_document_info %}
-        {% set revision = info.getRevision(data.release.environmentSource.name) %}
-        {% if revision %}
+        {% set revisionTarget = info.getRevision(data.release.environmentTarget.name) %}
+        {% if revisionTarget %}
+            <a href="{{ path('emsco_view_revisions', {ouuid: data.revisionOuuid, type: data.contentType.name, revisionId: revisionTarget.id}) }}">
+                {{ 'release.release-revisison.revision'|trans({ '%date%' : revisionTarget.created|date(date_time_format) ,'%user%' : revisionTarget.finalizedBy|default('')|displayname }) }}
+            </a>
+        {% else %}
             {{ 'release.release-revisison.revision-not-applicable'|trans }}
         {% endif %}
     {% endif %}
@@ -59,7 +65,9 @@
         {% set revision = info.getRevision(data.release.environmentTarget) %}
         {% set stil_in_target = (data.revision.id is same as (revision.id)) %}
     {% else %}
-        {% set stil_in_target = true %}
+        {% set info = data.emsId|emsco_document_info %}
+        {% set revisionTarget = info.getRevision(data.release.environmentTarget.name) %}
+        {% set stil_in_target = (revisionTarget ? true : false) %}
     {% endif %}
     {%  if stil_in_target %}
         <i class="fa fa-check-square"><span class="sr-only"</span>{{ 'release.release-revisison.still_in_target'|trans({'%target%': data.release.environmentTarget.label}) }}</i>

--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/release/columns/revisions.html.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/release/columns/revisions.html.twig
@@ -1,15 +1,17 @@
-{% use "bootstrap_3_layout.html.twig" %}{% trans_default_domain 'EMSCoreBundle' %}
+{% trans_default_domain 'EMSCoreBundle' %}
 
-       
+{% block publish_label %}{{ data.emsLink|emsco_display }}{% endblock %}
+{% block unpublish_label %}{{ data.label }}{% endblock %}
+
 {% block minrevid %}
     {% set release = app.request.get('release') %}
     {% set minrev = data.minrevid|split('/') %}
     {% set maxrev = data.maxrevid|split('/') %}
 
     {% if minrev[0] == release.environmentSource.id %}
-        {{ '%date% Finalized by %user%'|trans({ '%date%' : minrev[2]|date(date_time_format) ,'%user%' : minrev[3] }) }}     
+        {{ '%date% Finalized by %user%'|trans({ '%date%' : minrev[2]|date(date_time_format) ,'%user%' : minrev[3] }) }}
     {% elseif maxrev[0] == release.environmentSource.id %}
-        {{ '%date% Finalized by %user%'|trans({ '%date%' : maxrev[2]|date(date_time_format) ,'%user%' : maxrev[3] }) }}  
+        {{ '%date% Finalized by %user%'|trans({ '%date%' : maxrev[2]|date(date_time_format) ,'%user%' : maxrev[3] }) }}
     {% else %}
         {{ 'no revision in %env%'|trans({ '%env%' : release.environmentSource.name }) }}
     {% endif %}
@@ -41,9 +43,9 @@
     {% set minrev = data.minrevid|split('/') %}
     {% set maxrev = data.maxrevid|split('/') %}
     {% if maxrev[0] == release.environmentTarget.id %}
-        {{ '%date% Finalized by %user%'|trans({ '%date%' : maxrev[2]|date(date_time_format) ,'%user%' : maxrev[3] }) }}  
+        {{ '%date% Finalized by %user%'|trans({ '%date%' : maxrev[2]|date(date_time_format) ,'%user%' : maxrev[3] }) }}
     {% elseif minrev[0] == release.environmentTarget.id %}
-        {{ '%date% Finalized by %user%'|trans({ '%date%' : minrev[2]|date(date_time_format) ,'%user%' : minrev[3] }) }}     
+        {{ '%date% Finalized by %user%'|trans({ '%date%' : minrev[2]|date(date_time_format) ,'%user%' : minrev[3] }) }}
     {% else %}
         {{ 'no revision in %env%'|trans({ '%env%' : release.environmentTarget.name }) }}
     {% endif %}
@@ -53,11 +55,11 @@
     {% set release = app.request.get('release') %}
     {% set minrev = data.minrevid|split('/') %}
     {% set maxrev = data.maxrevid|split('/') %}
-  
+
     {% if minrev[0] == release.environmentSource.id %}
-        {{ '%date% Finalized by %user%'|trans({ '%date%' : minrev[2]|date(date_time_format) ,'%user%' : minrev[3] }) }}     
+        {{ '%date% Finalized by %user%'|trans({ '%date%' : minrev[2]|date(date_time_format) ,'%user%' : minrev[3] }) }}
     {% elseif maxrev[0] == release.environmentSource.id %}
-        {{ '%date% Finalized by %user%'|trans({ '%date%' : maxrev[2]|date(date_time_format) ,'%user%' : maxrev[3] }) }}  
+        {{ '%date% Finalized by %user%'|trans({ '%date%' : maxrev[2]|date(date_time_format) ,'%user%' : maxrev[3] }) }}
     {% else %}
         {{ 'Unpublish in %env%'|trans({ '%env%' : release.environmentTarget.name }) }}
     {% endif %}
@@ -68,9 +70,9 @@
     {% set release = app.request.get('release') %}
     {% set maxrev = data.maxrevid|split('/') %}
     {% set minrev = data.minrevid|split('/') %}
-           
+
     {% if maxrev[0] == release.environmentTarget.id %}
-        {{ '%date% Finalized by %user%'|trans({ '%date%' : maxrev[2]|date(date_time_format) ,'%user%' : maxrev[3] }) }}  
+        {{ '%date% Finalized by %user%'|trans({ '%date%' : maxrev[2]|date(date_time_format) ,'%user%' : maxrev[3] }) }}
     {% elseif minrev[0] == release.environmentTarget.id %}
         {{ '%date% Finalized by %user%'|trans({ '%date%' : minrev[2]|date(date_time_format) ,'%user%' : minrev[3] }) }}
     {% else %}
@@ -82,3 +84,22 @@
         {{ 'replace by revision %date%'|trans({ '%date%' : maxrev[2]|date(date_time_format) }) }}
     {% endif %}
 {% endblock maxrevidstatus  %}
+
+{% block unpublish_source %}
+    <div style="width: 250px">
+        {{ '%date% Finalized by %user%'|trans({
+            '%date%': data.default_finalized_date|date(date_time_format),
+            '%user%': data.default_finalized_by
+        }) }}
+    </div>
+{% endblock unpublish_source %}
+
+{% block unpublish_target %}
+    <div style="width: 250px">
+        {{ '%date% Finalized by %user%'|trans({
+            '%date%': data.published_finalized_date|date(date_time_format),
+            '%user%': data.published_finalized_by
+        }) }}
+    </div>
+{% endblock unpublish_target %}
+

--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/release/form.html.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/release/form.html.twig
@@ -32,20 +32,20 @@
 		{% if release is defined and release.status == 'wip' %}
 			<div class="box-footer">
 				<div class="btn-group">
-					{% include '@EMSCore/elements/get-button.html.twig' with {
+					{% include '@EMSAdminUI/bootstrap5/elements/get-button.html.twig' with {
 						'url':  path('emsco_release_add_revisions', {'release': release.id, 'type': 'publish' } ),
 						'label': 'release.actions.add_publish'|trans,
 						'icon': 'plus',
 						'btnType': 'primary',
 					}%}
-                    {% include '@EMSCore/elements/get-button.html.twig' with {
+                    {% include '@EMSAdminUI/bootstrap5/elements/get-button.html.twig' with {
                         'url':  path('emsco_release_add_revisions', {'release': release.id, 'type': 'unpublish' } ),
                         'label': 'release.actions.add_unpublish'|trans,
                         'icon': 'minus',
                         'btnType': 'default',
                     }%}
 					{% if release.revisions|length > 0 %}
-						{% include '@EMSCore/elements/post-button.html.twig' with {
+						{% include '@EMSAdminUI/bootstrap5/elements/post-button.html.twig' with {
 							'url': path('emsco_release_set_status', {'release': release.id, 'status': 'ready'}),
 							'label': 'release.actions.set_status_ready'|trans,
 							'btnType': 'default',

--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/release/form.html.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/release/form.html.twig
@@ -32,14 +32,20 @@
 		{% if release is defined and release.status == 'wip' %}
 			<div class="box-footer">
 				<div class="btn-group">
-					{% include '@EMSAdminUI/bootstrap5/elements/get-button.html.twig' with {
-						'url':  path('emsco_release_add_revisions', {'release': release.id} ),
-						'label': 'release.actions.add_revisions'|trans,
+					{% include '@EMSCore/elements/get-button.html.twig' with {
+						'url':  path('emsco_release_add_revisions', {'release': release.id, 'type': 'publish' } ),
+						'label': 'release.actions.add_publish'|trans,
 						'icon': 'plus',
 						'btnType': 'primary',
 					}%}
+                    {% include '@EMSCore/elements/get-button.html.twig' with {
+                        'url':  path('emsco_release_add_revisions', {'release': release.id, 'type': 'unpublish' } ),
+                        'label': 'release.actions.add_unpublish'|trans,
+                        'icon': 'minus',
+                        'btnType': 'default',
+                    }%}
 					{% if release.revisions|length > 0 %}
-						{% include '@EMSAdminUI/bootstrap5/elements/post-button.html.twig' with {
+						{% include '@EMSCore/elements/post-button.html.twig' with {
 							'url': path('emsco_release_set_status', {'release': release.id, 'status': 'ready'}),
 							'label': 'release.actions.set_status_ready'|trans,
 							'btnType': 'default',

--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/release/revisions.html.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/release/revisions.html.twig
@@ -19,6 +19,6 @@
 {% endblock %}
 
 {% block body %}
-	{% form_theme form '@EMSCore/form/forms.html.twig' %}
+	{% form_theme form '@EMSAdminUI/bootstrap5/form/forms.html.twig' %}
 	{{ form(form) }}
 {% endblock %}

--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/release/revisions.html.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/release/revisions.html.twig
@@ -1,7 +1,14 @@
 {% extends '@EMSAdminUI/bootstrap5/base/admin.html.twig' %}
 {% trans_default_domain 'EMSCoreBundle' %}
 
-{% block title %}{{ 'release.revision.index.title'|trans }}{% endblock %}
+{% block title %}
+    {%- if type == 'publish' -%}
+        {{- 'release.revision.index.publish'|trans -}}
+    {%- elseif type == 'unpublish' -%}
+        {{- 'release.revision.index.unpublish'|trans -}}
+    {%- endif -%}
+{% endblock %}
+
 {% block pagetitle %}{{ block('title') }}{% endblock %}
 
 {% block breadcrumb %}
@@ -12,12 +19,6 @@
 {% endblock %}
 
 {% block body %}
-	{%  set toolbar %}
-
-	{%  endset %}
-
-	{% form_theme form '@EMSAdminUI/bootstrap5/form/forms.html.twig' %}
-	{{ form(form, {
-		toolbar: toolbar
-	}) }}
+	{% form_theme form '@EMSCore/form/forms.html.twig' %}
+	{{ form(form) }}
 {% endblock %}

--- a/EMS/common-bundle/src/Elasticsearch/Document/Document.php
+++ b/EMS/common-bundle/src/Elasticsearch/Document/Document.php
@@ -62,11 +62,11 @@ class Document implements DocumentInterface
     /**
      * @param array<string, mixed> $rawData
      */
-    public static function fromData(ContentType $contentType, string $ouuid, array $rawData, string $index = 'not_available'): Document
+    public static function fromData(ContentType|string $contentType, string $ouuid, array $rawData, string $index = 'not_available'): Document
     {
         return new self([
             '_source' => \array_merge($rawData, [
-                EMSSource::FIELD_CONTENT_TYPE => $contentType->getName(),
+                EMSSource::FIELD_CONTENT_TYPE => \is_string($contentType) ? $contentType : $contentType->getName(),
             ]),
             '_id' => $ouuid,
             '_index' => $index,

--- a/EMS/core-bundle/src/Controller/ContentManagement/ReleaseController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/ReleaseController.php
@@ -5,26 +5,22 @@ declare(strict_types=1);
 namespace EMS\CoreBundle\Controller\ContentManagement;
 
 use EMS\CoreBundle\Core\DataTable\DataTableFactory;
+use EMS\CoreBundle\DataTable\Type\Release\ReleaseNonMemberRevisionsDataTableType;
 use EMS\CoreBundle\DataTable\Type\Release\ReleaseOverviewDataTableType;
 use EMS\CoreBundle\DataTable\Type\Release\ReleasePickDataTableType;
 use EMS\CoreBundle\DataTable\Type\Release\ReleaseRevisionDataTableType;
 use EMS\CoreBundle\Entity\Release;
 use EMS\CoreBundle\Entity\Revision;
-use EMS\CoreBundle\Form\Data\QueryTable;
 use EMS\CoreBundle\Form\Data\TableAbstract;
-use EMS\CoreBundle\Form\Data\TemplateBlockTableColumn;
 use EMS\CoreBundle\Form\Form\ReleaseType;
 use EMS\CoreBundle\Form\Form\TableType;
-use EMS\CoreBundle\Helper\DataTableRequest;
 use EMS\CoreBundle\Routes;
-use EMS\CoreBundle\Service\ReleaseRevisionService;
 use EMS\CoreBundle\Service\ReleaseService;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\ClickableInterface;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\SubmitButton;
-use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -35,22 +31,9 @@ final class ReleaseController extends AbstractController
     public function __construct(
         private readonly LoggerInterface $logger,
         private readonly ReleaseService $releaseService,
-        private readonly ReleaseRevisionService $releaseRevisionService,
         private readonly DataTableFactory $dataTableFactory,
         private readonly string $templateNamespace
     ) {
-    }
-
-    public function ajaxReleaseTableNonMemberRevisions(Request $request, Release $release): Response
-    {
-        $table = $this->getNonMemberRevisionsTable($release);
-        $dataTableRequest = DataTableRequest::fromRequest($request);
-        $table->resetIterator($dataTableRequest);
-
-        return $this->render("@$this->templateNamespace/datatable/ajax.html.twig", [
-            'dataTableRequest' => $dataTableRequest,
-            'table' => $table,
-        ], new JsonResponse());
     }
 
     public function index(Request $request): Response
@@ -205,7 +188,9 @@ final class ReleaseController extends AbstractController
 
     public function addRevisions(Request $request, Release $release): Response
     {
-        $table = $this->getNonMemberRevisionsTable($release);
+        $table = $this->dataTableFactory->create(ReleaseNonMemberRevisionsDataTableType::class, [
+            'release_id' => $release->getId(),
+        ]);
         $form = $this->createForm(TableType::class, $table);
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {
@@ -245,22 +230,5 @@ final class ReleaseController extends AbstractController
             'form' => $form->createView(),
             'revision' => $revision,
         ]);
-    }
-
-    private function getNonMemberRevisionsTable(Release $release): QueryTable
-    {
-        $table = new QueryTable($this->templateNamespace, $this->releaseRevisionService, 'revisions-to-publish', $this->generateUrl(Routes::RELEASE_NON_MEMBER_REVISION_AJAX, ['release' => $release->getId()]), $release);
-        $table->setMassAction(true);
-        $table->setLabelAttribute('item_labelField');
-        $table->setIdField('emsLink');
-        $table->addColumn('release.revision.index.column.label', 'item_labelField');
-        $table->addColumn('release.revision.index.column.CT', 'content_type_singular_name');
-        $table->setSelected($release->getRevisionsOuuids());
-        $table->addColumnDefinition(new TemplateBlockTableColumn('release.revision.index.column.minRevId', 'minrevid', "@$this->templateNamespace/release/columns/revisions.html.twig"));
-        $table->addColumnDefinition(new TemplateBlockTableColumn('release.revision.index.column.maxRevId', 'maxrevid', "@$this->templateNamespace/release/columns/revisions.html.twig"));
-        $table->addTableAction(TableAbstract::ADD_ACTION, 'fa fa-plus', 'release.revision.actions.add', 'release.revision.actions.add_confirm');
-        $table->addDynamicItemPostAction(Routes::RELEASE_ADD_REVISION, 'release.revision.action.add', 'plus', 'release.revision.actions.add_confirm', ['release' => \sprintf('%d', $release->getId()), 'emsLinkToAdd' => 'emsLink']);
-
-        return $table;
     }
 }

--- a/EMS/core-bundle/src/Controller/ContentManagement/ReleaseController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/ReleaseController.php
@@ -169,9 +169,13 @@ final class ReleaseController extends AbstractController
         return $this->redirectToRoute(Routes::RELEASE_INDEX);
     }
 
-    public function addRevisionById(Release $release, Revision $revision): Response
+    public function addRevisionById(Release $release, Revision $revision, string $type): Response
     {
-        $this->releaseService->addRevision($release, $revision);
+        match ($type) {
+            'publish' => $this->releaseService->addRevisionForPublish($release, $revision),
+            'unpublish' => $this->releaseService->addRevisionForUnpublish($release, $revision),
+            default => throw new \RuntimeException('invalid type')
+        };
 
         return $this->redirectToRoute(Routes::VIEW_REVISIONS, [
             'type' => $revision->giveContentType()->getName(),

--- a/EMS/core-bundle/src/Core/DataTable/DataTableFactory.php
+++ b/EMS/core-bundle/src/Core/DataTable/DataTableFactory.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace EMS\CoreBundle\Core\DataTable;
 
 use EMS\CoreBundle\Core\DataTable\Type\AbstractEntityTableType;
+use EMS\CoreBundle\Core\DataTable\Type\AbstractQueryTableType;
 use EMS\CoreBundle\Core\DataTable\Type\DataTableTypeCollection;
 use EMS\CoreBundle\Core\DataTable\Type\DataTableTypeInterface;
 use EMS\CoreBundle\Form\Data\EntityTable;
+use EMS\CoreBundle\Form\Data\QueryTable;
 use EMS\CoreBundle\Form\Data\TableAbstract;
 use EMS\CoreBundle\Routes;
 use EMS\Helpers\Standard\Hash;
@@ -59,6 +61,7 @@ class DataTableFactory
 
         return match (true) {
             $type instanceof AbstractEntityTableType => $this->buildEntityTable($type, $ajaxUrl, $options),
+            $type instanceof AbstractQueryTableType => $this->buildQueryTable($type, $ajaxUrl, $options),
             default => throw new \RuntimeException('Unknown dataTableType')
         };
     }
@@ -71,6 +74,25 @@ class DataTableFactory
         $table = new EntityTable(
             $this->templateNamespace,
             $type->getEntityService(),
+            $ajaxUrl,
+            $type->getContext($options),
+            $type->getLoadMaxRows()
+        );
+
+        $type->build($table);
+
+        return $table;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private function buildQueryTable(AbstractQueryTableType $type, string $ajaxUrl, array $options = []): QueryTable
+    {
+        $table = new QueryTable(
+            $this->templateNamespace,
+            $type->getQueryService(),
+            $type->getQueryName(),
             $ajaxUrl,
             $type->getContext($options),
             $type->getLoadMaxRows()

--- a/EMS/core-bundle/src/Core/DataTable/Type/AbstractQueryTableType.php
+++ b/EMS/core-bundle/src/Core/DataTable/Type/AbstractQueryTableType.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\Core\DataTable\Type;
+
+use EMS\CoreBundle\Form\Data\QueryTable;
+use EMS\CoreBundle\Service\QueryServiceInterface;
+
+abstract class AbstractQueryTableType extends AbstractTableType
+{
+    public const LOAD_MAX_ROWS = 400;
+
+    public function __construct(
+        private readonly QueryServiceInterface $queryService
+    ) {
+    }
+
+    abstract public function getQueryName(): string;
+
+    public function build(QueryTable $table): void
+    {
+    }
+
+    public function getQueryService(): QueryServiceInterface
+    {
+        return $this->queryService;
+    }
+
+    /**
+     * @param array<mixed> $options
+     */
+    public function getContext(array $options): mixed
+    {
+        return null;
+    }
+
+    public function getLoadMaxRows(): int
+    {
+        return self::LOAD_MAX_ROWS;
+    }
+}

--- a/EMS/core-bundle/src/Core/Revision/Query/PublishedRevisionsQueryService.php
+++ b/EMS/core-bundle/src/Core/Revision/Query/PublishedRevisionsQueryService.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\Core\Revision\Query;
+
+use Doctrine\Bundle\DoctrineBundle\Registry;
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Doctrine\ORM\EntityManager;
+use EMS\CommonBundle\Elasticsearch\Document\Document;
+use EMS\CoreBundle\Entity\ContentType;
+use EMS\CoreBundle\Entity\Environment;
+use EMS\CoreBundle\Service\ContentTypeService;
+use EMS\CoreBundle\Service\QueryServiceInterface;
+use EMS\CoreBundle\Service\Revision\RevisionService;
+use EMS\Helpers\Standard\Json;
+
+class PublishedRevisionsQueryService implements QueryServiceInterface
+{
+    public function __construct(
+        private readonly Registry $doctrine,
+        private readonly ContentTypeService $contentTypeService,
+        private readonly RevisionService $revisionService
+    ) {
+    }
+
+    public function isQuerySortable(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @param array{'environment': Environment} $context
+     */
+    public function query(int $from, int $size, ?string $orderField, string $orderDirection, string $searchValue, mixed $context = null): array
+    {
+        if (!isset($context['environment'])) {
+            throw new \RuntimeException('Missing environment');
+        }
+
+        $environment = $context['environment'];
+
+        $results = $this->createQueryBuilder($environment)
+            ->addSelect("CONCAT(c.name, ':', p.ouuid) AS ems_link")
+            ->addSelect('c.name as content_type_name')
+            ->addSelect('c.singularname as content_type_label')
+            ->addSelect('c.fields as fields')
+            ->addSelect('p.ouuid as ouuid')
+            ->addSelect('p.raw_data published_raw')
+            ->addSelect('p.finalized_by as published_finalized_by')
+            ->addSelect('p.finalized_date as published_finalized_date')
+            ->addSelect('r.finalized_by as default_finalized_by')
+            ->addSelect('r.finalized_date as default_finalized_date')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        foreach ($results as &$result) {
+            [$contentTypeName, $ouuid] = [$result['content_type_name'], $result['ouuid']];
+
+            $publishedDocument = Document::fromData($contentTypeName, $ouuid, Json::decode($result['published_raw']));
+            $result['label'] = $this->revisionService->display($publishedDocument);
+        }
+
+        return $results;
+    }
+
+    /**
+     * @param array{'environment': Environment} $context
+     */
+    public function countQuery(string $searchValue = '', mixed $context = null): int
+    {
+        if (!isset($context['environment'])) {
+            throw new \RuntimeException('Missing environment');
+        }
+
+        $qb = $this->createQueryBuilder($context['environment']);
+
+        return (int) $qb->select('count(p.id)')->fetchOne();
+    }
+
+    private function createQueryBuilder(Environment $environment): QueryBuilder
+    {
+        $contentTypes = $this->contentTypeService->getAllGrantedForPublication();
+        $contentTypeIds = \array_map(static fn (ContentType $contentType) => $contentType->getId(), $contentTypes);
+
+        /** @var EntityManager $em */
+        $em = $this->doctrine->getManager();
+
+        $qb = $em->getConnection()->createQueryBuilder();
+
+        return $qb
+            ->from('revision', 'p')
+            ->join('p', 'content_type', 'c', 'p.content_type_id = c.id')
+            ->join('p', 'environment_revision', 'er', 'er.revision_id = p.id')
+            ->join('p', 'revision', 'r', 'r.end_time is null and r.ouuid = p.ouuid')
+            ->andWhere($qb->expr()->eq('er.environment_id', ':environment_id'))
+            ->andWhere($qb->expr()->in('c.id', ':content_type_ids'))
+            ->setParameter('environment_id', $environment->getId())
+            ->setParameter('content_type_ids', $contentTypeIds, ArrayParameterType::INTEGER);
+    }
+}

--- a/EMS/core-bundle/src/DataTable/Type/Release/ReleaseNonMemberRevisionsDataTableType.php
+++ b/EMS/core-bundle/src/DataTable/Type/Release/ReleaseNonMemberRevisionsDataTableType.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\DataTable\Type\Release;
+
+use EMS\CoreBundle\Core\DataTable\Type\AbstractQueryTableType;
+use EMS\CoreBundle\Entity\Release;
+use EMS\CoreBundle\Form\Data\QueryTable;
+use EMS\CoreBundle\Form\Data\TableAbstract;
+use EMS\CoreBundle\Form\Data\TemplateBlockTableColumn;
+use EMS\CoreBundle\Roles;
+use EMS\CoreBundle\Routes;
+use EMS\CoreBundle\Service\ReleaseRevisionService;
+use EMS\CoreBundle\Service\ReleaseService;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ReleaseNonMemberRevisionsDataTableType extends AbstractQueryTableType
+{
+    public function __construct(
+        ReleaseRevisionService $releaseRevisionService,
+        private readonly ReleaseService $releaseService,
+        private readonly string $templateNamespace
+    ) {
+        parent::__construct($releaseRevisionService);
+    }
+
+    public function build(QueryTable $table): void
+    {
+        /** @var Release $release */
+        $release = $table->getContext();
+
+        $table->setMassAction(true);
+        $table->setLabelAttribute('item_labelField');
+        $table->setIdField('emsLink');
+        $table->setSelected($release->getRevisionsOuuids());
+
+        $table->addColumn('release.revision.index.column.label', 'item_labelField');
+        $table->addColumn('release.revision.index.column.CT', 'content_type_singular_name');
+        $table->addColumnDefinition(new TemplateBlockTableColumn('release.revision.index.column.minRevId', 'minrevid', "@$this->templateNamespace/release/columns/revisions.html.twig"));
+        $table->addColumnDefinition(new TemplateBlockTableColumn('release.revision.index.column.maxRevId', 'maxrevid', "@$this->templateNamespace/release/columns/revisions.html.twig"));
+
+        $table->addTableAction(TableAbstract::ADD_ACTION, 'fa fa-plus', 'release.revision.actions.add', 'release.revision.actions.add_confirm');
+        $table->addDynamicItemPostAction(Routes::RELEASE_ADD_REVISION, 'release.revision.action.add', 'plus', 'release.revision.actions.add_confirm', ['release' => \sprintf('%d', $release->getId()), 'emsLinkToAdd' => 'emsLink']);
+    }
+
+    public function getQueryName(): string
+    {
+        return 'revisions-to-publish';
+    }
+
+    public function getRoles(): array
+    {
+        return [Roles::ROLE_PUBLISHER];
+    }
+
+    public function getContext(array $options): Release
+    {
+        return $this->releaseService->getById($options['release_id']);
+    }
+
+    public function configureOptions(OptionsResolver $optionsResolver): void
+    {
+        $optionsResolver->setRequired(['release_id']);
+    }
+}

--- a/EMS/core-bundle/src/DataTable/Type/Release/ReleaseNonMemberRevisionsDataTableType.php
+++ b/EMS/core-bundle/src/DataTable/Type/Release/ReleaseNonMemberRevisionsDataTableType.php
@@ -35,7 +35,7 @@ class ReleaseNonMemberRevisionsDataTableType extends AbstractQueryTableType
         $table->setIdField('emsLink');
         $table->setSelected($release->getRevisionsOuuids());
 
-        $table->addColumn('release.revision.index.column.label', 'item_labelField');
+        $table->addColumnDefinition(new TemplateBlockTableColumn('release.revision.index.column.label', 'label', "@$this->templateNamespace/release/columns/revisions.html.twig"));
         $table->addColumn('release.revision.index.column.CT', 'content_type_singular_name');
         $table->addColumnDefinition(new TemplateBlockTableColumn('release.revision.index.column.minRevId', 'minrevid', "@$this->templateNamespace/release/columns/revisions.html.twig"));
         $table->addColumnDefinition(new TemplateBlockTableColumn('release.revision.index.column.maxRevId', 'maxrevid', "@$this->templateNamespace/release/columns/revisions.html.twig"));

--- a/EMS/core-bundle/src/DataTable/Type/Release/ReleaseOverviewDataTableType.php
+++ b/EMS/core-bundle/src/DataTable/Type/Release/ReleaseOverviewDataTableType.php
@@ -37,7 +37,9 @@ class ReleaseOverviewDataTableType extends AbstractEntityTableType
             ->addCondition(new Terms('status', [Release::APPLIED_STATUS, Release::SCHEDULED_STATUS, Release::READY_STATUS]));
         $table->addItemGetAction(Routes::RELEASE_EDIT, 'release.actions.edit', 'pencil')
             ->addCondition(new Terms('status', [Release::WIP_STATUS]));
-        $table->addItemGetAction(Routes::RELEASE_ADD_REVISIONS, 'release.actions.add_revisions', 'plus')
+        $table->addItemGetAction(Routes::RELEASE_ADD_REVISIONS, 'release.actions.add_publish', 'plus', ['type' => 'publish'])
+            ->addCondition(new Terms('status', [Release::WIP_STATUS]));
+        $table->addItemGetAction(Routes::RELEASE_ADD_REVISIONS, 'release.actions.add_unpublish', 'minus', ['type' => 'unpublish'])
             ->addCondition(new Terms('status', [Release::WIP_STATUS]));
         $table->addItemGetAction(Routes::RELEASE_SET_STATUS, 'release.actions.set_status_ready', 'play', ['status' => Release::READY_STATUS])
             ->addCondition(new Terms('status', [Release::WIP_STATUS]))

--- a/EMS/core-bundle/src/DataTable/Type/Release/ReleasePickDataTableType.php
+++ b/EMS/core-bundle/src/DataTable/Type/Release/ReleasePickDataTableType.php
@@ -36,7 +36,8 @@ class ReleasePickDataTableType extends AbstractEntityTableType
         $table->addColumnDefinition(new TemplateBlockTableColumn('release.index.column.status', 'status', "@$this->templateNamespace/release/columns/revisions.html.twig"));
         $table->addColumnDefinition(new TemplateBlockTableColumn('release.index.column.docs_count', 'docs_count', "@$this->templateNamespace/release/columns/revisions.html.twig"))->setCellClass('text-right');
 
-        $table->addItemPostAction(Routes::DATA_ADD_REVISION_TO_RELEASE, 'data.actions.add_to_release', 'plus', 'data.actions.add_to_release_confirm', ['revision' => $revision->getId()])->setButtonType('primary');
+        $table->addItemPostAction(Routes::DATA_ADD_REVISION_TO_RELEASE, 'data.actions.add_to_release_publish', 'plus', 'data.actions.add_to_release_confirm', ['revision' => $revision->getId(), 'type' => 'publish'])->setButtonType('primary');
+        $table->addItemPostAction(Routes::DATA_ADD_REVISION_TO_RELEASE, 'data.actions.add_to_release_unpublish', 'minus', 'data.actions.add_to_release_confirm', ['revision' => $revision->getId(), 'type' => 'unpublish'])->setButtonType('default');
     }
 
     public function getRoles(): array

--- a/EMS/core-bundle/src/DataTable/Type/Release/ReleaseRevisionsPublishDataTableType.php
+++ b/EMS/core-bundle/src/DataTable/Type/Release/ReleaseRevisionsPublishDataTableType.php
@@ -15,7 +15,7 @@ use EMS\CoreBundle\Service\ReleaseRevisionService;
 use EMS\CoreBundle\Service\ReleaseService;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class ReleaseNonMemberRevisionsDataTableType extends AbstractQueryTableType
+class ReleaseRevisionsPublishDataTableType extends AbstractQueryTableType
 {
     public function __construct(
         ReleaseRevisionService $releaseRevisionService,
@@ -29,19 +29,29 @@ class ReleaseNonMemberRevisionsDataTableType extends AbstractQueryTableType
     {
         /** @var Release $release */
         $release = $table->getContext();
+        $template = "@$this->templateNamespace/release/columns/revisions.html.twig";
 
         $table->setMassAction(true);
         $table->setLabelAttribute('item_labelField');
         $table->setIdField('emsLink');
         $table->setSelected($release->getRevisionsOuuids());
 
-        $table->addColumnDefinition(new TemplateBlockTableColumn('release.revision.index.column.label', 'label', "@$this->templateNamespace/release/columns/revisions.html.twig"));
+        $table->addColumnDefinition(new TemplateBlockTableColumn('release.revision.index.column.label', 'publish_label', $template));
         $table->addColumn('release.revision.index.column.CT', 'content_type_singular_name');
-        $table->addColumnDefinition(new TemplateBlockTableColumn('release.revision.index.column.minRevId', 'minrevid', "@$this->templateNamespace/release/columns/revisions.html.twig"));
-        $table->addColumnDefinition(new TemplateBlockTableColumn('release.revision.index.column.maxRevId', 'maxrevid', "@$this->templateNamespace/release/columns/revisions.html.twig"));
+        $table->addColumnDefinition(new TemplateBlockTableColumn('release.revision.index.column.minRevId', 'minrevid', $template));
+        $table->addColumnDefinition(new TemplateBlockTableColumn('release.revision.index.column.maxRevId', 'maxrevid', $template));
 
-        $table->addTableAction(TableAbstract::ADD_ACTION, 'fa fa-plus', 'release.revision.actions.add', 'release.revision.actions.add_confirm');
-        $table->addDynamicItemPostAction(Routes::RELEASE_ADD_REVISION, 'release.revision.action.add', 'plus', 'release.revision.actions.add_confirm', ['release' => \sprintf('%d', $release->getId()), 'emsLinkToAdd' => 'emsLink']);
+        $table->addTableAction(TableAbstract::ADD_ACTION, 'fa fa-plus', 'release.actions.add_publish', 'release.revision.actions.add_confirm');
+        $table->addDynamicItemPostAction(
+            route: Routes::RELEASE_ADD_REVISION,
+            labelKey: 'release.revision.action.publish',
+            icon: 'plus',
+            messageKey: 'release.revision.actions.add_confirm',
+            routeParameters: [
+                'release' => (string) $release->getId(),
+                'type' => 'publish',
+                'emsLinkToAdd' => 'emsLink',
+            ]);
     }
 
     public function getQueryName(): string

--- a/EMS/core-bundle/src/DataTable/Type/Release/ReleaseRevisionsUnpublishDataTableType.php
+++ b/EMS/core-bundle/src/DataTable/Type/Release/ReleaseRevisionsUnpublishDataTableType.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\DataTable\Type\Release;
+
+use EMS\CoreBundle\Core\DataTable\Type\AbstractQueryTableType;
+use EMS\CoreBundle\Core\Revision\Query\PublishedRevisionsQueryService;
+use EMS\CoreBundle\Entity\Environment;
+use EMS\CoreBundle\Entity\Release;
+use EMS\CoreBundle\Form\Data\QueryTable;
+use EMS\CoreBundle\Form\Data\TableAbstract;
+use EMS\CoreBundle\Form\Data\TemplateBlockTableColumn;
+use EMS\CoreBundle\Roles;
+use EMS\CoreBundle\Routes;
+use EMS\CoreBundle\Service\ReleaseService;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ReleaseRevisionsUnpublishDataTableType extends AbstractQueryTableType
+{
+    public function __construct(
+        PublishedRevisionsQueryService $queryService,
+        private readonly ReleaseService $releaseService,
+        private readonly string $templateNamespace
+    ) {
+        parent::__construct($queryService);
+    }
+
+    public function build(QueryTable $table): void
+    {
+        /** @var Release $release */
+        $release = $table->getContext()['release'];
+        $template = "@$this->templateNamespace/release/columns/revisions.html.twig";
+
+        $table->setMassAction(true);
+        $table->setLabelAttribute('ems_link');
+        $table->setIdField('ems_link');
+        $table->setSelected($release->getRevisionsOuuids());
+
+        $table->addColumnDefinition(new TemplateBlockTableColumn('release.revision.index.column.label', 'unpublish_label', $template));
+        $table->addColumn('release.revision.index.column.CT', 'content_type_name');
+        $table->addColumnDefinition(new TemplateBlockTableColumn('release.revision.index.column.minRevId', 'unpublish_source', $template));
+        $table->addColumnDefinition(new TemplateBlockTableColumn('release.revision.index.column.maxRevId', 'unpublish_target', $template));
+
+        $table->addTableAction(TableAbstract::ADD_ACTION, 'fa fa-minus', 'release.actions.add_unpublish', 'release.revision.actions.add_confirm');
+        $table->addDynamicItemPostAction(
+            route: Routes::RELEASE_ADD_REVISION,
+            labelKey: 'release.revision.action.unpublish',
+            icon: 'plus',
+            messageKey: 'release.revision.actions.add_confirm',
+            routeParameters: [
+                'release' => (string) $release->getId(),
+                'type' => 'unpublish',
+                'emsLinkToAdd' => 'ems_link',
+            ]);
+    }
+
+    public function getQueryName(): string
+    {
+        return 'release_revisions_unpublish';
+    }
+
+    public function getRoles(): array
+    {
+        return [Roles::ROLE_PUBLISHER];
+    }
+
+    /**
+     * @param array{'release_id': int} $options
+     *
+     * @return array{'release': Release, 'environment': Environment}
+     */
+    public function getContext(array $options): array
+    {
+        $release = $this->releaseService->getById($options['release_id']);
+
+        return [
+            'release' => $release,
+            'environment' => $release->getEnvironmentTarget(),
+            'exclude_ouuids' => $release->getRevisionsOuuids(),
+        ];
+    }
+
+    public function configureOptions(OptionsResolver $optionsResolver): void
+    {
+        $optionsResolver->setRequired(['release_id']);
+    }
+}

--- a/EMS/core-bundle/src/Entity/ReleaseRevision.php
+++ b/EMS/core-bundle/src/Entity/ReleaseRevision.php
@@ -57,6 +57,15 @@ class ReleaseRevision implements EntityInterface
      */
     private ContentType $contentType;
 
+    public static function createFromRevision(Revision $revision): self
+    {
+        $releaseRevision = new self();
+        $releaseRevision->setContentType($revision->giveContentType());
+        $releaseRevision->setRevisionOuuid($revision->giveOuuid());
+
+        return $releaseRevision;
+    }
+
     public function getId(): int
     {
         return $this->id;

--- a/EMS/core-bundle/src/Form/Data/QueryTable.php
+++ b/EMS/core-bundle/src/Form/Data/QueryTable.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EMS\CoreBundle\Form\Data;
 
+use EMS\CoreBundle\Helper\DataTableRequest;
 use EMS\CoreBundle\Service\QueryServiceInterface;
 
 class QueryTable extends TableAbstract
@@ -11,6 +12,8 @@ class QueryTable extends TableAbstract
     private bool $loadAll;
     private bool $massAction = true;
     private string $idField = 'id';
+    private ?int $count = null;
+    private ?int $totalCount = null;
 
     /**
      * @param mixed $context
@@ -49,6 +52,13 @@ class QueryTable extends TableAbstract
         return $this->idField;
     }
 
+    public function resetIterator(DataTableRequest $dataTableRequest): void
+    {
+        parent::resetIterator($dataTableRequest);
+        $this->totalCount = null;
+        $this->count = null;
+    }
+
     /**
      * @return \Traversable<string, QueryRow>
      */
@@ -65,12 +75,20 @@ class QueryTable extends TableAbstract
 
     public function count(): int
     {
-        return $this->service->countQuery($this->getSearchValue(), $this->context);
+        if (null === $this->count) {
+            $this->count = $this->service->countQuery($this->getSearchValue(), $this->context);
+        }
+
+        return $this->count;
     }
 
     public function totalCount(): int
     {
-        return $this->service->countQuery('', $this->context);
+        if (null === $this->totalCount) {
+            $this->totalCount = $this->service->countQuery('', $this->context);
+        }
+
+        return $this->totalCount;
     }
 
     public function supportsTableActions(): bool

--- a/EMS/core-bundle/src/Resources/config/controllers.xml
+++ b/EMS/core-bundle/src/Resources/config/controllers.xml
@@ -231,7 +231,6 @@
         <service id="EMS\CoreBundle\Controller\ContentManagement\ReleaseController" public="true">
             <argument type="service" id="logger" />
             <argument type="service" id="ems.service.release" />
-            <argument type="service" id="ems.service.release_revision" />
             <argument type="service" id="emsco.data_table.factory" />
             <argument>%ems_core.template_namespace%</argument>
             <call method="setContainer"/>

--- a/EMS/core-bundle/src/Resources/config/datatable.xml
+++ b/EMS/core-bundle/src/Resources/config/datatable.xml
@@ -18,6 +18,12 @@
             <argument>%ems_core.template_namespace%</argument>
             <tag name="emsco.datatable" />
         </service>
+      <service id="emsco.data_table.release.non_member" class="EMS\CoreBundle\DataTable\Type\Release\ReleaseNonMemberRevisionsDataTableType">
+        <argument type="service" id="ems.service.release_revision"/>
+        <argument type="service" id="ems.service.release"/>
+        <argument>%ems_core.template_namespace%</argument>
+        <tag name="emsco.datatable" />
+      </service>
         <service id="emsco.data_table.release.overview" class="EMS\CoreBundle\DataTable\Type\Release\ReleaseOverviewDataTableType">
             <argument type="service" id="ems.service.release"/>
             <argument>%ems_core.template_namespace%</argument>

--- a/EMS/core-bundle/src/Resources/config/datatable.xml
+++ b/EMS/core-bundle/src/Resources/config/datatable.xml
@@ -18,12 +18,18 @@
             <argument>%ems_core.template_namespace%</argument>
             <tag name="emsco.datatable" />
         </service>
-      <service id="emsco.data_table.release.non_member" class="EMS\CoreBundle\DataTable\Type\Release\ReleaseNonMemberRevisionsDataTableType">
-        <argument type="service" id="ems.service.release_revision"/>
-        <argument type="service" id="ems.service.release"/>
-        <argument>%ems_core.template_namespace%</argument>
-        <tag name="emsco.datatable" />
-      </service>
+        <service id="emsco.data_table.release.publish" class="EMS\CoreBundle\DataTable\Type\Release\ReleaseRevisionsPublishDataTableType">
+            <argument type="service" id="ems.service.release_revision"/>
+            <argument type="service" id="ems.service.release"/>
+            <argument>%ems_core.template_namespace%</argument>
+            <tag name="emsco.datatable" />
+        </service>
+        <service id="emsco.data_table.release.unpublish" class="EMS\CoreBundle\DataTable\Type\Release\ReleaseRevisionsUnpublishDataTableType">
+            <argument type="service" id="emsco.core.revision.query.published_revisions"/>
+            <argument type="service" id="ems.service.release"/>
+            <argument>%ems_core.template_namespace%</argument>
+            <tag name="emsco.datatable" />
+        </service>
         <service id="emsco.data_table.release.overview" class="EMS\CoreBundle\DataTable\Type\Release\ReleaseOverviewDataTableType">
             <argument type="service" id="ems.service.release"/>
             <argument>%ems_core.template_namespace%</argument>

--- a/EMS/core-bundle/src/Resources/config/routing/data.xml
+++ b/EMS/core-bundle/src/Resources/config/routing/data.xml
@@ -125,9 +125,11 @@
     <route id="emsco_pick_a_release" path="/pick-a-release/{revision}"
            controller="EMS\CoreBundle\Controller\ContentManagement\ReleaseController::pickRelease"
            methods="GET|POST"/>
-    <route id="emsco_data_add_revision_to_release" path="/add-to-release/{revision}/{release}"
+    <route id="emsco_data_add_revision_to_release" path="/add-to-release/{type}/{revision}/{release}"
            controller="EMS\CoreBundle\Controller\ContentManagement\ReleaseController::addRevisionById"
-           methods="POST"/>
+           methods="POST">
+        <requirement key="type">publish|unpublish</requirement>
+    </route>
 
     <!-- Deprecated routes -->
     <route id="ems_data_default_search" path="/{name}"

--- a/EMS/core-bundle/src/Resources/config/routing/release.xml
+++ b/EMS/core-bundle/src/Resources/config/routing/release.xml
@@ -22,12 +22,16 @@
     <route id="emsco_release_set_status" path="/{release}/set-status/{status}"
            controller="EMS\CoreBundle\Controller\ContentManagement\ReleaseController::changeStatus"
            methods="GET|POST"/>
-    <route id="emsco_release_add_revision" path="/{release}/add-revision/{emsLinkToAdd}"
+    <route id="emsco_release_add_revision" path="/{release}/add-revision/{type}/{emsLinkToAdd}"
            controller="EMS\CoreBundle\Controller\ContentManagement\ReleaseController::addRevision"
-           methods="POST"/>
-    <route id="emsco_release_add_revisions" path="/{release}/add-revisions"
+           methods="POST">
+        <requirement key="type">publish|unpublish</requirement>
+    </route>
+    <route id="emsco_release_add_revisions" path="/{release}/add-revisions/{type}"
            controller="EMS\CoreBundle\Controller\ContentManagement\ReleaseController::addRevisions"
-           methods="GET|POST"/>
+           methods="GET|POST">
+        <requirement key="type">publish|unpublish</requirement>
+    </route>
     <route id="emsco_release_publish" path="/{release}/publish"
            controller="EMS\CoreBundle\Controller\ContentManagement\ReleaseController::releasePublish"
            methods="POST"/>

--- a/EMS/core-bundle/src/Resources/config/routing/release.xml
+++ b/EMS/core-bundle/src/Resources/config/routing/release.xml
@@ -28,9 +28,6 @@
     <route id="emsco_release_add_revisions" path="/{release}/add-revisions"
            controller="EMS\CoreBundle\Controller\ContentManagement\ReleaseController::addRevisions"
            methods="GET|POST"/>
-    <route id="emsco_release_ajax_data_table_non_member_revision" path="/{release}/non-member-datatable.json"
-           controller="EMS\CoreBundle\Controller\ContentManagement\ReleaseController::ajaxReleaseTableNonMemberRevisions"
-           methods="GET"/>
     <route id="emsco_release_publish" path="/{release}/publish"
            controller="EMS\CoreBundle\Controller\ContentManagement\ReleaseController::releasePublish"
            methods="POST"/>

--- a/EMS/core-bundle/src/Resources/config/services.xml
+++ b/EMS/core-bundle/src/Resources/config/services.xml
@@ -467,7 +467,6 @@
             <argument type="service" id="EMS\CoreBundle\Repository\RevisionRepository"/>
             <argument type="service" id="logger"/>
             <argument type="service" id="ems.service.contenttype"/>
-            <argument type="service" id="ems.service.user"/>
             <tag name="kernel.event_listener" event="EMS\CoreBundle\Event\RevisionFinalizeDraftEvent" method="finalizeDraftEvent" priority="0" />
         </service>
         <service id="ems.form_submission" class="EMS\CoreBundle\Service\Form\Submission\FormSubmissionService">

--- a/EMS/core-bundle/src/Resources/config/services.xml
+++ b/EMS/core-bundle/src/Resources/config/services.xml
@@ -197,6 +197,11 @@
             <argument>%ems_core.template_namespace%</argument>
             <tag name="twig.runtime"/>
         </service>
+        <service id="emsco.core.revision.query.published_revisions" class="EMS\CoreBundle\Core\Revision\Query\PublishedRevisionsQueryService">
+            <argument type="service" id="doctrine" />
+            <argument type="service" id="EMS\CoreBundle\Service\ContentTypeService" />
+            <argument type="service" id="ems.service.revision" />
+        </service>
 
         <service id="ems.log.manager" class="EMS\CoreBundle\Core\Log\LogManager">
             <argument type="service" id="ems.repository.log"/>

--- a/EMS/core-bundle/src/Resources/translations/EMSCoreBundle.en.yml
+++ b/EMS/core-bundle/src/Resources/translations/EMSCoreBundle.en.yml
@@ -126,6 +126,7 @@ log:
             reindex_failed_in: 'The document "%label%" has encountered an exception during its reindexing in %environment%'
             added_to_release: 'Document "%label%" has been added to release "%release%"'
             can_not_add_draft_in_release: 'Revision in draft mode can not be added to a release'
+            document_not_in_target: 'Document "%label%" is not published in target environment "%environment%"'
             document_already_in_release_but_updated: 'Document "%label%" has been updated with a new revision in release "%release%"'
             already_in_release: 'This revision of document "%label%" was already in release "%release%"'
     elasticsearch:
@@ -526,7 +527,8 @@ data:
     custom-view:
         pagetitle: 'View %name% of the %contentType% "%label%" as indexed in %environment%'
     actions:
-        add_to_release: 'Add to release'
+        add_to_release_publish: 'Add to release for publication'
+        add_to_release_unpublish: 'Add to release for unpublish'
         add_to_release_confirm: 'Do you confirm ?'
 field_type:
     textarea:

--- a/EMS/core-bundle/src/Resources/translations/EMSCoreBundle.en.yml
+++ b/EMS/core-bundle/src/Resources/translations/EMSCoreBundle.en.yml
@@ -610,8 +610,8 @@ release:
         delete_selected: 'Delete selected'
         delete_selected_confirm: 'Delete all selected Releases?'
         edit: Edit
-        publish_release: 'Publish now'
-        publish_confirm: 'Publish the release?'
+        publish_release: 'Release now'
+        publish_confirm: 'Do you confirm ?'
         set_status_canceled: 'Cancel release'
         set_status_ready: 'Validate release'
         set_status_wip: 'Rework release'

--- a/EMS/core-bundle/src/Resources/translations/EMSCoreBundle.en.yml
+++ b/EMS/core-bundle/src/Resources/translations/EMSCoreBundle.en.yml
@@ -126,7 +126,7 @@ log:
             reindex_failed_in: 'The document "%label%" has encountered an exception during its reindexing in %environment%'
             added_to_release: 'Document "%label%" has been added to release "%release%"'
             can_not_add_draft_in_release: 'Revision in draft mode can not be added to a release'
-            document_not_in_target: 'Document "%label%" is not published in target environment "%environment%"'
+            document_not_in_target: 'Document "%label%" is not published in target environment "%target%"'
             document_already_in_release_but_updated: 'Document "%label%" has been updated with a new revision in release "%release%"'
             already_in_release: 'This revision of document "%label%" was already in release "%release%"'
     elasticsearch:

--- a/EMS/core-bundle/src/Resources/translations/EMSCoreBundle.en.yml
+++ b/EMS/core-bundle/src/Resources/translations/EMSCoreBundle.en.yml
@@ -603,7 +603,8 @@ query_search:
     menu: QuerySearch
 release:
     actions:
-        add_revisions: 'Add documents'
+        add_publish: 'Add documents for publication'
+        add_unpublish: 'Add documents for unpublish'
         delete: Delete
         delete_confirm: 'Delete the Release?'
         delete_selected: 'Delete selected'
@@ -634,11 +635,11 @@ release:
     menu: Releases
     revision:
         actions:
-            add: 'Add document'
             add_confirm: 'Do you confirm ?'
             remove: 'Remove documents'
         action:
-            add: 'Add document to release'
+            publish: 'Add document for publication'
+            unpublish: 'Add document for unpublish'
         index:
             column:
                 CT: 'Content Type'
@@ -652,7 +653,8 @@ release:
                 not-applicable: 'not applicable'
                 still_in_target: 'Still in %target%'
                 compare: Compare
-            title: 'List of documents available for release'
+            publish: 'List of documents available for publication'
+            unpublish: 'List of documents available for unpublish'
         menu: 'Add documents'
         view:
             title: 'Release''s documents'

--- a/EMS/core-bundle/src/Resources/translations/emsco-twigs.en.yml
+++ b/EMS/core-bundle/src/Resources/translations/emsco-twigs.en.yml
@@ -233,7 +233,7 @@ release:
         publish: Publish
         unpublish: Unpublish
         revision: '%date% finalized by %user%'
-        missing-revision: 'The document %ouuid% is no more available in %environment%'
+        missing-revision: 'The document "%label%" is no more available in %environment%'
         not-applicable: 'not applicable'
         still_in_target: 'Still released in %target%'
         no_more_in_target: 'This revision has been unpublished from %target%'

--- a/EMS/core-bundle/src/Resources/views/release/columns/release-revisions.html.twig
+++ b/EMS/core-bundle/src/Resources/views/release/columns/release-revisions.html.twig
@@ -2,14 +2,16 @@
 
 {% block label %}
     {% if data.revision %}
-        {{ data.revision.label }}
+        {{ data.revision|emsco_display }}
     {% else %}
         {% set info = data.emsId|emsco_document_info %}
-        {% set release = info.getRevision(data.release.environmentSource.name) %}
-        {% if release %}
-            {{ release.label }}
+        {% set revisionSource = info.getRevision(data.release.environmentSource.name) %}
+        {% set revisionTarget = info.getRevision(data.release.environmentTarget.name) %}
+
+        {% if revisionTarget %}
+            {{ revisionTarget|emsco_display }}
         {% else %}
-            {{ 'release.release-revisison.missing-revision'|trans({'%ouuid%': data.revisionOuuid, '%environment%': data.release.environmentSource.label}) }}
+            {{ 'release.release-revisison.missing-revision'|trans({'%label%': revisionSource|emsco_display, '%environment%': data.release.environmentTarget.name}) }}
         {% endif %}
     {% endif %}
 {% endblock label %}
@@ -25,8 +27,12 @@
         </a>
     {% else %}
         {% set info = data.emsId|emsco_document_info %}
-        {% set revision = info.getRevision(data.release.environmentSource.name) %}
-        {% if revision %}
+        {% set revisionTarget = info.getRevision(data.release.environmentTarget.name) %}
+        {% if revisionTarget %}
+            <a href="{{ path('emsco_view_revisions', {ouuid: data.revisionOuuid, type: data.contentType.name, revisionId: revisionTarget.id}) }}">
+                {{ 'release.release-revisison.revision'|trans({ '%date%' : revisionTarget.created|date(date_time_format) ,'%user%' : revisionTarget.finalizedBy|default('')|displayname }) }}
+            </a>
+        {% else %}
             {{ 'release.release-revisison.revision-not-applicable'|trans }}
         {% endif %}
     {% endif %}
@@ -59,7 +65,9 @@
         {% set revision = info.getRevision(data.release.environmentTarget) %}
         {% set stil_in_target = (data.revision.id is same as (revision.id)) %}
     {% else %}
-        {% set stil_in_target = true %}
+        {% set info = data.emsId|emsco_document_info %}
+        {% set revisionTarget = info.getRevision(data.release.environmentTarget.name) %}
+        {% set stil_in_target = (revisionTarget ? true : false) %}
     {% endif %}
     {%  if stil_in_target %}
         <i class="fa fa-check-square"><span class="sr-only"</span>{{ 'release.release-revisison.still_in_target'|trans({'%target%': data.release.environmentTarget.label}) }}</i>

--- a/EMS/core-bundle/src/Resources/views/release/columns/revisions.html.twig
+++ b/EMS/core-bundle/src/Resources/views/release/columns/revisions.html.twig
@@ -1,15 +1,18 @@
-{% use "bootstrap_3_layout.html.twig" %}{% trans_default_domain 'EMSCoreBundle' %}
+{% trans_default_domain 'EMSCoreBundle' %}
 
-       
+{% block label %}
+    {{ data.emsLink|emsco_display }}
+{% endblock %}
+
 {% block minrevid %}
     {% set release = app.request.get('release') %}
     {% set minrev = data.minrevid|split('/') %}
     {% set maxrev = data.maxrevid|split('/') %}
 
     {% if minrev[0] == release.environmentSource.id %}
-        {{ '%date% Finalized by %user%'|trans({ '%date%' : minrev[2]|date(date_time_format) ,'%user%' : minrev[3] }) }}     
+        {{ '%date% Finalized by %user%'|trans({ '%date%' : minrev[2]|date(date_time_format) ,'%user%' : minrev[3] }) }}
     {% elseif maxrev[0] == release.environmentSource.id %}
-        {{ '%date% Finalized by %user%'|trans({ '%date%' : maxrev[2]|date(date_time_format) ,'%user%' : maxrev[3] }) }}  
+        {{ '%date% Finalized by %user%'|trans({ '%date%' : maxrev[2]|date(date_time_format) ,'%user%' : maxrev[3] }) }}
     {% else %}
         {{ 'no revision in %env%'|trans({ '%env%' : release.environmentSource.name }) }}
     {% endif %}
@@ -41,9 +44,9 @@
     {% set minrev = data.minrevid|split('/') %}
     {% set maxrev = data.maxrevid|split('/') %}
     {% if maxrev[0] == release.environmentTarget.id %}
-        {{ '%date% Finalized by %user%'|trans({ '%date%' : maxrev[2]|date(date_time_format) ,'%user%' : maxrev[3] }) }}  
+        {{ '%date% Finalized by %user%'|trans({ '%date%' : maxrev[2]|date(date_time_format) ,'%user%' : maxrev[3] }) }}
     {% elseif minrev[0] == release.environmentTarget.id %}
-        {{ '%date% Finalized by %user%'|trans({ '%date%' : minrev[2]|date(date_time_format) ,'%user%' : minrev[3] }) }}     
+        {{ '%date% Finalized by %user%'|trans({ '%date%' : minrev[2]|date(date_time_format) ,'%user%' : minrev[3] }) }}
     {% else %}
         {{ 'no revision in %env%'|trans({ '%env%' : release.environmentTarget.name }) }}
     {% endif %}
@@ -53,11 +56,11 @@
     {% set release = app.request.get('release') %}
     {% set minrev = data.minrevid|split('/') %}
     {% set maxrev = data.maxrevid|split('/') %}
-  
+
     {% if minrev[0] == release.environmentSource.id %}
-        {{ '%date% Finalized by %user%'|trans({ '%date%' : minrev[2]|date(date_time_format) ,'%user%' : minrev[3] }) }}     
+        {{ '%date% Finalized by %user%'|trans({ '%date%' : minrev[2]|date(date_time_format) ,'%user%' : minrev[3] }) }}
     {% elseif maxrev[0] == release.environmentSource.id %}
-        {{ '%date% Finalized by %user%'|trans({ '%date%' : maxrev[2]|date(date_time_format) ,'%user%' : maxrev[3] }) }}  
+        {{ '%date% Finalized by %user%'|trans({ '%date%' : maxrev[2]|date(date_time_format) ,'%user%' : maxrev[3] }) }}
     {% else %}
         {{ 'Unpublish in %env%'|trans({ '%env%' : release.environmentTarget.name }) }}
     {% endif %}
@@ -68,9 +71,9 @@
     {% set release = app.request.get('release') %}
     {% set maxrev = data.maxrevid|split('/') %}
     {% set minrev = data.minrevid|split('/') %}
-           
+
     {% if maxrev[0] == release.environmentTarget.id %}
-        {{ '%date% Finalized by %user%'|trans({ '%date%' : maxrev[2]|date(date_time_format) ,'%user%' : maxrev[3] }) }}  
+        {{ '%date% Finalized by %user%'|trans({ '%date%' : maxrev[2]|date(date_time_format) ,'%user%' : maxrev[3] }) }}
     {% elseif minrev[0] == release.environmentTarget.id %}
         {{ '%date% Finalized by %user%'|trans({ '%date%' : minrev[2]|date(date_time_format) ,'%user%' : minrev[3] }) }}
     {% else %}

--- a/EMS/core-bundle/src/Resources/views/release/columns/revisions.html.twig
+++ b/EMS/core-bundle/src/Resources/views/release/columns/revisions.html.twig
@@ -1,8 +1,7 @@
 {% trans_default_domain 'EMSCoreBundle' %}
 
-{% block label %}
-    {{ data.emsLink|emsco_display }}
-{% endblock %}
+{% block publish_label %}{{ data.emsLink|emsco_display }}{% endblock %}
+{% block unpublish_label %}{{ data.label }}{% endblock %}
 
 {% block minrevid %}
     {% set release = app.request.get('release') %}
@@ -18,26 +17,21 @@
     {% endif %}
 {% endblock minrevid %}
 
-
 {% block environmentSource %}
     {{ data.environmentSource.label }}
 {% endblock environmentSource %}
-
 
 {% block status %}
     {{ ('release.status.'~data.status)|trans }}
 {% endblock status %}
 
-
 {% block environmentTarget %}
     {{ data.environmentTarget.label }}
 {% endblock environmentTarget %}
 
-
 {% block docs_count %}
     {{ data.revisions|length }}
 {% endblock docs_count %}
-
 
 {% block maxrevid %}
     {% set release = app.request.get('release') %}
@@ -66,7 +60,6 @@
     {% endif %}
 {% endblock minrevidstatus %}
 
-
 {% block maxrevidstatus  %}
     {% set release = app.request.get('release') %}
     {% set maxrev = data.maxrevid|split('/') %}
@@ -85,3 +78,22 @@
         {{ 'replace by revision %date%'|trans({ '%date%' : maxrev[2]|date(date_time_format) }) }}
     {% endif %}
 {% endblock maxrevidstatus  %}
+
+{% block unpublish_source %}
+    <div style="width: 250px">
+        {{ '%date% Finalized by %user%'|trans({
+            '%date%': data.default_finalized_date|date(date_time_format),
+            '%user%': data.default_finalized_by
+        }) }}
+    </div>
+{% endblock unpublish_source %}
+
+{% block unpublish_target %}
+    <div style="width: 250px">
+        {{ '%date% Finalized by %user%'|trans({
+            '%date%': data.published_finalized_date|date(date_time_format),
+            '%user%': data.published_finalized_by
+        }) }}
+    </div>
+{% endblock unpublish_target %}
+

--- a/EMS/core-bundle/src/Resources/views/release/form.html.twig
+++ b/EMS/core-bundle/src/Resources/views/release/form.html.twig
@@ -33,11 +33,17 @@
 			<div class="box-footer">
 				<div class="btn-group">
 					{% include '@EMSCore/elements/get-button.html.twig' with {
-						'url':  path('emsco_release_add_revisions', {'release': release.id} ),
-						'label': 'release.actions.add_revisions'|trans,
+						'url':  path('emsco_release_add_revisions', {'release': release.id, 'type': 'publish' } ),
+						'label': 'release.actions.add_publish'|trans,
 						'icon': 'plus',
 						'btnType': 'primary',
 					}%}
+                    {% include '@EMSCore/elements/get-button.html.twig' with {
+                        'url':  path('emsco_release_add_revisions', {'release': release.id, 'type': 'unpublish' } ),
+                        'label': 'release.actions.add_unpublish'|trans,
+                        'icon': 'minus',
+                        'btnType': 'default',
+                    }%}
 					{% if release.revisions|length > 0 %}
 						{% include '@EMSCore/elements/post-button.html.twig' with {
 							'url': path('emsco_release_set_status', {'release': release.id, 'status': 'ready'}),

--- a/EMS/core-bundle/src/Resources/views/release/revisions.html.twig
+++ b/EMS/core-bundle/src/Resources/views/release/revisions.html.twig
@@ -1,7 +1,14 @@
 {% extends '@EMSCore/base.html.twig' %}
 {% trans_default_domain 'EMSCoreBundle' %}
 
-{% block title %}{{ 'release.revision.index.title'|trans }}{% endblock %}
+{% block title %}
+    {%- if type == 'publish' -%}
+        {{- 'release.revision.index.publish'|trans -}}
+    {%- elseif type == 'unpublish' -%}
+        {{- 'release.revision.index.unpublish'|trans -}}
+    {%- endif -%}
+{% endblock %}
+
 {% block pagetitle %}{{ block('title') }}{% endblock %}
 
 {% block breadcrumb %}
@@ -12,12 +19,6 @@
 {% endblock %}
 
 {% block body %}
-	{%  set toolbar %}
-
-	{%  endset %}
-
 	{% form_theme form '@EMSCore/form/forms.html.twig' %}
-	{{ form(form, {
-		toolbar: toolbar
-	}) }}
+	{{ form(form) }}
 {% endblock %}

--- a/EMS/core-bundle/src/Service/ContentTypeService.php
+++ b/EMS/core-bundle/src/Service/ContentTypeService.php
@@ -239,6 +239,26 @@ class ContentTypeService implements EntityServiceInterface
         return \array_keys($out);
     }
 
+    /**
+     * @return ContentType[]
+     */
+    public function getAllGrantedForPublication(): array
+    {
+        $contentTypes = [];
+        foreach ($this->getAll() as $contentType) {
+            if ($contentType->getDeleted()) {
+                continue;
+            }
+
+            $publishRole = $contentType->role(ContentTypeRoles::PUBLISH);
+            if ($this->authorizationChecker->isGranted($publishRole)) {
+                $contentTypes[] = $contentType;
+            }
+        }
+
+        return $contentTypes;
+    }
+
     public function getAllAliases(): string
     {
         $this->loadEnvironment();

--- a/EMS/core-bundle/src/Service/ReleaseService.php
+++ b/EMS/core-bundle/src/Service/ReleaseService.php
@@ -40,7 +40,7 @@ final class ReleaseService implements EntityServiceInterface
         $this->releaseRepository->create($release);
     }
 
-    public function addRevision(Release $release, Revision $revision): void
+    public function addRevisionForPublish(Release $release, Revision $revision): void
     {
         if ($revision->getDraft()) {
             $this->logger->error('log.data.revision.can_not_add_draft_in_release', [...['release' => $release->getName()], ...LogRevisionContext::read($revision)]);
@@ -62,12 +62,45 @@ final class ReleaseService implements EntityServiceInterface
 
             return;
         }
-        $releaseRevision = new ReleaseRevision();
+
+        $releaseRevision = ReleaseRevision::createFromRevision($revision);
         $releaseRevision->setRelease($release);
-        $releaseRevision->setContentType($revision->giveContentType());
-        $releaseRevision->setRevisionOuuid($revision->giveOuuid());
         $releaseRevision->setRevision($revision);
         $release->addRevision($releaseRevision);
+
+        $this->releaseRepository->create($release);
+        $this->logger->notice('log.data.revision.added_to_release', [...['release' => $release->getName()], ...LogRevisionContext::read($revision)]);
+    }
+
+    public function addRevisionForUnpublish(Release $release, Revision $revision): void
+    {
+        if ($revision->getDraft()) {
+            $this->logger->error('log.data.revision.can_not_add_draft_in_release', [...['release' => $release->getName()], ...LogRevisionContext::read($revision)]);
+
+            return;
+        }
+
+        foreach ($release->getRevisions() as $releaseRevision) {
+            if ($releaseRevision->getRevisionOuuid() === $revision->giveOuuid()) {
+                $this->logger->notice('log.data.revision.already_in_release', [...['release' => $release->getName()], ...LogRevisionContext::read($revision)]);
+
+                return;
+            }
+        }
+
+        try {
+            $this->dataService->getRevisionByEnvironment($revision->giveOuuid(), $revision->giveContentType(), $release->getEnvironmentTarget());
+        } catch (NoResultException) {
+            $this->logger->notice('log.data.revision.document_not_in_target', [...['environment' => $release->getEnvironmentTarget()->getName()], ...LogRevisionContext::read($revision)]);
+
+            return;
+        }
+
+        $releaseRevision = ReleaseRevision::createFromRevision($revision);
+        $releaseRevision->setRelease($release);
+        $releaseRevision->setRevision(null);
+        $release->addRevision($releaseRevision);
+
         $this->releaseRepository->create($release);
         $this->logger->notice('log.data.revision.added_to_release', [...['release' => $release->getName()], ...LogRevisionContext::read($revision)]);
     }

--- a/EMS/core-bundle/src/Service/ReleaseService.php
+++ b/EMS/core-bundle/src/Service/ReleaseService.php
@@ -75,7 +75,7 @@ final class ReleaseService implements EntityServiceInterface
     /**
      * @param array<string> $emsLinks
      */
-    public function addRevisions(Release $release, array $emsLinks): void
+    public function addRevisions(Release $release, string $type, array $emsLinks): void
     {
         foreach ($emsLinks as $emsLink) {
             $emsLinkObject = EMSLink::fromText($emsLink);
@@ -85,15 +85,18 @@ final class ReleaseService implements EntityServiceInterface
 
             $contentType = $this->contentTypeService->giveByName($emsLinkObject->getContentType());
             $releaseRevision->setContentType($contentType);
-            $revision = null;
 
-            try {
-                $revision = $this->dataService->getRevisionByEnvironment($emsLinkObject->getOuuid(), $contentType, $release->getEnvironmentSource());
-            } catch (NoResultException) {
-                $revision = null;
+            if ('publish' === $type) {
+                try {
+                    $revision = $this->dataService->getRevisionByEnvironment($emsLinkObject->getOuuid(), $contentType, $release->getEnvironmentSource());
+                } catch (NoResultException) {
+                    $revision = null;
+                }
+                $releaseRevision->setRevision($revision);
+            } elseif ('unpublish' === $type) {
+                $releaseRevision->setRevision(null);
             }
 
-            $releaseRevision->setRevision($revision);
             $release->addRevision($releaseRevision);
         }
         $this->releaseRepository->create($release);

--- a/EMS/core-bundle/src/Service/ReleaseService.php
+++ b/EMS/core-bundle/src/Service/ReleaseService.php
@@ -91,7 +91,7 @@ final class ReleaseService implements EntityServiceInterface
         try {
             $this->dataService->getRevisionByEnvironment($revision->giveOuuid(), $revision->giveContentType(), $release->getEnvironmentTarget());
         } catch (NoResultException) {
-            $this->logger->notice('log.data.revision.document_not_in_target', [...['environment' => $release->getEnvironmentTarget()->getName()], ...LogRevisionContext::read($revision)]);
+            $this->logger->notice('log.data.revision.document_not_in_target', [...['target' => $release->getEnvironmentTarget()->getName()], ...LogRevisionContext::read($revision)]);
 
             return;
         }


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  n |
| New feature?   | y  |
| BC breaks?     | n  |
| Deprecations?  |  n |
| Fixed tickets? |  n |
| Documentation? | n  |

- [x] Add new feature for adding unpublish documents to a release
- [x] Also accessible from the revision in the "add to release" action
- [x] The dataTableFactory can now also build QueryTables, before it was only used for EntityTables
- [x] Fixed QueryTable counting issue
- [x] Aligned twig changes to AdminUIBundle

