### PR TITLE
fix(admin): still reference template @EMSCore

### DIFF
--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/admin-form/reorder.html.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/admin-form/reorder.html.twig
@@ -12,7 +12,7 @@
             {{ form_start(form) }}
 				<div class="box-body no-padding">
 					<ol class="nested-sortable vertical" id="root-list" data-nested-max-level="15" data-nested-is-tree="true">
-						{% include "@EMSCore/contenttype/reorder_item.html.twig" with {
+						{% include "@EMSAdminUI/bootstrap5/contenttype/reorder_item.html.twig" with {
 							parent: entity.fieldType
 						} %}
 					</ol>

--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/analyzer/add.html.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/analyzer/add.html.twig
@@ -13,7 +13,7 @@
 
 {% block body %}
 
-    {% include "@EMSCore/analyzer/form.html.twig" with {
+    {% include "@EMSAdminUI/bootstrap5/analyzer/form.html.twig" with {
     	form: form,
     	label: 'Add an analyzer',
     } %}

--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/analyzer/edit.html.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/analyzer/edit.html.twig
@@ -13,7 +13,7 @@
 
 {% block body %}
 
-    {% include "@EMSCore/analyzer/form.html.twig" with {
+    {% include "@EMSAdminUI/bootstrap5/analyzer/form.html.twig" with {
     	form: form,
     	label: 'Edit an Analyzer'|trans,
     } %}

--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/channel/add.html.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/channel/add.html.twig
@@ -12,7 +12,7 @@
 {% endblock %}
 
 {% block body %}
-    {% include "@EMSCore/channel/form.html.twig" with {
+    {% include "@EMSAdminUI/bootstrap5/channel/form.html.twig" with {
     	label: 'channel.add.title',
 		save_action_key: 'channel.add.save',
     } %}

--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/channel/edit.html.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/channel/edit.html.twig
@@ -12,7 +12,7 @@
 {% endblock %}
 
 {% block body %}
-    {% include "@EMSCore/channel/form.html.twig" with {
+    {% include "@EMSAdminUI/bootstrap5/channel/form.html.twig" with {
     	label: 'channel.edit.title',
 		save_action_key: 'channel.edit.save',
     } %}

--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/components/json_menu_nested/template.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/components/json_menu_nested/template.twig
@@ -187,7 +187,7 @@
 
 {%- block jmn_modal_view -%}
     {%- if dataFields -%}
-        {%- import "@EMSCore/macros/data-field-type.html.twig" as macros -%}
+        {%- import "@EMSAdminUI/bootstrap5/macros/data-field-type.html.twig" as macros -%}
         {{ macros.renderDataField(dataFields, rawData, false, []) }}
     {%- else -%}
         <p class="text-red">{{ 'view.data.json-menu-nested-json-preview.field-type-not-found'|trans }}</p>

--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/contenttype/reorder.html.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/contenttype/reorder.html.twig
@@ -32,7 +32,7 @@
             {{ form_start(form) }}
 				<div class="box-body no-padding">
 					<ol class="nested-sortable vertical" id="root-list" data-nested-max-level="15" data-nested-is-tree="true">
-						{% include "@EMSCore/contenttype/reorder_item.html.twig" with {
+						{% include "@EMSAdminUI/bootstrap5/contenttype/reorder_item.html.twig" with {
 							parent: contentType.fieldType
 						} %}
 					</ol>

--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/contenttype/reorder_item.html.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/contenttype/reorder_item.html.twig
@@ -16,7 +16,7 @@
         		</div>
         		{% if (child.type~'::isContainer')|call_user_func and child.children|length > 0  %}
         			<ol>
-                        {% include "@EMSCore/contenttype/reorder_item.html.twig" with {
+                        {% include "@EMSAdminUI/bootstrap5/contenttype/reorder_item.html.twig" with {
                     		parent: child
                     	} %}
         			</ol>

--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/data/custom-view.html.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/data/custom-view.html.twig
@@ -25,7 +25,7 @@
 
 
 {% block body %}
-{% import "@EMSCore/macros/data-field-type.html.twig" as macros %}
+{% import "@EMSAdminUI/bootstrap5/macros/data-field-type.html.twig" as macros %}
 <div class="row">
 	<div class="col-xs-12">
 		<div class="box">

--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/data/revisions-data.html.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/data/revisions-data.html.twig
@@ -1,6 +1,6 @@
 {% extends '@EMSAdminUI/bootstrap5/base/admin.html.twig' %}{% trans_default_domain 'emsco-twigs' %}
 
-{% import "@EMSCore/macros/data-field-type.html.twig" as macros %}
+{% import "@EMSAdminUI/bootstrap5/macros/data-field-type.html.twig" as macros %}
 
 {% set revisionColor = revision.contentType.color %}
 

--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/elasticsearch/search.html.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/elasticsearch/search.html.twig
@@ -9,7 +9,7 @@
 
 <div class="row">
 	<div id="search-page" class="col-md-12">
-        {% include "@EMSCore/elasticsearch/search-form-filter.html.twig" with {
+        {% include "@EMSAdminUI/bootstrap5/elasticsearch/search-form-filter.html.twig" with {
 			form: form,
 		} %}
 	</div>

--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/filter/add.html.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/filter/add.html.twig
@@ -13,7 +13,7 @@
 
 {% block body %}
 
-    {% include "@EMSCore/filter/form.html.twig" with {
+    {% include "@EMSAdminUI/bootstrap5/filter/form.html.twig" with {
     	form: form,
     	label: 'Add a Filter'|trans,
     } %}

--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/filter/edit.html.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/filter/edit.html.twig
@@ -13,7 +13,7 @@
 
 {% block body %}
 
-    {% include "@EMSCore/filter/form.html.twig" with {
+    {% include "@EMSAdminUI/bootstrap5/filter/form.html.twig" with {
     	form: form,
     	label: 'Edit a Filter'|trans,
     } %}

--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/i18n/edit.html.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/i18n/edit.html.twig
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block body %}
-    {% include "@EMSCore/i18n/form.html.twig" with {
+    {% include "@EMSAdminUI/bootstrap5/i18n/form.html.twig" with {
 		form: edit_form,
 		title: 'I18N edit',
 		action: 'Save',

--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/i18n/new.html.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/i18n/new.html.twig
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block body %}
-    {% include "@EMSCore/i18n/form.html.twig" with {
+    {% include "@EMSAdminUI/bootstrap5/i18n/form.html.twig" with {
 		form: form,
 		title: 'I18N create',
 		action: 'Create',

--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/release/add.html.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/release/add.html.twig
@@ -12,7 +12,7 @@
 {% endblock %}
 
 {% block body %}
-    {% include "@EMSCore/release/form.html.twig" with {
+    {% include "@EMSAdminUI/bootstrap5/release/form.html.twig" with {
     	label: 'release.add.title',
     } %}
 {% endblock %}

--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/release/edit.html.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/release/edit.html.twig
@@ -12,7 +12,7 @@
 {% endblock %}
 
 {% block body %}
-    {% include "@EMSCore/release/form.html.twig" with {
+    {% include "@EMSAdminUI/bootstrap5/release/form.html.twig" with {
     	label: 'release.edit.title',
     } %}
 

--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/revision/json/json_menu_nested.html.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/revision/json/json_menu_nested.html.twig
@@ -230,7 +230,7 @@
 
 {% block modalPreview %}
     {%- if dataFields -%}
-        {%- import "@EMSCore/macros/data-field-type.html.twig" as macros -%}
+        {%- import "@EMSAdminUI/bootstrap5/macros/data-field-type.html.twig" as macros -%}
         {{ macros.renderDataField(dataFields, rawData, false, []) }}
     {%- else -%}
         <p class="text-red">{{ 'view.data.json-menu-nested-json-preview.field-type-not-found'|trans }}</p>

--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/view/custom/calendar_view.html.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/view/custom/calendar_view.html.twig
@@ -9,7 +9,7 @@
 
 	<div class="row">
     	<div class="col-md-12">
-            {% include "@EMSCore/elasticsearch/search-form-filter.html.twig" with {
+            {% include "@EMSAdminUI/bootstrap5/elasticsearch/search-form-filter.html.twig" with {
 				form: form,
 			} %}
 		</div>

--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/view/custom/gallery_view.html.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/view/custom/gallery_view.html.twig
@@ -10,7 +10,7 @@
 
 	<div class="row">
     	<div class="col-md-12">
-            {% include "@EMSCore/elasticsearch/search-form-filter.html.twig" with {
+            {% include "@EMSAdminUI/bootstrap5/elasticsearch/search-form-filter.html.twig" with {
 				form: form,
 			} %}
 		</div>

--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/view/custom/hierarchical_add_item.html.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/view/custom/hierarchical_add_item.html.twig
@@ -26,7 +26,7 @@
 	</div>
 	{% if contentType.name == view.contentType.name %}
 		<ol style="display:none;">
-            {% include "@EMSCore/view/custom/hierarchical_item.html.twig" with {
+            {% include "@EMSAdminUI/bootstrap5/view/custom/hierarchical_item.html.twig" with {
         		parent: data,
             	view: view,
         	} %}

--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/view/custom/hierarchical_item.html.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/view/custom/hierarchical_item.html.twig
@@ -6,14 +6,14 @@
     		{% set key = child|split(':') %}
     	    {% set contentType = key[0]|get_content_type %}
 
-            {% include "@EMSCore/view/custom/hierarchical_add_item.html.twig" with {
+            {% include "@EMSAdminUI/bootstrap5/view/custom/hierarchical_add_item.html.twig" with {
         		parent: data,
             	view: view,
             	key: key,
             	contentType: contentType,
             	child: child
-        	} %}  
+        	} %}
         {% endif %}
-    
+
     {% endfor %}
 {% endif %}

--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/view/custom/hierarchical_view.html.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/view/custom/hierarchical_view.html.twig
@@ -16,7 +16,7 @@
                 {{ form_start(form) }}
                     <div class="box-body no-padding">
                         <ol class="nested-sortable vertical" id="root-list" data-nested-max-level="{% if view.options.maxDepth is defined and view.options.maxDepth and view.options.maxDepth >= 1 %}{{ view.options.maxDepth }}{% else %}3{% endif %}" data-nested-is-tree="true">
-                            {% include "@EMSCore/view/custom/hierarchical_item.html.twig" with {
+                            {% include "@EMSAdminUI/bootstrap5/view/custom/hierarchical_item.html.twig" with {
                                 parent: parent._source,
                                 view: view,
                             } %}


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  |  n |
| Fixed tickets? | n  |
| Documentation? | n  |

On the 5.x some admin-ui templates are still referencing "EMSCore"
