### PR TITLE
fix(demo): using session in stateless api calls

### DIFF
--- a/EMS/core-bundle/src/Core/UI/FlashMessageLogger.php
+++ b/EMS/core-bundle/src/Core/UI/FlashMessageLogger.php
@@ -45,6 +45,10 @@ final class FlashMessageLogger extends AbstractProcessingHandler
 
         $message = $this->translator->trans($logArray['message'], $parameters, EMSCoreBundle::TRANS_DOMAIN);
 
+        if (!$currentRequest->hasSession(true)) {
+            return;
+        }
+
         /** @var Session $session */
         $session = $currentRequest->getSession();
         $session->getFlashBag()->add(\strtolower($logArray['level_name']), $message);

--- a/EMS/core-bundle/src/Resources/views/ajax/notification.json.twig
+++ b/EMS/core-bundle/src/Resources/views/ajax/notification.json.twig
@@ -1,14 +1,14 @@
 {
    "acknowledged": true,
-   	{% set notice = app.session.flashbag.get('notice')  %}
+   	{% set notice = app.request.hasSession(true) ? app.session.flashbag.get('notice') : false %}
 	{% if notice %}
 		"notice": {{ notice|json_encode|raw }},
 	{% endif %}
-	{% set warning = app.session.flashbag.get('warning')  %}
+	{% set warning = app.request.hasSession(true) ? app.session.flashbag.get('warning') : false  %}
 	{% if warning %}
 		"warning": {{ warning|json_encode|raw }},
 	{% endif %}
-	{% set error = app.session.flashbag.get('error')  %}
+	{% set error = app.request.hasSession(true) ? app.session.flashbag.get('error') : false  %}
 	{% if error %}
 		"error": {{ error|json_encode|raw }},
 	{% endif %}


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? |  n |
| Documentation? | n  |

The ```ems:admin:restore``` and ```emsch:local:push``` commands are failing because we use the session.
Our api is stateless, so no session.
