### PR TITLE
fix(common/elastica): filter the indexes if a regex is defined

### DIFF
--- a/EMS/common-bundle/src/Common/CoreApi/Endpoint/Search/Search.php
+++ b/EMS/common-bundle/src/Common/CoreApi/Endpoint/Search/Search.php
@@ -75,6 +75,22 @@ class Search implements SearchInterface
     }
 
     /**
+     * @param  string[] $aliases
+     * @return string[]
+     */
+    public function getIndicesFromAliases(array $aliases): array
+    {
+        $indices = $this->client->post('/api/search/indices-from-aliases', [
+            'aliases' => $aliases,
+        ])->getData()['indices'] ?? null;
+        if (!\is_array($indices)) {
+            throw new \RuntimeException('Unexpected: indices must be an array');
+        }
+
+        return $indices;
+    }
+
+    /**
      * @return string[]
      */
     public function getIndicesFromAlias(string $alias): array
@@ -83,7 +99,7 @@ class Search implements SearchInterface
             'alias' => $alias,
         ])->getData()['indices'] ?? null;
         if (!\is_array($indices)) {
-            throw new \RuntimeException('Unexpected: search must be an array');
+            throw new \RuntimeException('Unexpected: indices must be an array');
         }
 
         return $indices;

--- a/EMS/core-bundle/src/Controller/Api/Search/SearchController.php
+++ b/EMS/core-bundle/src/Controller/Api/Search/SearchController.php
@@ -112,6 +112,19 @@ class SearchController
         ]);
     }
 
+    public function getIndicesFromAliases(Request $request): Response
+    {
+        $json = Json::decode((string) $request->getContent());
+        $aliases = $json['aliases'] ?? null;
+        if (!\is_array($aliases)) {
+            throw new \RuntimeException('Unexpected: aliases must be an array of strings');
+        }
+
+        return new JsonResponse([
+            'indices' => $this->elasticaService->getIndicesFromAliases($aliases),
+        ]);
+    }
+
     public function getIndicesForContentTypes(Request $request): Response
     {
         $json = Json::decode((string) $request->getContent());

--- a/EMS/core-bundle/src/Resources/config/routing/api/search.xml
+++ b/EMS/core-bundle/src/Resources/config/routing/api/search.xml
@@ -28,7 +28,7 @@
     <route id="emsco_api_indices_from_alias" path="/indices-from-alias"
            controller="EMS\CoreBundle\Controller\Api\Search\SearchController::getIndicesFromAlias"
            methods="POST"/>
-    <route id="emsco_api_indices_from_alias" path="/indices-from-aliases"
+    <route id="emsco_api_indices_from_aliases" path="/indices-from-aliases"
            controller="EMS\CoreBundle\Controller\Api\Search\SearchController::getIndicesFromAliases"
            methods="POST"/>
     <route id="emsco_api_aliases_from_index" path="/aliases-from-index"

--- a/EMS/core-bundle/src/Resources/config/routing/api/search.xml
+++ b/EMS/core-bundle/src/Resources/config/routing/api/search.xml
@@ -28,6 +28,9 @@
     <route id="emsco_api_indices_from_alias" path="/indices-from-alias"
            controller="EMS\CoreBundle\Controller\Api\Search\SearchController::getIndicesFromAlias"
            methods="POST"/>
+    <route id="emsco_api_indices_from_alias" path="/indices-from-aliases"
+           controller="EMS\CoreBundle\Controller\Api\Search\SearchController::getIndicesFromAliases"
+           methods="POST"/>
     <route id="emsco_api_aliases_from_index" path="/aliases-from-index"
            controller="EMS\CoreBundle\Controller\Api\Search\SearchController::getAliasesFromIndex"
            methods="POST"/>


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? |  n |
| Documentation? |  n |

With a new feature: getIndicesFromAliases (both in ElasticaService and via the API)