### PR TITLE
refactor(core/api): remove json.twig templates for JsonResponse

### DIFF
--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/ajax/images.json.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/ajax/images.json.twig
@@ -1,7 +1,0 @@
-[{% for image in images %}
-	{
-		"image": {{path('ems_file_view', {sha1: image.sha1, name:image.name , type: image.type})|json_encode|raw}},
-		"thumb": {{path('ems_file_view', {sha1: image.sha1, name:image.name , type: image.type})|json_encode|raw}},
-		"folder": {{ image.user|json_encode|raw }}
-	}{% if not loop.last %},{% endif %}{% endfor %}
-]

--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/ajax/multipart.json.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/ajax/multipart.json.twig
@@ -1,5 +1,0 @@
-{
-	"uploaded": {%if asset.available %}1{%else%}0{%endif%},
-	"fileName": {{ asset.name|json_encode|raw }},
-    "url": {{path('ems_file_view', {sha1: asset.sha1, name:asset.name , type: asset.type})|json_encode|raw}}
-}

--- a/EMS/core-bundle/src/Controller/ContentManagement/FileController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/FileController.php
@@ -39,7 +39,6 @@ class FileController extends AbstractController
         private readonly FlashMessageLogger $flashMessageLogger,
         private readonly AssetRuntime $assetRuntime,
         protected array $assetConfig,
-        private readonly string $templateNamespace,
         private readonly string $themeColor,
     ) {
     }

--- a/EMS/core-bundle/src/Controller/ContentManagement/FileController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/FileController.php
@@ -176,10 +176,21 @@ class FileController extends AbstractController
     public function indexImages(): Response
     {
         $images = $this->fileService->getImages();
+        $response = [];
+        foreach ($images as $image) {
+            $url = $this->generateUrl('ems_file_view', [
+                'sha1' => $image->getSha1(),
+                'name' => $image->getName(),
+                'type' => $image->getType(),
+            ]);
+            $response[] = [
+                'image' => $url,
+                'thumb' => $url,
+                'folder' => $image->getUser(),
+            ];
+        }
 
-        return $this->render("@$this->templateNamespace/ajax/images.json.twig", [
-            'images' => $images,
-        ]);
+        return new JsonResponse($response);
     }
 
     public function icon(Request $request, int $width, int $height, string $background = null): Response

--- a/EMS/core-bundle/src/Controller/ContentManagement/FileController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/FileController.php
@@ -262,9 +262,15 @@ class FileController extends AbstractController
                 ]);
             }
 
-            return $this->render("@$this->templateNamespace/ajax/multipart.json.twig", [
+            return new JsonResponse([
                 'success' => true,
-                'asset' => $uploadedAsset,
+                'uploaded' => $uploadedAsset->getUploaded(),
+                'fileName' => $uploadedAsset->getName(),
+                'url' => $this->generateUrl('ems_file_view', [
+                    'sha1' => $uploadedAsset->getSha1(),
+                    'name' => $uploadedAsset->getName(),
+                    'type' => $uploadedAsset->getType(),
+                ]),
             ]);
         } else {
             $this->logger->warning('log.file.upload_error', [

--- a/EMS/core-bundle/src/Resources/config/controllers.xml
+++ b/EMS/core-bundle/src/Resources/config/controllers.xml
@@ -180,7 +180,6 @@
             <argument type="service" id="ems_core.core_ui.flash_message_logger" />
             <argument type="service" id="EMS\CommonBundle\Twig\AssetRuntime" />
             <argument>%ems_core.asset_config%</argument>
-            <argument>%ems_core.template_namespace%</argument>
             <argument>%ems_core.theme_color%</argument>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>

--- a/EMS/core-bundle/src/Resources/views/ajax/images.json.twig
+++ b/EMS/core-bundle/src/Resources/views/ajax/images.json.twig
@@ -1,7 +1,0 @@
-[{% for image in images %}
-	{
-		"image": {{path('ems_file_view', {sha1: image.sha1, name:image.name , type: image.type})|json_encode|raw}},
-		"thumb": {{path('ems_file_view', {sha1: image.sha1, name:image.name , type: image.type})|json_encode|raw}},
-		"folder": {{ image.user|json_encode|raw }}
-	}{% if not loop.last %},{% endif %}{% endfor %}
-]

--- a/EMS/core-bundle/src/Resources/views/ajax/multipart.json.twig
+++ b/EMS/core-bundle/src/Resources/views/ajax/multipart.json.twig
@@ -1,5 +1,0 @@
-{
-	"uploaded": {%if asset.available %}1{%else%}0{%endif%},
-	"fileName": {{ asset.name|json_encode|raw }},
-    "url": {{path('ems_file_view', {sha1: asset.sha1, name:asset.name , type: asset.type})|json_encode|raw}}
-}


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  n |
| New feature?   |  n |
| BC breaks?     |  n |
| Deprecations?  |  y |
| Fixed tickets? |  n |
| Documentation? | n  |

remove some uggly json.twig files
