### PR TITLE
feat(core/field-type): new FieldTypeService for building tree

### DIFF
--- a/EMS/core-bundle/src/Core/ContentType/FieldType/FieldTypeService.php
+++ b/EMS/core-bundle/src/Core/ContentType/FieldType/FieldTypeService.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\Core\ContentType\FieldType;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use EMS\CoreBundle\Entity\ContentType;
+use EMS\CoreBundle\Entity\FieldType;
+use EMS\CoreBundle\Repository\FieldTypeRepository;
+
+class FieldTypeService
+{
+    /** @var ?ArrayCollection<int, FieldType> */
+    private ?ArrayCollection $fieldTypes = null;
+
+    public function __construct(
+        private readonly FieldTypeRepository $fieldTypeRepository
+    ) {
+    }
+
+    public function getTree(ContentType $contentType): FieldTypeTreeItem
+    {
+        return $this->buildTreeItem($contentType->getFieldType());
+    }
+
+    private function buildTreeItem(FieldType $fieldType): FieldTypeTreeItem
+    {
+        $fieldTypeTreeItem = new FieldTypeTreeItem($fieldType);
+
+        foreach ($this->getChildren($fieldType) as $child) {
+            $childTreeItem = $this->buildTreeItem($child)->setParent($fieldTypeTreeItem);
+            $fieldTypeTreeItem->addChild($childTreeItem);
+        }
+
+        $fieldTypeTreeItem->orderChildren();
+
+        return $fieldTypeTreeItem;
+    }
+
+    /**
+     * @return ArrayCollection<int, FieldType>
+     */
+    private function getChildren(FieldType $fieldType): ArrayCollection
+    {
+        return $this->getFieldTypes()->filter(fn (FieldType $f) => $f->getParent()?->getId() === $fieldType->getId());
+    }
+
+    /**
+     * @return ArrayCollection<int, FieldType>
+     */
+    private function getFieldTypes(): ArrayCollection
+    {
+        if (null === $this->fieldTypes) {
+            $fieldTypes = $this->fieldTypeRepository->findAllNotDeleted();
+            $this->fieldTypes = new ArrayCollection($fieldTypes);
+        }
+
+        return $this->fieldTypes;
+    }
+}

--- a/EMS/core-bundle/src/Core/ContentType/FieldType/FieldTypeService.php
+++ b/EMS/core-bundle/src/Core/ContentType/FieldType/FieldTypeService.php
@@ -21,15 +21,15 @@ class FieldTypeService
 
     public function getTree(ContentType $contentType): FieldTypeTreeItem
     {
-        return $this->buildTreeItem($contentType->getFieldType());
+        return $this->createTreeItem($contentType->getFieldType());
     }
 
-    private function buildTreeItem(FieldType $fieldType): FieldTypeTreeItem
+    private function createTreeItem(FieldType $fieldType, FieldTypeTreeItem $parent = null): FieldTypeTreeItem
     {
-        $fieldTypeTreeItem = new FieldTypeTreeItem($fieldType);
+        $fieldTypeTreeItem = new FieldTypeTreeItem($fieldType, $parent);
 
         foreach ($this->getChildren($fieldType) as $child) {
-            $childTreeItem = $this->buildTreeItem($child)->setParent($fieldTypeTreeItem);
+            $childTreeItem = $this->createTreeItem($child, $fieldTypeTreeItem);
             $fieldTypeTreeItem->addChild($childTreeItem);
         }
 

--- a/EMS/core-bundle/src/Core/ContentType/FieldType/FieldTypeService.php
+++ b/EMS/core-bundle/src/Core/ContentType/FieldType/FieldTypeService.php
@@ -21,29 +21,7 @@ class FieldTypeService
 
     public function getTree(ContentType $contentType): FieldTypeTreeItem
     {
-        return $this->createTreeItem($contentType->getFieldType());
-    }
-
-    private function createTreeItem(FieldType $fieldType, FieldTypeTreeItem $parent = null): FieldTypeTreeItem
-    {
-        $fieldTypeTreeItem = new FieldTypeTreeItem($fieldType, $parent);
-
-        foreach ($this->getChildren($fieldType) as $child) {
-            $childTreeItem = $this->createTreeItem($child, $fieldTypeTreeItem);
-            $fieldTypeTreeItem->addChild($childTreeItem);
-        }
-
-        $fieldTypeTreeItem->orderChildren();
-
-        return $fieldTypeTreeItem;
-    }
-
-    /**
-     * @return ArrayCollection<int, FieldType>
-     */
-    private function getChildren(FieldType $fieldType): ArrayCollection
-    {
-        return $this->getFieldTypes()->filter(fn (FieldType $f) => $f->getParent()?->getId() === $fieldType->getId());
+        return new FieldTypeTreeItem($contentType->getFieldType(), $this->getFieldTypes());
     }
 
     /**

--- a/EMS/core-bundle/src/Core/ContentType/FieldType/FieldTypeService.php
+++ b/EMS/core-bundle/src/Core/ContentType/FieldType/FieldTypeService.php
@@ -52,8 +52,7 @@ class FieldTypeService
     private function getFieldTypes(): ArrayCollection
     {
         if (null === $this->fieldTypes) {
-            $fieldTypes = $this->fieldTypeRepository->findAllNotDeleted();
-            $this->fieldTypes = new ArrayCollection($fieldTypes);
+            $this->fieldTypes = new ArrayCollection($this->fieldTypeRepository->findBy(['deleted' => false]));
         }
 
         return $this->fieldTypes;

--- a/EMS/core-bundle/src/Core/ContentType/FieldType/FieldTypeTreeItem.php
+++ b/EMS/core-bundle/src/Core/ContentType/FieldType/FieldTypeTreeItem.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\Core\ContentType\FieldType;
+
+use EMS\CoreBundle\Entity\FieldType;
+
+/**
+ * @implements \IteratorAggregate<FieldTypeTreeItem>
+ */
+class FieldTypeTreeItem implements \IteratorAggregate
+{
+    private FieldTypeTreeItemCollection $children;
+    private string $name;
+    private ?FieldTypeTreeItem $parent = null;
+
+    public function __construct(private readonly FieldType $fieldType)
+    {
+        $this->name = $this->fieldType->getName();
+        $this->children = new FieldTypeTreeItemCollection();
+    }
+
+    public function __toString(): string
+    {
+        return $this->name;
+    }
+
+    public function addChild(FieldTypeTreeItem $child): self
+    {
+        $this->children->set($child->fieldType->getOrderKey(), $child);
+
+        return $this;
+    }
+
+    public function getChildren(): FieldTypeTreeItemCollection
+    {
+        return $this->children;
+    }
+
+    public function getChildrenRecursive(): FieldTypeTreeItemCollection
+    {
+        return new FieldTypeTreeItemCollection($this->toArray());
+    }
+
+    public function getFieldType(): FieldType
+    {
+        return $this->fieldType;
+    }
+
+    /**
+     * @return \Traversable<FieldTypeTreeItem>
+     */
+    public function getIterator(): \Traversable
+    {
+        return new \RecursiveArrayIterator($this->toArray());
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return FieldTypeTreeItem[]
+     */
+    public function getPath(): array
+    {
+        $path = [$this];
+
+        if ($this->parent) {
+            $path = [...$this->parent->getPath(), ...$path];
+        }
+
+        return $path;
+    }
+
+    public function orderChildren(): void
+    {
+        $iterator = $this->children->getIterator();
+        $iterator->ksort();
+
+        $this->children = new FieldTypeTreeItemCollection(\iterator_to_array($iterator));
+    }
+
+    public function setParent(FieldTypeTreeItem $parent): self
+    {
+        $this->parent = $parent;
+
+        return $this;
+    }
+
+    /**
+     * @return FieldTypeTreeItem[]
+     */
+    public function toArray(): array
+    {
+        $data = [$this];
+
+        foreach ($this->children as $child) {
+            $data = [...$data, ...$child->toArray()];
+        }
+
+        return $data;
+    }
+}

--- a/EMS/core-bundle/src/Core/ContentType/FieldType/FieldTypeTreeItem.php
+++ b/EMS/core-bundle/src/Core/ContentType/FieldType/FieldTypeTreeItem.php
@@ -13,10 +13,11 @@ class FieldTypeTreeItem implements \IteratorAggregate
 {
     private FieldTypeTreeItemCollection $children;
     private string $name;
-    private ?FieldTypeTreeItem $parent = null;
 
-    public function __construct(private readonly FieldType $fieldType)
-    {
+    public function __construct(
+        private readonly FieldType $fieldType,
+        private readonly ?FieldTypeTreeItem $parent = null
+    ) {
         $this->name = $this->fieldType->getName();
         $this->children = new FieldTypeTreeItemCollection();
     }
@@ -81,13 +82,6 @@ class FieldTypeTreeItem implements \IteratorAggregate
         $iterator->ksort();
 
         $this->children = new FieldTypeTreeItemCollection(\iterator_to_array($iterator));
-    }
-
-    public function setParent(FieldTypeTreeItem $parent): self
-    {
-        $this->parent = $parent;
-
-        return $this;
     }
 
     /**

--- a/EMS/core-bundle/src/Core/ContentType/FieldType/FieldTypeTreeItemCollection.php
+++ b/EMS/core-bundle/src/Core/ContentType/FieldType/FieldTypeTreeItemCollection.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\Core\ContentType\FieldType;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * @extends ArrayCollection<int, FieldTypeTreeItem>
+ *
+ * @method \ArrayIterator<int, FieldTypeTreeItem> getIterator()
+ */
+class FieldTypeTreeItemCollection extends ArrayCollection
+{
+}

--- a/EMS/core-bundle/src/Repository/FieldTypeRepository.php
+++ b/EMS/core-bundle/src/Repository/FieldTypeRepository.php
@@ -18,6 +18,14 @@ class FieldTypeRepository extends ServiceEntityRepository
         parent::__construct($registry, FieldType::class);
     }
 
+    /**
+     * @return FieldType[]
+     */
+    public function findAllNotDeleted(): array
+    {
+        return $this->findBy(['deleted' => false]);
+    }
+
     public function save(FieldType $field): void
     {
         $this->_em->persist($field);

--- a/EMS/core-bundle/src/Repository/FieldTypeRepository.php
+++ b/EMS/core-bundle/src/Repository/FieldTypeRepository.php
@@ -18,14 +18,6 @@ class FieldTypeRepository extends ServiceEntityRepository
         parent::__construct($registry, FieldType::class);
     }
 
-    /**
-     * @return FieldType[]
-     */
-    public function findAllNotDeleted(): array
-    {
-        return $this->findBy(['deleted' => false]);
-    }
-
     public function save(FieldType $field): void
     {
         $this->_em->persist($field);

--- a/EMS/core-bundle/src/Resources/config/services.xml
+++ b/EMS/core-bundle/src/Resources/config/services.xml
@@ -79,6 +79,9 @@
             <argument type="service" id="ems.service.contenttype"/>
             <argument type="service" id="ems.content_type.view_types" />
         </service>
+        <service id="emsco.core.content_type.field_type.service" class="EMS\CoreBundle\Core\ContentType\FieldType\FieldTypeService">
+            <argument type="service" id="ems.repository.field_type" />
+        </service>
         <service id="ems_core.core_content_type_transformer.content_transformer" class="EMS\CoreBundle\Core\ContentType\Transformer\ContentTransformer">
             <argument type="service" id="ems_core.core_content_type_transformer.content_transformers"/>
             <argument type="service" id="ems.service.data"/>


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | n  |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  |  n |
| Fixed tickets? |  n |
| Documentation? | n  |

Add a new FieldTypeService for building a tree structure. This will be used in https://github.com/ems-project/elasticms/pull/780

Future music: 
- we should use this service on more places (generating mapping, edit structure, ..)
- currently the service fetchs all fields with one query. We could cache the result, until the table get modified ...

Example: 
- build a tree for a contentType
- give all fields that have a minimum_role defined

```php
<?php

namespace EMS\CoreBundle\Controller;

use EMS\CoreBundle\Core\ContentType\FieldType\FieldTypeService;
use EMS\CoreBundle\Core\ContentType\FieldType\FieldTypeTreeItem;
use EMS\CoreBundle\Service\ContentTypeService;
use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
use Symfony\Component\HttpFoundation\Response;

class ExampleController extends AbstractController
{
    public function __construct(
        private readonly ContentTypeService $contentTypeService,
        private readonly FieldTypeService $fieldTypeService,
    ) {
    }

    public function example(): Response
    {
        $pageContentType = $this->contentTypeService->giveByName('page');
        $tree = $this->fieldTypeService->getTree($pageContentType);

        $fieldTypesWithMinimumRole = $tree->getChildrenRecursive()->filter(function (FieldTypeTreeItem $item) {
            return $item->getFieldType()->getRestrictionOption('minimum_role', false);
        });

        return $this->render("@$this->templateNamespace/example.html.twig", [
            'tree' => $tree,
            'children' => $fieldTypesWithMinimumRole,
        ]);
    }
}
```
Add in twig we could do: 

```twig
     <ul>
          {% for item in tree%}
              <li>{{ item.path|map(i => i.fieldType.name)|join(' > ') }}</li>
          {% endfor %}
    </ul>
```

