### PR TITLE
fix(core/flash-messages): obvious duplicate alerts

### DIFF
--- a/EMS/core-bundle/src/Core/UI/FlashMessageLogger.php
+++ b/EMS/core-bundle/src/Core/UI/FlashMessageLogger.php
@@ -49,7 +49,11 @@ final class FlashMessageLogger extends AbstractProcessingHandler
 
         /** @var Session $session */
         $session = $currentRequest->getSession();
-        $session->getFlashBag()->add(\strtolower($record->level->getName()), $message);
+        $level = \strtolower($record->level->getName());
+        if (\in_array($message, $session->getFlashBag()->peek($level))) {
+            return;
+        }
+        $session->getFlashBag()->add($level, $message);
     }
 
     /**


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? |  n |
| Documentation? | n  |

e.g. if the style set's assets archive is missing we'll have one error alert per WYSIWYG fields