### PR TITLE
fix(emsch/api): refresh through core api

### DIFF
--- a/EMS/client-helper-bundle/src/Helper/Local/LocalHelper.php
+++ b/EMS/client-helper-bundle/src/Helper/Local/LocalHelper.php
@@ -96,7 +96,12 @@ final class LocalHelper
     {
         if ($refresh) {
             if ('green' === $this->clientRequest->healthStatus()) {
-                $this->clientRequest->refresh();
+                $api = $this->api($environment);
+                if (\version_compare($api->admin()->getCoreVersion(), '5.11.0') <= 0) {
+                    $this->clientRequest->refresh();
+                } else {
+                    $this->api($environment)->search()->refresh();
+                }
             }
             $this->contentTypeHelper->clear();
         }

--- a/EMS/common-bundle/src/Service/ElasticaService.php
+++ b/EMS/common-bundle/src/Service/ElasticaService.php
@@ -50,9 +50,16 @@ class ElasticaService
         if ($this->useAdminProxy) {
             return $this->adminHelper->getCoreApi()->getBaseUrl();
         }
-        $url = $this->client->getConnection()->getConfig('url');
 
-        return \is_array($url) ? \implode(' | ', $url) : Type::string($url);
+        $connection = $this->client->getConnection();
+
+        if ($connection->hasConfig('url')) {
+            $url = $connection->getConfig('url');
+
+            return \is_array($url) ? \implode(' | ', $url) : Type::string($url);
+        }
+
+        return $connection->getHost();
     }
 
     public function refresh(?string $index): bool


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? |  n |
| Documentation? | n  |

With using a new cluster, we could not call the refresh from local.
Is better to use the api, which is allowed to do the refresh

In the feature locally everything should go on api
