### PR TITLE
fix(core/user): throw expired exception inside providers

### DIFF
--- a/EMS/core-bundle/src/Entity/UserInterface.php
+++ b/EMS/core-bundle/src/Entity/UserInterface.php
@@ -59,6 +59,8 @@ interface UserInterface extends \Symfony\Component\Security\Core\User\UserInterf
 
     public function hasRole(string $role): bool;
 
+    public function isExpired(): bool;
+
     /**
      * @return array{
      *     id: int|string,

--- a/EMS/core-bundle/src/EventListener/LoginListener.php
+++ b/EMS/core-bundle/src/EventListener/LoginListener.php
@@ -7,7 +7,6 @@ namespace EMS\CoreBundle\EventListener;
 use EMS\CoreBundle\Core\User\UserManager;
 use EMS\CoreBundle\Entity\User;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 use Symfony\Component\Security\Http\SecurityEvents;
 
@@ -31,15 +30,9 @@ final class LoginListener implements EventSubscriberInterface
     {
         $user = $event->getAuthenticationToken()->getUser();
 
-        if (!$user instanceof User) {
-            return;
+        if ($user instanceof User) {
+            $user->setLastLogin(new \DateTime());
+            $this->userManager->update($user);
         }
-
-        if ($user->isExpired()) {
-            throw new AccessDeniedException('Access Denied: Your account has expired.');
-        }
-
-        $user->setLastLogin(new \DateTime());
-        $this->userManager->update($user);
     }
 }

--- a/EMS/core-bundle/src/Security/Provider/UserApiProvider.php
+++ b/EMS/core-bundle/src/Security/Provider/UserApiProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace EMS\CoreBundle\Security\Provider;
 
 use EMS\CoreBundle\Repository\AuthTokenRepository;
+use Symfony\Component\Security\Core\Exception\AccountExpiredException;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -23,6 +24,10 @@ class UserApiProvider implements UserProviderInterface
 
         if (null === $user) {
             throw new UserNotFoundException($identifier);
+        }
+
+        if ($user->isExpired()) {
+            throw new AccountExpiredException(\sprintf('The account "%s" is expired', $user->getUserIdentifier()));
         }
 
         return $user;

--- a/EMS/core-bundle/src/Security/Provider/UserProvider.php
+++ b/EMS/core-bundle/src/Security/Provider/UserProvider.php
@@ -6,6 +6,7 @@ namespace EMS\CoreBundle\Security\Provider;
 
 use EMS\CoreBundle\Entity\User;
 use EMS\CoreBundle\Repository\UserRepository;
+use Symfony\Component\Security\Core\Exception\AccountExpiredException;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -45,6 +46,10 @@ class UserProvider implements UserProviderInterface
     {
         if (null === $user = $this->userRepository->findUserByUsernameOrEmail($usernameOrEmail)) {
             throw new UserNotFoundException(\sprintf('Username "%s" does not exists.', $usernameOrEmail));
+        }
+
+        if ($user->isExpired()) {
+            throw new AccountExpiredException(\sprintf('The account "%s" is expired', $user->getUserIdentifier()));
         }
 
         return $user;


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   |  n |
| BC breaks?     |  n |
| Deprecations?  |  n |
| Fixed tickets? |  n |
| Documentation? | n  |

They LoginListener.php was not a good place, better throw exceptions inside the providers. The result on the frontend is just saying "Bad credentials", it is security check from symfony to hide exceptions.
