### PR TITLE
fix(core/tasks): emsco:revision:task:create skip revisions with drafts

### DIFF
--- a/EMS/core-bundle/src/Command/Revision/Task/TaskCreateCommand.php
+++ b/EMS/core-bundle/src/Command/Revision/Task/TaskCreateCommand.php
@@ -130,7 +130,9 @@ final class TaskCreateCommand extends AbstractCommand
             return;
         }
 
-        if ($revision->getDraft() || $revision->hasTasks(false)) {
+        if ($revision->hasEndTime()
+            || null !== $revision->getVersionDate('to')
+            || $revision->hasTasks(false)) {
             return;
         }
 

--- a/EMS/core-bundle/src/Command/Revision/Task/TaskCreateCommand.php
+++ b/EMS/core-bundle/src/Command/Revision/Task/TaskCreateCommand.php
@@ -130,7 +130,7 @@ final class TaskCreateCommand extends AbstractCommand
             return;
         }
 
-        if ($revision->hasTasks(false)) {
+        if ($revision->getDraft() || $revision->hasTasks(false)) {
             return;
         }
 

--- a/EMS/core-bundle/src/Entity/Revision.php
+++ b/EMS/core-bundle/src/Entity/Revision.php
@@ -474,6 +474,11 @@ class Revision implements EntityInterface, \Stringable
         return $this;
     }
 
+    public function isDraft(): bool
+    {
+        return $this->draft;
+    }
+
     public function getDraft(): bool
     {
         return $this->draft;

--- a/EMS/core-bundle/src/Entity/Revision.php
+++ b/EMS/core-bundle/src/Entity/Revision.php
@@ -474,11 +474,6 @@ class Revision implements EntityInterface, \Stringable
         return $this;
     }
 
-    public function isDraft(): bool
-    {
-        return $this->draft;
-    }
-
     public function getDraft(): bool
     {
         return $this->draft;

--- a/docs/elasticms-admin/commands/commands.md
+++ b/docs/elasticms-admin/commands/commands.md
@@ -261,14 +261,13 @@ Usage:
   emsco:revision:task:create [options] [--] <environment>
 
 Arguments:
-  environment
+  environment                          
 
 Options:
       --task=TASK                      {\"title\":\"title\",\"assignee\":\"username\",\"description\":\"optional\"}
-      --field-owner=FIELD-OWNER        owner field in es document
       --field-assignee=FIELD-ASSIGNEE  assignee field in es document
+      --requester=REQUESTER            requester
       --field-deadline=FIELD-DEADLINE  deadline field in es document
-      --default-owner=DEFAULT-OWNER    default owner username
       --not-published=NOT-PUBLISHED    only for revisions not published in this environment
       --scroll-size=SCROLL-SIZE        Size of the elasticsearch scroll request
       --scroll-timeout=SCROLL-TIMEOUT  Time to migrate "scrollSize" items i.e. 30s or 2m


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   |  n |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | y  |

When we create tasks from the command, we should skip revision that are in draft. We can not automatically create tasks for draft revisions.

The commands searches for documents and get the revision (environment_revision). It will check if it's published in live or not. 

We know that the revision has a draft, if the end time is not null. We can only create tasks for the current revision, meaning the revision with end time set too null.
