### PR TITLE
fix(core/twig): emsco_revisions_draft broken accessing revision as array

### DIFF
--- a/EMS/core-bundle/src/Repository/RevisionRepository.php
+++ b/EMS/core-bundle/src/Repository/RevisionRepository.php
@@ -252,9 +252,7 @@ class RevisionRepository extends EntityRepository
             ->andWhere($qb->expr()->eq('c.name', ':content_type_name'))
             ->setParameter('content_type_name', $contentTypeName);
 
-        foreach ($qb->getQuery()->toIterable() as $row) {
-            yield $row[0];
-        }
+        yield from $qb->getQuery()->toIterable();
     }
 
     /**


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  |  n |
| Fixed tickets? | n  |
| Documentation? | n  |

Using emsco_revisions_draft causes the following error: "Cannot use object of type EMS\CoreBundle\Entity\Revision as array"

This was broken inside: https://github.com/ems-project/elasticms/pull/620/files#diff-eee4ec5a690df9c4229d05b481fcf31c7be6201b6cd17080c60f9870028e07b6R270
