### PR TITLE
fix(core/channel): entry path not defined should return null

### DIFF
--- a/EMS/core-bundle/src/Entity/Channel.php
+++ b/EMS/core-bundle/src/Entity/Channel.php
@@ -168,9 +168,9 @@ class Channel extends JsonDeserializer implements \JsonSerializable, EntityInter
 
     public function getEntryPath(): ?string
     {
-        $entryPath = $this->getOptions()['entryPath'];
+        $entryPath = $this->getOptions()['entryPath'] ?? null;
 
-        if (!\is_string($entryPath) || 0 === \strlen($entryPath)) {
+        if (!\is_string($entryPath) || '' === $entryPath) {
             return null;
         }
         if (!\str_starts_with($entryPath, '/')) {


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Not defining an entry path should return null on the channel getEntryPath method.
