### PR TITLE
fix(core/xliff): reply-to option for emsco:xliff:extract command

### DIFF
--- a/EMS/core-bundle/src/Command/Xliff/ExtractCommand.php
+++ b/EMS/core-bundle/src/Command/Xliff/ExtractCommand.php
@@ -56,6 +56,7 @@ final class ExtractCommand extends AbstractCommand
     public const OPTION_MAIL_SUBJECT = 'mail-subject';
     public const OPTION_MAIL_TO = 'mail-to';
     public const OPTION_MAIL_CC = 'mail-cc';
+    public const OPTION_MAIL_REPLY_TO = 'mail-reply-to';
     private const MAIL_TEMPLATE = '@EMSCore/email/xliff/extract.email.html.twig';
 
     protected static $defaultName = Commands::XLIFF_EXTRACT;
@@ -69,6 +70,7 @@ final class ExtractCommand extends AbstractCommand
     private string $mailSubject;
     private ?string $mailTo;
     private ?string $mailCC;
+    private ?string $mailReplyTo;
 
     public function __construct(
         private readonly ContentTypeService $contentTypeService,
@@ -101,7 +103,9 @@ final class ExtractCommand extends AbstractCommand
             ->addOption(self::OPTION_WITH_BASELINE, null, InputOption::VALUE_NONE, 'The baseline has been checked and can be used to flag field as final')
             ->addOption(self::OPTION_MAIL_SUBJECT, null, InputOption::VALUE_OPTIONAL, 'Mail subject', 'A new XLIFF has been generated')
             ->addOption(self::OPTION_MAIL_TO, null, InputOption::VALUE_OPTIONAL, 'A comma seperated list of emails where to send the XLIFF')
-            ->addOption(self::OPTION_MAIL_CC, null, InputOption::VALUE_OPTIONAL, 'A comma seperated list of emails where to send, in carbon copy, the XLIFF');
+            ->addOption(self::OPTION_MAIL_CC, null, InputOption::VALUE_OPTIONAL, 'A comma seperated list of emails where to send, in carbon copy, the XLIFF')
+            ->addOption(self::OPTION_MAIL_REPLY_TO, null, InputOption::VALUE_OPTIONAL, 'A comma seperated list of emails where to send, in carbon copy, the XLIFF')
+        ;
     }
 
     protected function initialize(InputInterface $input, OutputInterface $output): void
@@ -128,6 +132,7 @@ final class ExtractCommand extends AbstractCommand
         $this->mailSubject = $this->getOptionString(self::OPTION_MAIL_SUBJECT);
         $this->mailTo = $this->getOptionStringNull(self::OPTION_MAIL_TO);
         $this->mailCC = $this->getOptionStringNull(self::OPTION_MAIL_CC);
+        $this->mailReplyTo = $this->getOptionStringNull(self::OPTION_MAIL_REPLY_TO);
 
         if (null === $this->translationField && $this->translationField !== $this->localeField) {
             throw new \RuntimeException(\sprintf('Both %s and %s options must be defined or not defined at all (fields defined with %%locale%% placeholder)', self::OPTION_TRANSLATION_FIELD, self::OPTION_LOCALE_FIELD));
@@ -208,6 +213,12 @@ final class ExtractCommand extends AbstractCommand
             $split = \explode(',', $this->mailCC);
             foreach ($split as $email) {
                 $mailTemplate->addCc($email);
+            }
+        }
+        if (null !== $this->mailReplyTo) {
+            $split = \explode(',', $this->mailReplyTo);
+            foreach ($split as $email) {
+                $mailTemplate->addReplyTo($email);
             }
         }
         $mailTemplate->setBodyBlock('xliff_extracted', [

--- a/EMS/core-bundle/src/Command/Xliff/ExtractCommand.php
+++ b/EMS/core-bundle/src/Command/Xliff/ExtractCommand.php
@@ -104,7 +104,7 @@ final class ExtractCommand extends AbstractCommand
             ->addOption(self::OPTION_MAIL_SUBJECT, null, InputOption::VALUE_OPTIONAL, 'Mail subject', 'A new XLIFF has been generated')
             ->addOption(self::OPTION_MAIL_TO, null, InputOption::VALUE_OPTIONAL, 'A comma seperated list of emails where to send the XLIFF')
             ->addOption(self::OPTION_MAIL_CC, null, InputOption::VALUE_OPTIONAL, 'A comma seperated list of emails where to send, in carbon copy, the XLIFF')
-            ->addOption(self::OPTION_MAIL_REPLY_TO, null, InputOption::VALUE_OPTIONAL, 'A comma seperated list of emails where to send, in carbon copy, the XLIFF')
+            ->addOption(self::OPTION_MAIL_REPLY_TO, null, InputOption::VALUE_OPTIONAL, 'A comma seperated list of emails where to reply')
         ;
     }
 

--- a/EMS/core-bundle/src/Core/Mail/MailTemplate.php
+++ b/EMS/core-bundle/src/Core/Mail/MailTemplate.php
@@ -21,7 +21,8 @@ final class MailTemplate
     private array $bcc = [];
     /** @var string[] */
     private array $attachments = [];
-    private ?string $replyTo = null;
+    /** @var array<mixed> */
+    private array $replyTo = [];
 
     public function __construct(private readonly TemplateWrapper $template, private readonly TranslatorInterface $translator, private readonly string $senderName)
     {
@@ -165,23 +166,21 @@ final class MailTemplate
         return $this->attachments;
     }
 
-    public function hasReplyTo(): bool
+    /**
+     * @return string[]
+     */
+    public function getReplyTo(): array
     {
-        return null !== $this->replyTo;
-    }
-
-    public function getReplyTo(): string
-    {
-        if (null === $this->replyTo) {
-            throw new \RuntimeException('Test if the reply to is defined first with the method MailTemplate::hasReplyTo');
-        }
-
         return $this->replyTo;
     }
 
-    public function setReplyTo(string $replyTo): self
+    public function addReplyTo(string $email, string $name = null): self
     {
-        $this->replyTo = $replyTo;
+        if ($name) {
+            $this->replyTo[$email] = $name;
+        } else {
+            $this->replyTo[] = $email;
+        }
 
         return $this;
     }

--- a/EMS/core-bundle/src/Core/Mail/MailerService.php
+++ b/EMS/core-bundle/src/Core/Mail/MailerService.php
@@ -70,8 +70,8 @@ class MailerService
         if (\count($template->getBCC()) > 0) {
             $email->bcc(...$template->getBCC());
         }
-        if ($template->hasReplyTo()) {
-            $email->replyTo($template->getReplyTo());
+        if (\count($template->getReplyTo()) > 0) {
+            $email->replyTo(...$template->getReplyTo());
         }
         foreach ($template->getAttachments() as $file) {
             $email->attachFromPath($file);

--- a/docs/elasticms-admin/commands/commands.md
+++ b/docs/elasticms-admin/commands/commands.md
@@ -458,7 +458,7 @@ Arguments:
   search-query                                   Query used to find elasticsearch records to extract from the source environment
   source-locale                                  Source locale
   target-locale                                  Target locale
-  fields                                         List of content type\s fields to extract. Use the pattern %locale% if required
+  fields                                         List of content type\s fields to extract. Use the pattern %locale% if required. Use the `.` to separate nested fields from their parent. Use `json:` `id_key:` and/or `base64;` to decode a field. You can also use `*` as wild char and `|` to list children fields  E.g. `%locale%.json:id_key:content.object.title|content` or `[%locale%][json:id_key:content][object][title|content]`
 
 Options:
       --bulk-size=BULK-SIZE                      Size of the elasticsearch scroll request [default: 500]
@@ -466,10 +466,14 @@ Options:
       --xliff-version[=XLIFF-VERSION]            XLIFF format version: 1.2 2.0 [default: "1.2"]
       --filename[=FILENAME]                      Generate the XLIFF specified file
       --base-url[=BASE-URL]                      Base url, in order to generate a download link to the XLIFF file
-      --locale-field[=LOCALE-FIELD]              Field containing the locale [default: "locale"]
+      --locale-field[=LOCALE-FIELD]              Field containing the locale
       --encoding[=ENCODING]                      Encoding used to generate the XLIFF file [default: "UTF-8"]
-      --translation-field[=TRANSLATION-FIELD]    Field containing the translation field [default: "translation_id"]
-      --encode-html                              HTML fields will be encoded in simple fields
+      --translation-field[=TRANSLATION-FIELD]    Field containing the translation field
+      --with-baseline                            The baseline has been checked and can be used to flag field as final
+      --mail-subject[=MAIL-SUBJECT]              Mail subject [default: "A new XLIFF has been generated"]
+      --mail-to[=MAIL-TO]                        A comma seperated list of emails where to send the XLIFF
+      --mail-cc[=MAIL-CC]                        A comma seperated list of emails where to send, in carbon copy, the XLIFF
+      --mail-reply-to[=MAIL-REPLY-TO]            A comma seperated list of emails where to reply
 ```
 
 #### XLIFF update


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   |  n |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | y  |

Add a new `reply-to` option for the `emsco:xliff:extract` command.
Also updated documentation of the command
