### PR TITLE
fix(core/task): doctrine listener only on current revisions

### DIFF
--- a/EMS/core-bundle/src/EventListener/RevisionDoctrineListener.php
+++ b/EMS/core-bundle/src/EventListener/RevisionDoctrineListener.php
@@ -15,14 +15,14 @@ class RevisionDoctrineListener
 
     public function preRemoveRevision(Revision $revision): void
     {
-        if (!$revision->isDraft()) {
+        if (!$revision->isDraft() && $revision->isCurrent()) {
             $revision->tasksClear();
         }
     }
 
     public function postRemoveRevision(Revision $revision): void
     {
-        if (!$revision->isDraft()) {
+        if (!$revision->isDraft() && $revision->isCurrent()) {
             $this->taskManager->tasksDeleteByRevision($revision);
         }
     }


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

We can trigger 'delete all revisions', from an old (not current revision).
On empty trash the task delete is called before deleting the current revision. 
The listener should only clear tasks for the current revision, tasks are only attached to the current revision.
