### PR TITLE
fix(core/release): revision ouuid does not exist anymore

### DIFF
--- a/EMS/core-bundle/src/Resources/views/release/columns/release-revisions.html.twig
+++ b/EMS/core-bundle/src/Resources/views/release/columns/release-revisions.html.twig
@@ -10,8 +10,10 @@
 
         {% if revisionTarget %}
             {{ revisionTarget|emsco_display }}
-        {% else %}
+        {% elseif revisionSource %}
             {{ 'release.release-revisison.missing-revision'|trans({'%label%': revisionSource|emsco_display, '%environment%': data.release.environmentTarget.name}) }}
+        {% else %}
+            {{ 'release.release-revisison.revision-not-applicable'|trans }}
         {% endif %}
     {% endif %}
 {% endblock label %}


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   |  n |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Reproduce:
- When we delete a revision, that is attached to a release for unpublish, we do not remove the revision from the release.
- When you then access the release, you face a 500 error

This is because the release revision link is by ouuid, we will fix this better in 5.15.0
