### PR TITLE
fix(form/choice): choice labels not defined and no cache with debug controller

### DIFF
--- a/EMS/form-bundle/src/Components/Form.php
+++ b/EMS/form-bundle/src/Components/Form.php
@@ -59,8 +59,12 @@ class Form extends AbstractType
 
         $resolver
             ->setRequired(['ouuid', 'locale'])
-            ->setDefault('config', null)
-            ->setNormalizer('config', fn (Options $options, $value) => $value ?: $this->configFactory->create($options['ouuid'], $options['locale']))
+            ->setDefaults(['config' => null, 'use_cache' => true])
+            ->setNormalizer('config', fn (Options $options, $value) => $value ?: $this->configFactory->create(
+                ouuid: $options['ouuid'],
+                locale: $options['locale'],
+                useCache: $options['use_cache']
+            ))
             ->setNormalizer('attr', function (Options $options, $value) {
                 if (!isset($options['config'])) {
                     return $value;

--- a/EMS/form-bundle/src/Controller/AbstractFormController.php
+++ b/EMS/form-bundle/src/Controller/AbstractFormController.php
@@ -23,16 +23,4 @@ abstract class AbstractFormController
 
         return $config;
     }
-
-    /** @return string[] */
-    protected function getFormOptions(string $ouuid, string $locale): array
-    {
-        return ['ouuid' => $ouuid, 'locale' => $locale];
-    }
-
-    /** @return mixed[] */
-    protected function getDisabledValidationsFormOptions(string $ouuid, string $locale): array
-    {
-        return \array_merge($this->getFormOptions($ouuid, $locale), ['validation_groups' => false]);
-    }
 }

--- a/EMS/form-bundle/src/Controller/DebugController.php
+++ b/EMS/form-bundle/src/Controller/DebugController.php
@@ -30,6 +30,7 @@ class DebugController extends AbstractFormController
         $form = $this->formFactory->create(Form::class, [], [
             'ouuid' => $ouuid,
             'locale' => $request->getLocale(),
+            'use_cache' => false,
         ]);
 
         return new Response($this->twig->render('@EMSForm/debug/iframe.html.twig', [
@@ -44,6 +45,7 @@ class DebugController extends AbstractFormController
         $formOptions = [
             'ouuid' => $ouuid,
             'locale' => $request->getLocale(),
+            'use_cache' => false,
         ];
 
         if (!$request->query->getBoolean('validate', true)) {

--- a/EMS/form-bundle/src/Controller/DebugController.php
+++ b/EMS/form-bundle/src/Controller/DebugController.php
@@ -27,7 +27,10 @@ class DebugController extends AbstractFormController
 
     public function iframe(Request $request, string $ouuid): Response
     {
-        $form = $this->formFactory->create(Form::class, [], $this->getFormOptions($ouuid, $request->getLocale()));
+        $form = $this->formFactory->create(Form::class, [], [
+            'ouuid' => $ouuid,
+            'locale' => $request->getLocale(),
+        ]);
 
         return new Response($this->twig->render('@EMSForm/debug/iframe.html.twig', [
             'config' => $this->getFormConfig($form, $request),
@@ -38,7 +41,10 @@ class DebugController extends AbstractFormController
 
     public function form(Request $request, string $ouuid): Response
     {
-        $formOptions = $this->getFormOptions($ouuid, $request->getLocale());
+        $formOptions = [
+            'ouuid' => $ouuid,
+            'locale' => $request->getLocale(),
+        ];
 
         if (!$request->query->getBoolean('validate', true)) {
             $formOptions['attr'] = ['novalidate' => 'novalidate'];

--- a/EMS/form-bundle/src/Controller/FormController.php
+++ b/EMS/form-bundle/src/Controller/FormController.php
@@ -68,7 +68,11 @@ class FormController extends AbstractFormController
 
     public function dynamicFieldAjax(Request $request, string $ouuid): Response
     {
-        $form = $this->formFactory->create(Form::class, [], $this->getDisabledValidationsFormOptions($ouuid, $request->getLocale()));
+        $form = $this->formFactory->create(Form::class, [], [
+            'ouuid' => $ouuid,
+            'locale' => $request->getLocale(),
+            'validation_groups' => false,
+        ]);
         $form->handleRequest($request);
 
         $dynamicFields = new SymfonyFormFieldsByNameArray($request->request->all());

--- a/EMS/form-bundle/src/FormConfig/FormConfigFactory.php
+++ b/EMS/form-bundle/src/FormConfig/FormConfigFactory.php
@@ -435,22 +435,34 @@ class FormConfigFactory
 
     private function addFieldChoicesFromJson(FieldConfig $fieldConfig, JsonMenuNested $document, string $locale): void
     {
-        $values = [];
-        $labels = [];
-        $sort = null;
-        $id = null;
-        foreach ($document->getChildren() as $child) {
-            if ($child->getType() !== $this->emsConfig[Configuration::TYPE_FORM_CHOICE]) {
-                continue;
-            }
+        $children = $document->getChildren();
+        $choiceType = $this->emsConfig[Configuration::TYPE_FORM_CHOICE];
+        $choiceChildren = \array_filter($children, static fn (JsonMenuNested $c) => $c->getType() === $choiceType);
+
+        if (0 === \count($choiceChildren)) {
+            return;
+        }
+
+        $values = $labels = [];
+        $id = $sort = null;
+
+        foreach ($choiceChildren as $child) {
             try {
                 $id = $child->getId();
-                $values = \array_merge($values, Json::decode($child->getObject()['values']));
-                $labels = \array_merge($labels, Json::decode($child->getObject()[$locale]['labels']));
-                if (isset($child->getObject()['choice_sort'])) {
-                    $sort = $child->getObject()['choice_sort'];
+                $object = $child->getObject();
+
+                $childValues = $object['values'] ?? null;
+                $childLabels = $object[$locale]['labels'] ?? $childValues;
+
+                if (null === $childValues) {
+                    continue;
                 }
-            } catch (\Exception $e) {
+
+                $values = [...$values, ...Json::decode($childValues)];
+                $labels = [...$labels, ...Json::decode($childLabels)];
+
+                $sort ??= $object['choice_sort'] ?? null;
+            } catch (\Throwable $e) {
                 $this->logger->error($e->getMessage(), [$e]);
             }
         }

--- a/EMS/form-bundle/src/FormConfig/FormConfigFactory.php
+++ b/EMS/form-bundle/src/FormConfig/FormConfigFactory.php
@@ -35,13 +35,13 @@ class FormConfigFactory
         $this->emsConfig = $emsConfig;
     }
 
-    public function create(string $ouuid, string $locale): FormConfig
+    public function create(string $ouuid, string $locale, bool $useCache = true): FormConfig
     {
         $validityTags = $this->getValidityTags();
         $cacheKey = $this->client->getCacheKey(\sprintf('formconfig_%s_%s_', $ouuid, $locale));
         $cacheItem = $this->cache->getItem($cacheKey);
 
-        if ($this->emsConfig[Configuration::CACHEABLE] && $cacheItem->isHit()) {
+        if ($this->emsConfig[Configuration::CACHEABLE] && $useCache && $cacheItem->isHit()) {
             $data = $cacheItem->get();
 
             $cacheValidityTags = $data['validity_tags'] ?? null;


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   |  n |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? |  n |
| Documentation? | n  |

- [x] If choice labels are not defined, just use the values, currently this throws an error because json decoding a null value.
- [x] Do not use cache when viewing the form with the debugController

