### PR TITLE
fix(core/environment): set order on create environment

### DIFF
--- a/EMS/core-bundle/src/Controller/ContentManagement/EnvironmentController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/EnvironmentController.php
@@ -438,7 +438,7 @@ class EnvironmentController extends AbstractController
                     $environment->setAlias($this->instanceId.$environment->getName());
                     $environment->setManaged(true);
 
-                    $this->environmentRepository->save($environment);
+                    $this->environmentRepository->create($environment);
 
                     $indexName = $environment->getNewIndexName();
                     $this->mapping->createIndex($indexName, $this->environmentService->getIndexAnalysisConfiguration());

--- a/EMS/core-bundle/src/Entity/Environment.php
+++ b/EMS/core-bundle/src/Entity/Environment.php
@@ -454,18 +454,17 @@ class Environment extends JsonDeserializer implements \JsonSerializable, EntityI
         return $this->contentTypesHavingThisAsDefault;
     }
 
-    /**
-     * Set orderKey.
-     */
     public function setOrderKey(int $orderKey): void
     {
         $this->orderKey = $orderKey;
     }
 
-    /**
-     * Get orderKey.
-     */
-    public function getOrderKey(): int
+    public function hasOrderKey(): bool
+    {
+        return null !== $this->orderKey;
+    }
+
+    public function getOrderKey(): ?int
     {
         return $this->orderKey;
     }

--- a/EMS/core-bundle/src/Repository/EnvironmentRepository.php
+++ b/EMS/core-bundle/src/Repository/EnvironmentRepository.php
@@ -206,6 +206,10 @@ class EnvironmentRepository extends EntityRepository
 
     public function create(Environment $environment): void
     {
+        if (!$environment->hasOrderKey() && $environment->getManaged()) {
+            $environment->setOrderKey($this->counter() + 1);
+        }
+
         $this->getEntityManager()->persist($environment);
         $this->getEntityManager()->flush();
     }

--- a/EMS/core-bundle/src/Resources/translations/EMSCoreBundle.en.yml
+++ b/EMS/core-bundle/src/Resources/translations/EMSCoreBundle.en.yml
@@ -8,6 +8,8 @@ log:
             delete: 'Form %name% has been deleted'
         action:
             delete: 'The action %label% has been deleted'
+        environment:
+            delete: 'The environment %name% has been deleted'
         channel:
             delete: 'The channel %name% has been deleted'
         content-type:

--- a/EMS/core-bundle/src/Service/EnvironmentService.php
+++ b/EMS/core-bundle/src/Service/EnvironmentService.php
@@ -359,7 +359,7 @@ class EnvironmentService implements EntityServiceInterface
         foreach ($ids as $id) {
             $environment = $this->environmentRepository->getById($id);
             $environment->setOrderKey($counter++);
-            $this->environmentRepository->create($environment);
+            $this->environmentRepository->save($environment);
         }
     }
 
@@ -435,7 +435,7 @@ class EnvironmentService implements EntityServiceInterface
         }
         $environment->setAlias($this->generateAlias($environment));
 
-        $this->environmentRepository->create($environment);
+        $this->environmentRepository->save($environment);
 
         return $environment;
     }


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   |  n |
| BC breaks?     |  n |
| Deprecations?  |  n |
| Fixed tickets? | n  |
| Documentation? | n  |

Currently we face a 500 error on creating an environment because the order key is null.
