### PR TITLE
feat(core/api): fileUrl for submission endpoint

### DIFF
--- a/EMS/core-bundle/src/Service/Form/Submission/FormSubmissionService.php
+++ b/EMS/core-bundle/src/Service/Form/Submission/FormSubmissionService.php
@@ -63,10 +63,11 @@ final class FormSubmissionService implements EntityServiceInterface
         return $submission;
     }
 
-    public function getProperty(FormSubmission $formSubmission, string $property): mixed
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function getProperty(array $data, string $property): mixed
     {
-        $data = $formSubmission->toArray();
-
         $propertyAccessor = new PropertyAccessor();
         if ($propertyAccessor->isReadable($data, $property)) {
             return $propertyAccessor->getValue($data, $property);

--- a/docs/dev/common-bundle/core-api.md
+++ b/docs/dev/common-bundle/core-api.md
@@ -128,6 +128,8 @@ final class Example
   > Submit form data, returns an array with submission_id and submission info
 * **getSubmission**(string $submissionId, ?string $property = null): array
   > Pass a property for filtering the response, for example '[expireData]', '[data][firstName]' or '[files][0][filename]'
+
+  > Pass a fileUrl for retrieving file urls for the files, example fileUrl=http://localhost:8882/form/{SUBMISSION_ID}/attachment/{FILE_ID}
 * **getSubmissionFile**(string $submissionId, ?string $submissionFileId): StreamedResponse
   > Returns a new proxy streamed response [Symfony\Component\HttpFoundation\StreamedResponse]
   > Because the file information is inside the headers (mimeType, size, name)

--- a/elasticms-admin/config/packages/framework.yaml
+++ b/elasticms-admin/config/packages/framework.yaml
@@ -18,6 +18,11 @@ framework:
     validation:
         email_validation_mode: html5
 
+    http_client:
+      default_options:
+        headers:
+          'Cookie': 'XDEBUG_SESSION=PHPSTORM'
+
 when@redis:
     framework:
         session:


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | n  |
| New feature?   |  y |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? |  n |
| Documentation? | y  |

Passing a `fileUrl` query parameter to [GET] /api/forms/submissions/{subbmisionId}

Will return a file_urls property, value an array of links based on the fileUrl pattern.

Example: 

GET http://localhost:8881/api/forms/submissions/ae863d5a-efd5-46d6-81b6-fa7e6f601d93?fileUrl=http://localhost:8882/form/{SUBMISSION_ID}/attachment/{FILE_ID}&property=[file_urls]

Returns

```json
{
  "[file_urls]": [
    "http:\/\/localhost:8882\/form\/ae863d5a-efd5-46d6-81b6-fa7e6f601d93\/attachment\/5f1d431e-b044-48c0-9165-ae1079e22fc5",
    "http:\/\/localhost:8882\/form\/ae863d5a-efd5-46d6-81b6-fa7e6f601d93\/attachment\/61b54831-982c-4b69-b199-a8f9119af222"
  ]
}
```
