### PR TITLE
fix(common/store_data): file system type not working

### DIFF
--- a/EMS/common-bundle/src/Resources/config/store_data.xml
+++ b/EMS/common-bundle/src/Resources/config/store_data.xml
@@ -28,7 +28,7 @@
       <service id="ems_common.store_data.factory.fs" class="EMS\CommonBundle\Common\StoreData\Factory\StoreDataFileSystemFactory">
           <tag name="ems_common.store_data.factory" alias="fs"/>
       </service>
-      <service id="ems_common.store_data.factory.fs" class="EMS\CommonBundle\Common\StoreData\Factory\StoreDataS3Factory">
+      <service id="ems_common.store_data.factory.s3" class="EMS\CommonBundle\Common\StoreData\Factory\StoreDataS3Factory">
           <tag name="ems_common.store_data.factory" alias="s3"/>
       </service>
   </services>


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   |  n |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Using type "fs" is not working, because type "s3" is using the same service id.
They fileSystemFactory their for is not injected.
