### PR TITLE
fix(submission/db): allow nullable expire_date

### DIFF
--- a/EMS/submission-bundle/src/Request/DatabaseRequest.php
+++ b/EMS/submission-bundle/src/Request/DatabaseRequest.php
@@ -95,7 +95,7 @@ final class DatabaseRequest
             ->setAllowedTypes('data', 'array')
             ->setAllowedTypes('files', 'array')
             ->setAllowedTypes('label', 'string')
-            ->setAllowedTypes('expire_date', 'string')
+            ->setAllowedTypes('expire_date', ['string', 'null'])
         ;
 
         try {


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   |  n |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? |  n |
| Documentation? | n  |

Fix that the expire date can be nullable
