### PR TITLE
feat(ems): ip filtering with EMS_TRUSTED_IPS env variable

### DIFF
--- a/EMS/common-bundle/src/Common/Route/Loader.php
+++ b/EMS/common-bundle/src/Common/Route/Loader.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace EMS\CommonBundle\Common\Route;
 
 use EMS\CommonBundle\Controller\MetricController;
+use EMS\CommonBundle\Routes;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
@@ -19,7 +20,7 @@ final class Loader
         $commonRouteCollection = new RouteCollection();
 
         if ($this->metricEnabled) {
-            $metricRoute = new Route('/metrics');
+            $metricRoute = new Route(Routes::METRICS->value);
             $metricRoute->setMethods(['GET']);
             $metricRoute->setHost('%ems.metric.host%');
             $metricRoute->setDefault('_controller', MetricController::METRICS);

--- a/EMS/common-bundle/src/Controller/MetricController.php
+++ b/EMS/common-bundle/src/Controller/MetricController.php
@@ -7,6 +7,7 @@ namespace EMS\CommonBundle\Controller;
 use EMS\CommonBundle\Common\Metric\MetricCollector;
 use Prometheus\RenderTextFormat;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 final class MetricController extends AbstractController
@@ -17,9 +18,9 @@ final class MetricController extends AbstractController
     {
     }
 
-    public function metrics(): Response
+    public function metrics(Request $request): Response
     {
-        if (null !== $this->metricPort && $this->metricPort !== $_SERVER['SERVER_PORT']) {
+        if (null !== $this->metricPort && $this->metricPort !== $request->server->get('SERVER_PORT')) {
             throw $this->createNotFoundException();
         }
 

--- a/EMS/common-bundle/src/DependencyInjection/Configuration.php
+++ b/EMS/common-bundle/src/DependencyInjection/Configuration.php
@@ -43,6 +43,7 @@ class Configuration implements ConfigurationInterface
         $this->addCacheSection($rootNode);
         $this->addMetricSection($rootNode);
         $this->addWebalizeSection($rootNode);
+        $this->addRequestSection($rootNode);
 
         return $treeBuilder;
     }
@@ -93,6 +94,19 @@ class Configuration implements ConfigurationInterface
                     ->children()
                         ->scalarNode('removable_regex')->defaultValue(self::WEBALIZE_REMOVABLE_REGEX)->setDeprecated('elasticms/common-bundle', '6.0.0')->end()
                         ->scalarNode('dashable_regex')->defaultValue(self::WEBALIZE_DASHABLE_REGEX)->setDeprecated('elasticms/common-bundle', '6.0.0')->end()
+                ->end()
+            ->end()
+        ;
+    }
+
+    private function addRequestSection(ArrayNodeDefinition $rootNode): void
+    {
+        $rootNode
+            ->children()
+                ->arrayNode('request')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->variableNode('trusted_ips')->defaultValue([])->end()
                 ->end()
             ->end()
         ;

--- a/EMS/common-bundle/src/DependencyInjection/EMSCommonExtension.php
+++ b/EMS/common-bundle/src/DependencyInjection/EMSCommonExtension.php
@@ -49,6 +49,7 @@ class EMSCommonExtension extends Extension
         $container->setParameter('ems_common.log_level', $config['log_level']);
         $container->setParameter('ems_common.excluded_content_types', $config['excluded_content_types']);
         $container->setParameter('ems_common.slug_symbol_map', $config['slug_symbol_map']);
+        $container->setParameter('ems_common.request.trusted_ips', $config['request']['trusted_ips']);
 
         $container->setParameter('ems_common.cache_config', $config['cache']);
 

--- a/EMS/common-bundle/src/EventListener/CommandListener.php
+++ b/EMS/common-bundle/src/EventListener/CommandListener.php
@@ -31,10 +31,7 @@ class CommandListener implements EventSubscriberInterface
         ];
     }
 
-    /**
-     * @return void
-     */
-    public function onCommand(ConsoleCommandEvent $event)
+    public function onCommand(ConsoleCommandEvent $event): void
     {
         $command = $event->getCommand();
 
@@ -45,10 +42,7 @@ class CommandListener implements EventSubscriberInterface
         $this->stopwatch->start((string) $command->getName());
     }
 
-    /**
-     * @return void
-     */
-    public function onTerminate(ConsoleTerminateEvent $event)
+    public function onTerminate(ConsoleTerminateEvent $event): void
     {
         $command = $event->getCommand();
 

--- a/EMS/common-bundle/src/EventListener/IpAddressListener.php
+++ b/EMS/common-bundle/src/EventListener/IpAddressListener.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CommonBundle\EventListener;
+
+use EMS\CommonBundle\Routes;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class IpAddressListener implements EventSubscriberInterface
+{
+    public function __construct(
+        private readonly RequestMatcherInterface $requestMatcher,
+        private readonly bool $metricEnabled
+    ) {
+    }
+
+    /**
+     * @return array<string, array<string|int>>
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => ['onKernelRequest', 512],
+        ];
+    }
+
+    public function onKernelRequest(RequestEvent $requestEvent): void
+    {
+        if (!$requestEvent->isMainRequest()) {
+            return;
+        }
+
+        $request = $requestEvent->getRequest();
+
+        if ($this->metricEnabled && $request->getPathInfo() === Routes::METRICS->value) {
+            return;
+        }
+
+        if (!$this->requestMatcher->matches($request)) {
+            throw new AccessDeniedHttpException();
+        }
+    }
+}

--- a/EMS/common-bundle/src/Resources/config/services.xml
+++ b/EMS/common-bundle/src/Resources/config/services.xml
@@ -50,11 +50,16 @@
             <argument type="service" id="ems_common.elastica.client"/>
         </service>
 
-        <service id="ems_common.event_listener.command" class="EMS\CommonBundle\EventListener\CommandListener">
+        <service id="ems.event_listener.command" class="EMS\CommonBundle\EventListener\CommandListener">
             <tag name="kernel.event_subscriber" />
         </service>
         <service id="ems.event_listener.doctrine_migration" class="EMS\CommonBundle\EventListener\DoctrineMigrationListener">
             <tag name="doctrine.event_listener" event="postGenerateSchema"/>
+        </service>
+        <service id="ems.event_listener.ip_address_listener" class="EMS\CommonBundle\EventListener\IpAddressListener">
+            <argument type="service" id="ems.request_matcher.trusted_ips"/>
+            <argument>%ems.metric.enabled%</argument>
+            <tag name="kernel.event_subscriber" />
         </service>
 
         <service id="ems_common.text.encoder" class="EMS\CommonBundle\Helper\Text\Encoder">
@@ -84,6 +89,10 @@
             <argument type="service" id="ems_common.core_api.factory" />
             <argument type="service" id="ems_common.core_api.token_store" />
             <argument type="service" id="logger" />
+        </service>
+
+        <service id="ems.request_matcher.trusted_ips" class="Symfony\Component\HttpFoundation\RequestMatcher">
+            <argument key="$ips">%ems_common.request.trusted_ips%</argument>
         </service>
 
         <!-- twig -->

--- a/EMS/common-bundle/src/Routes.php
+++ b/EMS/common-bundle/src/Routes.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CommonBundle;
+
+enum Routes: string
+{
+    case METRICS = '/metrics';
+}

--- a/EMS/common-bundle/tests/Unit/DependencyInjection/ConfigurationAiTest.php
+++ b/EMS/common-bundle/tests/Unit/DependencyInjection/ConfigurationAiTest.php
@@ -51,8 +51,8 @@ final class ConfigurationAiTest extends TestCase
             ],
             'slug_symbol_map' => null,
             'request' => [
-                'trusted_ips' => []
-            ]
+                'trusted_ips' => [],
+            ],
         ];
 
         $this->assertEquals($expected, $config);

--- a/EMS/common-bundle/tests/Unit/DependencyInjection/ConfigurationAiTest.php
+++ b/EMS/common-bundle/tests/Unit/DependencyInjection/ConfigurationAiTest.php
@@ -50,6 +50,9 @@ final class ConfigurationAiTest extends TestCase
                 'dashable_regex' => Configuration::WEBALIZE_DASHABLE_REGEX,
             ],
             'slug_symbol_map' => null,
+            'request' => [
+                'trusted_ips' => []
+            ]
         ];
 
         $this->assertEquals($expected, $config);

--- a/docs/elasticms-admin/environment-variables.md
+++ b/docs/elasticms-admin/environment-variables.md
@@ -429,6 +429,11 @@ Specify replacement strings, per locale to symbols. E.g. if you want to replace 
 
 Define (JSON format) the store data services, in the priority order. See the [Stora Data documentation](../recipes/store-data.md) for more details. Default value `[{"type":"db"}]`
 
+### EMS_TRUSTED_IPS
+
+Define (JSON format) a range of allowed ip address. Example: `["127.0.0.1", "::1", "192.168.0.1/24"]`
+Important the route `/metrics` is not filtered.
+
 ### EMS_EXCLUDED_CONTENT_TYPES
 
 Define (JSON format) a list of content type names to exclude from admin backup/restore commands. Example: `["route","template","template_ems","label"]`. Default value `[]`

--- a/docs/elasticms-web/parameters.md
+++ b/docs/elasticms-web/parameters.md
@@ -249,6 +249,11 @@ Specify replacement strings, per locale to symbols. E.g. if you want to replace 
 
 Define (JSON format) the store data services, in the priority order. See the [Stora Data documentation](../recipes/store-data.md) for more details. By default, the store data functionalities are disabled.
 
+### EMS_TRUSTED_IPS
+
+Define (JSON format) a range of allowed ip address. Example: `["127.0.0.1", "::1", "192.168.0.1/24"]`
+Important the route `/metrics` is not filtered.
+
 ### EMS_EXCLUDED_CONTENT_TYPES
 
 Define (JSON format) a list of content type names to exclude from admin backup/restore commands. Example: `["route","template","template_ems","label"]`. Default value `[]`

--- a/elasticms-admin/.env.dist
+++ b/elasticms-admin/.env.dist
@@ -89,6 +89,7 @@ EMS_EXCLUDED_CONTENT_TYPES='["route","template","template_ems","label"]'
 #EMS_METRIC_PORT=
 EMS_STORAGES='[{"type":"s3","usage":"cache","bucket":"demo","credentials":{"version":"2006-03-01","credentials":{"key":"accesskey","secret":"secretkey"},"region":"us-east-1","endpoint":"http://localhost:9000","use_path_style_endpoint":true}}]'
 EMS_STORE_DATA_SERVICES=[]
+EMS_TRUSTED_IPS='[]'
 #EMS_WEBALIZE_DASHABLE_REGEX='/[\/\_\|\ \-]+/'
 #EMS_WEBALIZE_REMOVABLE_REGEX='/([^a-zA-Z0-9\_\|\ \-\.])|(\.$)/'
 ###< elasticms/common-bundle ###

--- a/elasticms-admin/config/packages/ems_common.yaml
+++ b/elasticms-admin/config/packages/ems_common.yaml
@@ -35,6 +35,7 @@ parameters:
     env(EMS_WEBALIZE_DASHABLE_REGEX): '/[\/| '']+/'
     env(EMS_EXCLUDED_CONTENT_TYPES): '[]'
     env(EMS_SLUG_SYMBOL_MAP): ~
+    env(EMS_TRUSTED_IPS): '[]'
 
 ems_common:
     hash_algo: '%env(string:EMS_HASH_ALGO)%'
@@ -61,6 +62,8 @@ ems_common:
         enabled: '%env(bool:EMS_METRIC_ENABLED)%'
         host: '%env(string:EMS_METRIC_HOST)%'
         port: '%env(EMS_METRIC_PORT)%'
+    request:
+        trusted_ips: '%env(json:EMS_TRUSTED_IPS)%'
 
 when@dev:
     ems_common:

--- a/elasticms-web/.env.dist
+++ b/elasticms-web/.env.dist
@@ -43,6 +43,7 @@ EMS_EXCLUDED_CONTENT_TYPES='["route","template","template_ems","label"]'
 #EMS_METRIC_PORT=
 EMS_STORAGES='[{"type":"s3","usage":"cache","bucket":"demo","credentials":{"version":"2006-03-01","credentials":{"key":"accesskey","secret":"secretkey"},"region":"us-east-1","endpoint":"http://localhost:9000","use_path_style_endpoint":true}}]'
 EMS_STORE_DATA_SERVICES=[]
+EMS_TRUSTED_IPS='[]'
 #EMS_WEBALIZE_DASHABLE_REGEX='/[\/\_\|\ \-]+/'
 #EMS_WEBALIZE_REMOVABLE_REGEX='/([^a-zA-Z0-9\_\|\ \-\.])|(\.$)/'
 ###< elasticms/common-bundle ###

--- a/elasticms-web/config/packages/ems_common.yaml
+++ b/elasticms-web/config/packages/ems_common.yaml
@@ -29,6 +29,7 @@ parameters:
     env(EMS_WEBALIZE_DASHABLE_REGEX): '/[\/\_\|\ \-]+/'
     env(EMS_EXCLUDED_CONTENT_TYPES): '[]'
     env(EMS_SLUG_SYMBOL_MAP): ~
+    env(EMS_TRUSTED_IPS): '[]'
 
 ems_common:
     hash_algo: '%env(string:EMS_HASH_ALGO)%'
@@ -56,6 +57,8 @@ ems_common:
         enabled: '%env(bool:EMS_METRIC_ENABLED)%'
         host: '%env(string:EMS_METRIC_HOST)%'
         port: '%env(EMS_METRIC_PORT)%'
+    request:
+        trusted_ips: '%env(json:EMS_TRUSTED_IPS)%'
 
 when@dev:
     ems_common:


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  n |
| New feature?   |  y |
| BC breaks?     | n  |
| Deprecations?  |  n |
| Fixed tickets? |  #882  |
| Documentation? |  y |

Added a common event listener for ip filtering, it makes use of a symfony request matcher for checking the ips (if defined).
