### PR TITLE
chore(demo): remove publication route and upgrade note single colon controller

### DIFF
--- a/demo/skeleton/routes.yaml
+++ b/demo/skeleton/routes.yaml
@@ -73,14 +73,6 @@ emsch_api_form_attachment:
         defaults: { apiName: backend, _authenticated: true }
         controller: 'emsch.controller.api::getSubmissionFile'
         requirements: { submissionId: '.*', submissionFileId: '.*' }
-emsch_publication:
-    config:
-        path: { en: 'publications/{slug}', fr: 'fr/publications/{slug}', nl: 'nl/publicaties/{slug}', de: 'de/publikation/{slug}' }
-        controller: 'emsch.controller.router:asset'
-        defaults: { _target_group: site }
-        requirements: {  }
-    query: '{"query":{"bool":{"must":[{"terms":{"_contenttype":["publication"]}},{"term":{"target_group":"site"}},{"term":{"show_%_locale%":true}},{"term":{"slug_%_locale%":"%slug%"}}]}},"size":1}'
-    template_static: template/asset/publication.json.twig
 emsch_slideshow:
     config:
         path: { en: 'slideshow/{slug}', fr: 'fr/presentation/{slug}' }

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -1,5 +1,6 @@
 # Upgrade
 
+  * [version 5.17.x](#version-517x)
   * [version 5.15.x](#version-515x)
   * [version 5.14.x](#version-514x)
   * [version 5.7.x](#version-57x)
@@ -7,6 +8,12 @@
   * [version 4.2.x](#version-42x)
   * [version 4.x](#version-4x)
   * [Tips and tricks](#tips-and-tricks)
+
+## version 5.17.x
+
+* Check routes single colon is deprecated
+
+  Example replace ```emsch.controller.router:redirect``` by ```emsch.controller.router::redirect```
 
 ## version 5.15.x
 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  n |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? |  #857  |
| Documentation? |  y  |

Publication content type does not exist anymore inside the demo, so the route can be removed.
Plus the route was using a deprecated single colon controller definition.
