### PR TITLE
feat(demo): add asset content type (documentation)

### DIFF
--- a/demo/configs/admin/content-type/asset.json
+++ b/demo/configs/admin/content-type/asset.json
@@ -1,0 +1,442 @@
+{
+    "class": "EMS\\CoreBundle\\Entity\\ContentType",
+    "arguments": [],
+    "properties": {
+        "name": "asset",
+        "pluralName": "Assets",
+        "singularName": "Asset",
+        "icon": "fa fa-file-text",
+        "description": null,
+        "indexTwig": null,
+        "extra": null,
+        "lockBy": null,
+        "lockUntil": null,
+        "deleted": false,
+        "askForOuuid": false,
+        "color": "orange",
+        "fieldType": {
+            "class": "EMS\\CoreBundle\\Entity\\FieldType",
+            "arguments": [],
+            "properties": {
+                "type": "EMS\\CoreBundle\\Form\\DataField\\ContainerFieldType",
+                "name": "source",
+                "contentType": null,
+                "deleted": false,
+                "description": null,
+                "options": {
+                    "displayOptions": {
+                        "label": null,
+                        "class": null,
+                        "lastOfRow": false,
+                        "helptext": null,
+                        "icon": null
+                    },
+                    "restrictionOptions": {
+                        "minimum_role": null
+                    },
+                    "extraOptions": {
+                        "extra": null,
+                        "postProcessing": null,
+                        "clear_on_copy": false
+                    }
+                },
+                "orderKey": 0,
+                "children": [
+                    {
+                        "class": "EMS\\CoreBundle\\Entity\\FieldType",
+                        "arguments": [],
+                        "properties": {
+                            "type": "EMS\\CoreBundle\\Form\\DataField\\IndexedAssetFieldType",
+                            "name": "file",
+                            "contentType": null,
+                            "deleted": false,
+                            "description": null,
+                            "options": {
+                                "displayOptions": {
+                                    "label": "File",
+                                    "class": "col-md-4",
+                                    "lastOfRow": false,
+                                    "helptext": null,
+                                    "icon": "fa fa-book",
+                                    "imageAssetConfigIdentifier": null
+                                },
+                                "mappingOptions": {
+                                    "index": null,
+                                    "analyzer": null,
+                                    "copy_to": "live_search"
+                                },
+                                "restrictionOptions": {
+                                    "mandatory": true,
+                                    "mandatory_if": null,
+                                    "minimum_role": null
+                                },
+                                "extraOptions": {
+                                    "extra": null,
+                                    "clear_on_copy": false,
+                                    "postProcessing": null
+                                },
+                                "raw_data": [],
+                                "migrationOptions": {
+                                    "protected": false
+                                }
+                            },
+                            "orderKey": 1,
+                            "children": []
+                        },
+                        "replaced": []
+                    },
+                    {
+                        "class": "EMS\\CoreBundle\\Entity\\FieldType",
+                        "arguments": [],
+                        "properties": {
+                            "type": "EMS\\CoreBundle\\Form\\DataField\\ContainerFieldType",
+                            "name": "meta",
+                            "contentType": null,
+                            "deleted": false,
+                            "description": null,
+                            "options": {
+                                "displayOptions": {
+                                    "label": "Meta",
+                                    "class": "col-md-8",
+                                    "lastOfRow": false,
+                                    "helptext": null,
+                                    "icon": null
+                                },
+                                "mappingOptions": [],
+                                "restrictionOptions": {
+                                    "minimum_role": null
+                                },
+                                "extraOptions": {
+                                    "extra": null,
+                                    "postProcessing": null,
+                                    "clear_on_copy": false
+                                },
+                                "raw_data": []
+                            },
+                            "orderKey": 2,
+                            "children": [
+                                {
+                                    "class": "EMS\\CoreBundle\\Entity\\FieldType",
+                                    "arguments": [],
+                                    "properties": {
+                                        "type": "EMS\\CoreBundle\\Form\\DataField\\TextStringFieldType",
+                                        "name": "label",
+                                        "contentType": null,
+                                        "deleted": false,
+                                        "description": null,
+                                        "options": {
+                                            "displayOptions": {
+                                                "label": "Label",
+                                                "class": "col-md-12",
+                                                "lastOfRow": false,
+                                                "helptext": null,
+                                                "prefixIcon": null,
+                                                "prefixText": null,
+                                                "suffixIcon": null,
+                                                "suffixText": null,
+                                                "placeholder": null,
+                                                "icon": null
+                                            },
+                                            "mappingOptions": {
+                                                "index": null,
+                                                "analyzer": null,
+                                                "copy_to": "live_search"
+                                            },
+                                            "restrictionOptions": {
+                                                "mandatory": true,
+                                                "mandatory_if": null,
+                                                "minimum_role": null
+                                            },
+                                            "extraOptions": {
+                                                "extra": null,
+                                                "postProcessing": null,
+                                                "clear_on_copy": false
+                                            },
+                                            "raw_data": [],
+                                            "migrationOptions": {
+                                                "protected": false
+                                            }
+                                        },
+                                        "orderKey": 0,
+                                        "children": [
+                                            {
+                                                "class": "EMS\\CoreBundle\\Entity\\FieldType",
+                                                "arguments": [],
+                                                "properties": {
+                                                    "type": "EMS\\CoreBundle\\Form\\DataField\\SubfieldType",
+                                                    "name": "alpha_order",
+                                                    "contentType": null,
+                                                    "deleted": false,
+                                                    "description": null,
+                                                    "options": {
+                                                        "displayOptions": [],
+                                                        "mappingOptions": {
+                                                            "index": null,
+                                                            "analyzer": "alpha_order",
+                                                            "fielddata": true
+                                                        },
+                                                        "extraOptions": {
+                                                            "extra": null,
+                                                            "clear_on_copy": false,
+                                                            "postProcessing": null
+                                                        }
+                                                    },
+                                                    "orderKey": 0,
+                                                    "children": []
+                                                },
+                                                "replaced": []
+                                            }
+                                        ]
+                                    },
+                                    "replaced": []
+                                },
+                                {
+                                    "class": "EMS\\CoreBundle\\Entity\\FieldType",
+                                    "arguments": [],
+                                    "properties": {
+                                        "type": "EMS\\CoreBundle\\Form\\DataField\\ChoiceFieldType",
+                                        "name": "type",
+                                        "contentType": null,
+                                        "deleted": false,
+                                        "description": null,
+                                        "options": {
+                                            "displayOptions": {
+                                                "label": "Type",
+                                                "class": "col-md-12",
+                                                "lastOfRow": false,
+                                                "helptext": null,
+                                                "multiple": false,
+                                                "expanded": false,
+                                                "select2": false,
+                                                "choices": "manual",
+                                                "labels": "Manual",
+                                                "linked_collection": null,
+                                                "collection_label_field": null
+                                            },
+                                            "mappingOptions": {
+                                                "index": "not_analyzed",
+                                                "analyzer": "keyword",
+                                                "copy_to": null
+                                            },
+                                            "restrictionOptions": {
+                                                "mandatory": false,
+                                                "mandatory_if": null,
+                                                "minimum_role": null
+                                            },
+                                            "extraOptions": {
+                                                "extra": null,
+                                                "clear_on_copy": false,
+                                                "postProcessing": null
+                                            },
+                                            "raw_data": [],
+                                            "migrationOptions": {
+                                                "protected": false
+                                            }
+                                        },
+                                        "orderKey": 1,
+                                        "children": []
+                                    },
+                                    "replaced": []
+                                },
+                                {
+                                    "class": "EMS\\CoreBundle\\Entity\\FieldType",
+                                    "arguments": [],
+                                    "properties": {
+                                        "type": "EMS\\CoreBundle\\Form\\DataField\\ChoiceFieldType",
+                                        "name": "locales",
+                                        "contentType": null,
+                                        "deleted": false,
+                                        "description": null,
+                                        "options": {
+                                            "displayOptions": {
+                                                "label": "Locales",
+                                                "class": "col-md-12",
+                                                "lastOfRow": false,
+                                                "helptext": null,
+                                                "multiple": true,
+                                                "expanded": false,
+                                                "select2": true,
+                                                "choices": "en\r\nfr\r\nnl\r\nde",
+                                                "labels": "English\r\nFrench\r\nDutch\r\nGerman",
+                                                "linked_collection": null,
+                                                "collection_label_field": null
+                                            },
+                                            "mappingOptions": {
+                                                "index": "not_analyzed",
+                                                "analyzer": "keyword",
+                                                "copy_to": null
+                                            },
+                                            "restrictionOptions": {
+                                                "mandatory": false,
+                                                "mandatory_if": null,
+                                                "minimum_role": null
+                                            },
+                                            "extraOptions": {
+                                                "extra": null,
+                                                "clear_on_copy": false,
+                                                "postProcessing": null
+                                            },
+                                            "raw_data": [],
+                                            "migrationOptions": {
+                                                "protected": false
+                                            }
+                                        },
+                                        "orderKey": 2,
+                                        "children": []
+                                    },
+                                    "replaced": []
+                                }
+                            ]
+                        },
+                        "replaced": []
+                    },
+                    {
+                        "class": "EMS\\CoreBundle\\Entity\\FieldType",
+                        "arguments": [],
+                        "properties": {
+                            "type": "EMS\\CoreBundle\\Form\\DataField\\ComputedFieldType",
+                            "name": "live_search",
+                            "contentType": null,
+                            "deleted": false,
+                            "description": null,
+                            "options": {
+                                "displayOptions": {
+                                    "label": "Live Search",
+                                    "class": "hidden",
+                                    "lastOfRow": false,
+                                    "helptext": null,
+                                    "valueTemplate": null,
+                                    "json": false,
+                                    "displayTemplate": null
+                                },
+                                "mappingOptions": {
+                                    "mappingOptions": "{\r\n        \"type\": \"search_as_you_type\",\r\n        \"analyzer\": \"standard\"\r\n}",
+                                    "copy_to": null
+                                },
+                                "restrictionOptions": [],
+                                "extraOptions": {
+                                    "extra": null,
+                                    "clear_on_copy": false,
+                                    "postProcessing": null
+                                },
+                                "raw_data": []
+                            },
+                            "orderKey": 3,
+                            "children": []
+                        },
+                        "replaced": []
+                    }
+                ],
+                "__initializer__": null,
+                "__cloner__": null,
+                "__isInitialized__": true
+            },
+            "replaced": []
+        },
+        "refererFieldName": null,
+        "sortOrder": null,
+        "orderKey": 11,
+        "rootContentType": false,
+        "editTwigWithWysiwyg": false,
+        "webContent": false,
+        "autoPublish": false,
+        "templates": [
+            {
+                "class": "EMS\\CoreBundle\\Entity\\Template",
+                "arguments": [],
+                "properties": {
+                    "name": "download-link",
+                    "label": "Download link",
+                    "icon": "fa fa-download",
+                    "body": "{{ block('asset_download_link', '@EMSCH/template_ems/actions.twig') }}",
+                    "header": null,
+                    "editWithWysiwyg": false,
+                    "renderOption": "externalLink",
+                    "orderKey": 0,
+                    "accumulateInOneFile": false,
+                    "preview": false,
+                    "mimeType": null,
+                    "filename": null,
+                    "extension": null,
+                    "active": true,
+                    "role": "not-defined",
+                    "roleTo": "not-defined",
+                    "roleCc": "not-defined",
+                    "circlesTo": [],
+                    "responseTemplate": null,
+                    "emailContentType": null,
+                    "allowOrigin": null,
+                    "disposition": null,
+                    "orientation": null,
+                    "size": null,
+                    "public": false,
+                    "spreadsheet": false,
+                    "tag": null
+                },
+                "replaced": []
+            }
+        ],
+        "views": [
+            {
+                "class": "EMS\\CoreBundle\\Entity\\View",
+                "arguments": [],
+                "properties": {
+                    "name": "overview",
+                    "type": "ems.view.report",
+                    "label": "Overview",
+                    "icon": "fa fa-list",
+                    "options": {
+                        "body": null,
+                        "size": 0,
+                        "template": "{{ block(\"template\", \"@EMSCH/template_ems/view/overview.twig\") }}",
+                        "header": "{{ block(\"css\", \"@EMSCH/template_ems/view/overview.twig\") }}",
+                        "javascript": "{{ block(\"javascript\", \"@EMSCH/template_ems/view/overview.twig\") }}"
+                    },
+                    "orderKey": 1,
+                    "public": false,
+                    "role": "ROLE_WEBMASTER"
+                },
+                "replaced": []
+            }
+        ],
+        "defaultValue": null,
+        "versionTags": null,
+        "versionOptions": {
+            "dates_read_only": true,
+            "dates_interval_one_day": false
+        },
+        "versionFields": {
+            "date_from": null,
+            "date_to": null,
+            "version_tag": null
+        },
+        "roles": {
+            "view": "ROLE_WEBMASTER",
+            "create": "ROLE_WEBMASTER",
+            "edit": "ROLE_WEBMASTER",
+            "publish": "ROLE_WEBMASTER",
+            "delete": "ROLE_WEBMASTER",
+            "trash": "ROLE_WEBMASTER",
+            "archive": "not-defined",
+            "show_link_create": "ROLE_WEBMASTER",
+            "show_link_search": "not-defined"
+        },
+        "fields": {
+            "display": null,
+            "label": "label",
+            "color": null,
+            "sort": null,
+            "tooltip": null,
+            "circles": null,
+            "business_id": null,
+            "category": null,
+            "asset": null
+        },
+        "settings": {
+            "tasks_enabled": false,
+            "tasks_titles": [],
+            "hide_revision_sidebar": false
+        }
+    },
+    "replaced": []
+}

--- a/demo/configs/admin/content-type/label.json
+++ b/demo/configs/admin/content-type/label.json
@@ -422,7 +422,7 @@
         },
         "refererFieldName": null,
         "sortOrder": "asc",
-        "orderKey": 11,
+        "orderKey": 12,
         "rootContentType": false,
         "editTwigWithWysiwyg": true,
         "webContent": false,

--- a/demo/configs/admin/content-type/route.json
+++ b/demo/configs/admin/content-type/route.json
@@ -400,7 +400,7 @@
         },
         "refererFieldName": null,
         "sortOrder": "asc",
-        "orderKey": 12,
+        "orderKey": 13,
         "rootContentType": false,
         "editTwigWithWysiwyg": true,
         "webContent": false,

--- a/demo/configs/admin/content-type/template.json
+++ b/demo/configs/admin/content-type/template.json
@@ -170,7 +170,7 @@
         },
         "refererFieldName": null,
         "sortOrder": null,
-        "orderKey": 13,
+        "orderKey": 14,
         "rootContentType": false,
         "editTwigWithWysiwyg": true,
         "webContent": false,

--- a/demo/configs/admin/content-type/template_ems.json
+++ b/demo/configs/admin/content-type/template_ems.json
@@ -170,7 +170,7 @@
         },
         "refererFieldName": null,
         "sortOrder": null,
-        "orderKey": 14,
+        "orderKey": 15,
         "rootContentType": false,
         "editTwigWithWysiwyg": false,
         "webContent": false,

--- a/demo/skeleton/template/ems/asset.ems_link.twig
+++ b/demo/skeleton/template/ems/asset.ems_link.twig
@@ -1,0 +1,2 @@
+{%- set urlType = _emsch_go_to|default(false) ? 0 : 2 -%}
+{{- ems_asset_path(source.file, { '_url_type': urlType }) -}}

--- a/demo/skeleton/template_ems/actions.twig
+++ b/demo/skeleton/template_ems/actions.twig
@@ -57,3 +57,7 @@
     {% endif %}
 {% endblock show %}
 
+{% block asset_download_link %}
+    {{ "/channel/#{environment.name}/_emsch/go-to/nl/#{contentType.name}/#{object._id}" }}
+{% endblock asset_download_link %}
+


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | n  |
| New feature?   | y  |
| BC breaks?     |  n |
| Deprecations?  |  n |
| Fixed tickets? |  n |
| Documentation? | n  |

Request for adding "asset" content type, for managing documentation inside demo project
