### PR TITLE
fix(cli/import): trim import headers

### DIFF
--- a/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySync.php
+++ b/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySync.php
@@ -241,7 +241,7 @@ final class MediaLibrarySync
         $metadataFilePath = $this->options->hashMetaDataFile ? $this->getFileByHash($metadataFile) : $metadataFile;
 
         $rows = $this->fileReader->getData($metadataFilePath);
-        $header = \array_map('trim',$rows[0] ?? []);
+        $header = \array_map('trim', $rows[0] ?? []);
         $this->metadatas = [];
         foreach ($rows as $rowIndex => $value) {
             if (0 === $rowIndex) {

--- a/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySync.php
+++ b/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySync.php
@@ -241,7 +241,7 @@ final class MediaLibrarySync
         $metadataFilePath = $this->options->hashMetaDataFile ? $this->getFileByHash($metadataFile) : $metadataFile;
 
         $rows = $this->fileReader->getData($metadataFilePath);
-        $header = $rows[0] ?? [];
+        $header = \array_map('trim',$rows[0] ?? []);
         $this->metadatas = [];
         foreach ($rows as $rowIndex => $value) {
             if (0 === $rowIndex) {

--- a/elasticms-cli/src/Command/FileReader/FileReaderImportCommand.php
+++ b/elasticms-cli/src/Command/FileReader/FileReaderImportCommand.php
@@ -84,7 +84,7 @@ final class FileReaderImportCommand extends AbstractCommand
 
         $expressionLanguage = new ExpressionLanguage();
         $rows = $this->fileReader->getData($file, false, $this->encoding);
-        $header = $rows[0] ?? [];
+        $header = \array_map('trim',$rows[0] ?? []);
 
         $ouuids = [];
         if ($this->deleteMissingDocuments) {
@@ -100,14 +100,16 @@ final class FileReaderImportCommand extends AbstractCommand
 
         $counter = 0;
         $progressBar = $this->io->createProgressBar(\count($rows) - 1);
-        foreach ($rows as $key => $value) {
+        foreach ($rows as $key => $rowValues) {
+
+
             if (0 === $key) {
                 continue;
             }
             $row = [];
             $empty = true;
-            foreach ($value as $key => $cell) {
-                $row[$header[$key] ?? $key] = $cell;
+            foreach ($rowValues as $cellKey => $cell) {
+                $row[$header[$cellKey] ?? $cellKey] = $cell;
                 $empty = $empty && (null === $cell);
             }
             if ($empty) {

--- a/elasticms-cli/src/Command/FileReader/FileReaderImportCommand.php
+++ b/elasticms-cli/src/Command/FileReader/FileReaderImportCommand.php
@@ -101,8 +101,6 @@ final class FileReaderImportCommand extends AbstractCommand
         $counter = 0;
         $progressBar = $this->io->createProgressBar(\count($rows) - 1);
         foreach ($rows as $key => $rowValues) {
-
-
             if (0 === $key) {
                 continue;
             }

--- a/elasticms-cli/src/Command/FileReader/FileReaderImportCommand.php
+++ b/elasticms-cli/src/Command/FileReader/FileReaderImportCommand.php
@@ -84,7 +84,7 @@ final class FileReaderImportCommand extends AbstractCommand
 
         $expressionLanguage = new ExpressionLanguage();
         $rows = $this->fileReader->getData($file, false, $this->encoding);
-        $header = \array_map('trim',$rows[0] ?? []);
+        $header = \array_map('trim', $rows[0] ?? []);
 
         $ouuids = [];
         if ($this->deleteMissingDocuments) {


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   |  n |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

If we import a csv or excel and the first row (headers) contains spaces before or after, we are importing it.
Apply trim on the header values, improves the import.
