### PR TITLE
fix(core/twig): internal_links filter with null value

### DIFF
--- a/EMS/core-bundle/src/Resources/views/macros/data-field-type.html.twig
+++ b/EMS/core-bundle/src/Resources/views/macros/data-field-type.html.twig
@@ -625,7 +625,7 @@
 				<div class="panel panel-default">
 					<div class="panel-body {{ color }}">
 						{% if doCompare  %}
-							<pre class="ems-code-editor col-md-6" data-language="ace/mode/json" data-them="ace/theme/chrome">{{ compareRawData|get_string(dataField.fieldType.name)|json_encode|internal_links }}</pre>
+							<pre class="ems-code-editor col-md-6" data-language="ace/mode/json" data-them="ace/theme/chrome">{{ compareRawData|get_string(dataField.fieldType.name)|default('')|internal_links }}</pre>
 							<pre class="ems-code-editor col-md-6" data-language="ace/mode/json" data-them="ace/theme/chrome">{{ dataField.rawData|json_encode|internal_links }}</pre>
 						{% else %}
 							<pre class="ems-code-editor" data-language="ace/mode/json" data-them="ace/theme/chrome">{{ dataField.rawData|json_encode|internal_links }}</pre>
@@ -685,7 +685,7 @@
             <div class="panel panel-default">
                 <div class="panel-body {{ color }}">
                     {% if doCompare  %}
-                        <pre class="ems-code-editor col-md-6" data-language="ace/mode/json" data-them="ace/theme/chrome">{{ compareRawData|get_string(dataField.fieldType.name)|json_encode|internal_links }}</pre>
+                        <pre class="ems-code-editor col-md-6" data-language="ace/mode/json" data-them="ace/theme/chrome">{{ compareRawData|get_string(dataField.fieldType.name)|default('')|internal_links }}</pre>
                         <pre class="ems-code-editor col-md-6" data-language="ace/mode/json" data-them="ace/theme/chrome">{{ dataField.rawData|json_encode|internal_links }}</pre>
                     {% else %}
                         <pre class="ems-code-editor" data-language="ace/mode/json" data-them="ace/theme/chrome">

--- a/EMS/core-bundle/src/Resources/views/macros/data-field-type.html.twig
+++ b/EMS/core-bundle/src/Resources/views/macros/data-field-type.html.twig
@@ -625,7 +625,7 @@
 				<div class="panel panel-default">
 					<div class="panel-body {{ color }}">
 						{% if doCompare  %}
-							<pre class="ems-code-editor col-md-6" data-language="ace/mode/json" data-them="ace/theme/chrome">{{ compareRawData|get_string(dataField.fieldType.name)|internal_links }}</pre>
+							<pre class="ems-code-editor col-md-6" data-language="ace/mode/json" data-them="ace/theme/chrome">{{ compareRawData|get_string(dataField.fieldType.name)|json_encode|internal_links }}</pre>
 							<pre class="ems-code-editor col-md-6" data-language="ace/mode/json" data-them="ace/theme/chrome">{{ dataField.rawData|json_encode|internal_links }}</pre>
 						{% else %}
 							<pre class="ems-code-editor" data-language="ace/mode/json" data-them="ace/theme/chrome">{{ dataField.rawData|json_encode|internal_links }}</pre>
@@ -685,7 +685,7 @@
             <div class="panel panel-default">
                 <div class="panel-body {{ color }}">
                     {% if doCompare  %}
-                        <pre class="ems-code-editor col-md-6" data-language="ace/mode/json" data-them="ace/theme/chrome">{{ compareRawData|get_string(dataField.fieldType.name)|internal_links }}</pre>
+                        <pre class="ems-code-editor col-md-6" data-language="ace/mode/json" data-them="ace/theme/chrome">{{ compareRawData|get_string(dataField.fieldType.name)|json_encode|internal_links }}</pre>
                         <pre class="ems-code-editor col-md-6" data-language="ace/mode/json" data-them="ace/theme/chrome">{{ dataField.rawData|json_encode|internal_links }}</pre>
                     {% else %}
                         <pre class="ems-code-editor" data-language="ace/mode/json" data-them="ace/theme/chrome">

--- a/EMS/core-bundle/src/Routes.php
+++ b/EMS/core-bundle/src/Routes.php
@@ -43,6 +43,7 @@ class Routes
     final public const VIEW_DELETE = 'emsco_view_delete';
     final public const VIEW_DUPLICATE = 'emsco_view_duplicate';
     final public const DATA_DEFAULT_VIEW = 'emsco_data_default_view';
+    final public const DATA_LINK = 'emsco_data_link';
     final public const DATA_IN_MY_CIRCLE_VIEW = 'emsco_data_in_my_circle_view';
     final public const DATA_PUBLIC_VIEW = 'emsco_data_public_view';
     final public const DATA_PRIVATE_VIEW = 'emsco_data_private_view';

--- a/EMS/core-bundle/src/Twig/AppExtension.php
+++ b/EMS/core-bundle/src/Twig/AppExtension.php
@@ -805,16 +805,10 @@ class AppExtension extends AbstractExtension
         );
     }
 
-    public function internalLinks(?string $input, bool $asFileName = false): ?string
+    public function internalLinks(string $input, bool $asFileName = false): ?string
     {
-        if (null === $input) {
-            return null;
-        }
-
-        $regex = '/ems:(\/\/|\\\\\/\\\\\/)object:(?<key>[^\\\\|\s]*)/i';
-        $out = \preg_replace_callback($regex, function ($match) {
-            return $this->router->generate(Routes::DATA_LINK, ['key' => $match['key']], UrlGeneratorInterface::ABSOLUTE_PATH);
-        }, $input);
+        $url = $this->router->generate(Routes::DATA_LINK, ['key' => 'object:'], UrlGeneratorInterface::ABSOLUTE_PATH);
+        $out = \preg_replace('/ems:\/\/object:/i', $url, $input);
 
         if (null === $out) {
             throw new \RuntimeException('Unexpected null value');

--- a/EMS/core-bundle/src/Twig/AppExtension.php
+++ b/EMS/core-bundle/src/Twig/AppExtension.php
@@ -33,6 +33,7 @@ use EMS\CoreBundle\Form\DataField\DateRangeFieldType;
 use EMS\CoreBundle\Form\DataField\TimeFieldType;
 use EMS\CoreBundle\Form\Factory\ObjectChoiceListFactory;
 use EMS\CoreBundle\Repository\SequenceRepository;
+use EMS\CoreBundle\Routes;
 use EMS\CoreBundle\Service\ContentTypeService;
 use EMS\CoreBundle\Service\FileService;
 use EMS\CoreBundle\Service\Revision\RevisionService;
@@ -804,10 +805,16 @@ class AppExtension extends AbstractExtension
         );
     }
 
-    public function internalLinks(string $input, bool $asFileName = false): ?string
+    public function internalLinks(?string $input, bool $asFileName = false): ?string
     {
-        $url = $this->router->generate('data.link', ['key' => 'object:'], UrlGeneratorInterface::ABSOLUTE_PATH);
-        $out = \preg_replace('/ems:\/\/object:/i', $url, $input);
+        if (null === $input) {
+            return null;
+        }
+
+        $regex = '/ems:(\/\/|\\\\\/\\\\\/)object:(?<key>[^\\\\|\s]*)/i';
+        $out = \preg_replace_callback($regex, function ($match) {
+            return $this->router->generate(Routes::DATA_LINK, ['key' => $match['key']], UrlGeneratorInterface::ABSOLUTE_PATH);
+        }, $input);
 
         if (null === $out) {
             throw new \RuntimeException('Unexpected null value');


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? |  n |
| Documentation? | n  |

The internal_links is throwing an error when comparing 2 computed fieds and one has a null value.
This can happen if we change the display value on the computed field.

Also improved the internal links function, better regex which can also replace emsLink inside encoded strings.
