### PR TITLE
fix(core/api): json export remove proxy fields (__initializer__, ...)

### DIFF
--- a/EMS/core-bundle/src/Entity/Helper/JsonClass.php
+++ b/EMS/core-bundle/src/Entity/Helper/JsonClass.php
@@ -19,8 +19,18 @@ class JsonClass implements \JsonSerializable
      * @param array<mixed>         $constructorArguments
      * @param string[]             $replacedFields
      */
-    public function __construct(private array $properties, private readonly string $class, private readonly array $constructorArguments = [], private array $replacedFields = [])
-    {
+    public function __construct(
+        private array $properties,
+        private readonly string $class,
+        private readonly array $constructorArguments = [],
+        private array $replacedFields = []
+    ) {
+        $proxyFields = ['__initializer__', '__cloner__', '__isInitialized__'];
+        $this->properties = \array_filter(
+            $this->properties,
+            static fn ($v, $k) => !\in_array($k, $proxyFields, true),
+            \ARRAY_FILTER_USE_BOTH
+        );
     }
 
     public static function fromJsonString(string $jsonString): self

--- a/demo/configs/admin/wysiwyg-profile/Standard.json
+++ b/demo/configs/admin/wysiwyg-profile/Standard.json
@@ -4,10 +4,7 @@
     "properties": {
         "name": "Standard",
         "config": "{\r\n    \"plugins\": \"adv_link,uploadimage,imagebrowser,a11yhelp,basicstyles,bidi,clipboard,colorbutton,colordialog,contextmenu,dialogadvtab,div,elementspath,enterkey,entities,filebrowser,find,floatingspace,format,horizontalrule,htmlwriter,image2,indentlist,indentblock,justify,language,list,liststyle,magicline,maximize,newpage,preview,removeformat,resize,save,scayt,selectall,showborders,sourcearea,specialchar,stylescombo,tab,table,tabletools,templates,toolbar,undo,wsc,wysiwygarea\",\r\n    \"pasteFromWordRemoveFontStyles\": true,\r\n    \"pasteFromWordRemoveStyles\": true,\r\n    \"removeButtons\": \"Paste,Anchor,HorizontalRule,Underline,Strike\",\r\n    \"language\": \"en\",\r\n    \"toolbarGroups\": [\r\n        {\r\n            \"name\": \"clipboard\",\r\n            \"groups\": [\"clipboard\", \"undo\"]\r\n        },\r\n        {\r\n            \"name\": \"editing\"\r\n        },\r\n        {\r\n            \"name\": \"links\"\r\n        },\r\n        {\r\n            \"name\": \"insert\"\r\n        },\r\n        {\r\n            \"name\": \"tools\",\r\n            \"groups\": [\"mode\"]\r\n        },\r\n        {\r\n            \"name\": \"basicstyles\",\r\n            \"groups\": [\"basicstyles\", \"cleanup\"]\r\n        },\r\n        {\r\n            \"name\": \"paragraph\",\r\n            \"groups\": [\"list\", \"indent\", \"blocks\", \"align\"]\r\n        },\r\n        {\r\n            \"name\": \"styles\"\r\n        }\r\n    ]\r\n}",
-        "orderKey": 1,
-        "__initializer__": null,
-        "__cloner__": null,
-        "__isInitialized__": true
+        "orderKey": 1
     },
     "replaced": []
 }

--- a/elasticms-admin/config/packages/framework.yaml
+++ b/elasticms-admin/config/packages/framework.yaml
@@ -18,11 +18,6 @@ framework:
     validation:
         email_validation_mode: html5
 
-    http_client:
-      default_options:
-        headers:
-          'Cookie': 'XDEBUG_SESSION=PHPSTORM'
-
 when@redis:
     framework:
         session:


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

The json export for the standard wysiwyg profile contains proxy fields.
This happens because we authenticate and then request and export of wysiwyg profiles.
The profile attached too the authenticated user will already be proxy loaded by doctrine.
This explains why only the standard profile was containing these fields.


