### PR TITLE
fix(core/release): rework publish and unpublish

### DIFF
--- a/EMS/core-bundle/src/Command/Release/CreateReleaseCommand.php
+++ b/EMS/core-bundle/src/Command/Release/CreateReleaseCommand.php
@@ -11,10 +11,10 @@ use EMS\CommonBundle\Elasticsearch\Document\DocumentInterface;
 use EMS\CommonBundle\Search\Search;
 use EMS\CommonBundle\Service\ElasticaService;
 use EMS\CoreBundle\Commands;
+use EMS\CoreBundle\Core\Revision\Release\ReleaseRevisionType;
 use EMS\CoreBundle\Entity\ContentType;
 use EMS\CoreBundle\Entity\Environment;
 use EMS\CoreBundle\Entity\Release;
-use EMS\CoreBundle\Entity\ReleaseRevision;
 use EMS\CoreBundle\Service\ContentTypeService;
 use EMS\CoreBundle\Service\EnvironmentService;
 use EMS\CoreBundle\Service\ReleaseService;
@@ -93,12 +93,7 @@ class CreateReleaseCommand extends AbstractCommand
         foreach ($this->searchDocuments($search) as $document) {
             $revision = $this->revisionService->getByEmsLink(EMSLink::fromText($document->getEmsId()));
             if (null !== $revision && !$revision->isPublished($this->target->getName())) {
-                $releaseRevision = new ReleaseRevision();
-                $releaseRevision->setRelease($release);
-                $releaseRevision->setRevisionOuuid($document->getId());
-                $releaseRevision->setContentType($this->contentType);
-                $releaseRevision->setRevision($revision);
-                $release->addRevision($releaseRevision);
+                $release->addRevision($revision, ReleaseRevisionType::PUBLISH);
                 ++$revisionCount;
             }
         }

--- a/EMS/core-bundle/src/Command/Release/PublishReleaseCommand.php
+++ b/EMS/core-bundle/src/Command/Release/PublishReleaseCommand.php
@@ -42,7 +42,7 @@ class PublishReleaseCommand extends AbstractCommand
         }
 
         foreach ($releases as $release) {
-            $this->releaseService->publishRelease($release, true);
+            $this->releaseService->executeRelease($release, true);
             $output->writeln(\sprintf('Release %s has been published', $release->getName()));
         }
 

--- a/EMS/core-bundle/src/Controller/AbstractCoreController.php
+++ b/EMS/core-bundle/src/Controller/AbstractCoreController.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormInterface;
+
+abstract class AbstractCoreController extends AbstractController
+{
+    protected function getClickedButtonName(FormInterface $form): ?string
+    {
+        if (!$form instanceof Form) {
+            return null;
+        }
+
+        $clickedButton = $form->getClickedButton();
+
+        return $clickedButton instanceof FormInterface ? $clickedButton->getName() : null;
+    }
+}

--- a/EMS/core-bundle/src/Core/Revision/Release/ReleaseRevisionType.php
+++ b/EMS/core-bundle/src/Core/Revision/Release/ReleaseRevisionType.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\Core\Revision\Release;
+
+enum ReleaseRevisionType: string
+{
+    case PUBLISH = 'publish';
+    case UNPUBLISH = 'unpublish';
+}

--- a/EMS/core-bundle/src/DataTable/Type/Release/ReleaseRevisionDataTableType.php
+++ b/EMS/core-bundle/src/DataTable/Type/Release/ReleaseRevisionDataTableType.php
@@ -18,6 +18,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ReleaseRevisionDataTableType extends AbstractEntityTableType
 {
+    public const ACTION_ROLLBACK = 'rollback_action';
+
     public function __construct(
         ReleaseRevisionService $releaseRevisionService,
         private readonly ReleaseService $releaseService,
@@ -45,7 +47,7 @@ class ReleaseRevisionDataTableType extends AbstractEntityTableType
                 $table->addColumnDefinition(new TemplateBlockTableColumn('release.revision.index.column.still_in_target', 'stil_in_target', "@$this->templateNamespace/release/columns/release-revisions.html.twig"))->setLabelTransOption(['%target%' => $release->getEnvironmentTarget()->getLabel()]);
                 $table->addColumnDefinition(new TemplateBlockTableColumn('release.revision.index.column.previous', 'previous', "@$this->templateNamespace/release/columns/release-revisions.html.twig"));
                 $table->addDynamicItemGetAction(Routes::VIEW_REVISIONS, 'release.revision.index.column.compare', 'compress', ['type' => 'contentType', 'ouuid' => 'revisionOuuid', 'revisionId' => 'revision.id', 'compareId' => 'revisionBeforePublish.id'])->addCondition(new NotEmpty('revisionBeforePublish', 'revision'));
-                $table->addTableAction('rollback_action', 'fa fa-rotate-left', 'release.revision.table.rollback.action', 'release.revision.table.rollback.confirm');
+                $table->addTableAction(self::ACTION_ROLLBACK, 'fa fa-rotate-left', 'release.revision.table.rollback.action', 'release.revision.table.rollback.confirm');
                 break;
         }
     }

--- a/EMS/core-bundle/src/DataTable/Type/Release/ReleaseRevisionDataTableType.php
+++ b/EMS/core-bundle/src/DataTable/Type/Release/ReleaseRevisionDataTableType.php
@@ -46,7 +46,7 @@ class ReleaseRevisionDataTableType extends AbstractEntityTableType
             case Release::APPLIED_STATUS:
                 $table->addColumnDefinition(new TemplateBlockTableColumn('release.revision.index.column.still_in_target', 'stil_in_target', "@$this->templateNamespace/release/columns/release-revisions.html.twig"))->setLabelTransOption(['%target%' => $release->getEnvironmentTarget()->getLabel()]);
                 $table->addColumnDefinition(new TemplateBlockTableColumn('release.revision.index.column.previous', 'previous', "@$this->templateNamespace/release/columns/release-revisions.html.twig"));
-                $table->addDynamicItemGetAction(Routes::VIEW_REVISIONS, 'release.revision.index.column.compare', 'compress', ['type' => 'contentType', 'ouuid' => 'revisionOuuid', 'revisionId' => 'revision.id', 'compareId' => 'revisionBeforePublish.id'])->addCondition(new NotEmpty('revisionBeforePublish', 'revision'));
+                $table->addDynamicItemGetAction(Routes::VIEW_REVISIONS, 'release.revision.index.column.compare', 'compress', ['type' => 'contentType', 'ouuid' => 'revisionOuuid', 'revisionId' => 'revision.id', 'compareId' => 'rollbackRevision.id'])->addCondition(new NotEmpty('rollbackRevision', 'revision'));
                 $table->addTableAction(self::ACTION_ROLLBACK, 'fa fa-rotate-left', 'release.revision.table.rollback.action', 'release.revision.table.rollback.confirm');
                 break;
         }

--- a/EMS/core-bundle/src/Entity/Release.php
+++ b/EMS/core-bundle/src/Entity/Release.php
@@ -7,6 +7,7 @@ namespace EMS\CoreBundle\Entity;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use EMS\CoreBundle\Core\Revision\Release\ReleaseRevisionType;
 use EMS\CoreBundle\EMSCoreBundle;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
@@ -25,7 +26,6 @@ class Release implements EntityInterface
     final public const APPLIED_STATUS = 'applied';
     final public const CANCELED_STATUS = 'canceled';
     final public const SCHEDULED_STATUS = 'scheduled';
-    final public const ROLLBACKED_STATUS = 'rollbacked';
 
     /**
      * @ORM\Column(name="id", type="integer")
@@ -142,9 +142,15 @@ class Release implements EntityInterface
         return $this->environmentTarget;
     }
 
-    public function addRevision(ReleaseRevision $revision): Release
+    public function addRevision(Revision $revision, ReleaseRevisionType $type): Release
     {
-        $this->revisions[] = $revision;
+        $releaseRevision = new ReleaseRevision(
+            release: $this,
+            revision: $revision,
+            type: $type
+        );
+
+        $this->revisions[] = $releaseRevision;
 
         return $this;
     }

--- a/EMS/core-bundle/src/Form/Form/ReleaseType.php
+++ b/EMS/core-bundle/src/Form/Form/ReleaseType.php
@@ -18,6 +18,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class ReleaseType extends AbstractType
 {
+    public const BTN_SAVE = 'save';
+    public const BTN_SAVE_CLOSE = 'saveAndClose';
+
     public function __construct(private readonly EnvironmentService $environmentService)
     {
     }
@@ -32,9 +35,7 @@ final class ReleaseType extends AbstractType
             ->add('name', TextType::class, [
                 'required' => true,
                 'empty_data' => '',
-                'row_attr' => [
-                    'class' => 'col-md-3',
-                ],
+                'row_attr' => ['class' => 'col-md-3'],
             ])
             ->add('execution_date', DateTimeType::class, [
                 'required' => false,
@@ -46,67 +47,39 @@ final class ReleaseType extends AbstractType
                     'data-date-days-of-week-disabled' => '',
                     'data-date-disabled-hours' => '',
                 ],
-                'row_attr' => [
-                    'class' => 'col-md-6',
-                ],
+                'row_attr' => ['class' => 'col-md-6'],
             ])
             ->add('environmentSource', ChoiceType::class, [
-                'attr' => [
-                    'class' => 'select2',
-                ],
+                'attr' => ['class' => 'select2'],
                 'choices' => $this->environmentService->getEnvironments(),
                 'required' => true,
                 'choice_label' => fn (Environment $value) => '<i class="fa fa-square text-'.$value->getColor().'"></i>&nbsp;&nbsp;'.$value->getLabel(),
-                'row_attr' => [
-                    'class' => 'col-md-3',
-                ],
-                'choice_value' => function (?Environment $value) {
-                    if (null != $value) {
-                        return $value->getId();
-                    }
-
-                    return $value;
-                },
+                'row_attr' => ['class' => 'col-md-3'],
+                'choice_value' => static fn (?Environment $value) => $value?->getId(),
             ])
             ->add('environmentTarget', ChoiceType::class, [
-                'attr' => [
-                    'class' => 'select2',
-                ],
+                'attr' => ['class' => 'select2'],
                 'choices' => $this->environmentService->getEnvironments(),
                 'required' => true,
                 'choice_label' => fn (Environment $value) => '<i class="fa fa-square text-'.$value->getColor().'"></i>&nbsp;&nbsp;'.$value->getLabel(),
-                'row_attr' => [
-                    'class' => 'col-md-3',
-                ],
-                'choice_value' => function (?Environment $value) {
-                    if (null != $value) {
-                        return $value->getId();
-                    }
-
-                    return $value;
-                },
+                'row_attr' => ['class' => 'col-md-3'],
+                'choice_value' => static fn (?Environment $value) => $value?->getId(),
             ]);
 
         if ($options['add'] ?? false) {
             $builder->add('create', SubmitEmsType::class, [
-                    'attr' => [
-                        'class' => 'btn btn-primary btn-sm',
-                    ],
-                    'icon' => 'fa fa-plus',
-                    'label' => 'release.add.save',
-                ]);
+                'attr' => ['class' => 'btn btn-primary btn-sm'],
+                'icon' => 'fa fa-plus',
+                'label' => 'release.add.save',
+            ]);
         } else {
-            $builder->add('save', SubmitEmsType::class, [
-                'attr' => [
-                    'class' => 'btn btn-default btn-sm',
-                ],
+            $builder->add(self::BTN_SAVE, SubmitEmsType::class, [
+                'attr' => ['class' => 'btn btn-default btn-sm'],
                 'icon' => 'fa fa-save',
                 'label' => 'release.edit.save',
             ])
-            ->add('saveAndClose', SubmitEmsType::class, [
-                'attr' => [
-                    'class' => 'btn btn-default btn-sm',
-                ],
+            ->add(self::BTN_SAVE_CLOSE, SubmitEmsType::class, [
+                'attr' => ['class' => 'btn btn-default btn-sm'],
                 'icon' => 'fa fa-save',
                 'label' => 'release.edit.saveAndClose',
             ]);

--- a/EMS/core-bundle/src/Repository/ReleaseRevisionRepository.php
+++ b/EMS/core-bundle/src/Repository/ReleaseRevisionRepository.php
@@ -94,7 +94,7 @@ final class ReleaseRevisionRepository extends ServiceEntityRepository
             ->orderBy(\sprintf('rr.%s', $orderField ?? 'id'), $orderDirection)
             ->setFirstResult($from)
             ->setMaxResults($size)
-            ->setParameters([ 'release' => $release]);
+            ->setParameters(['release' => $release]);
 
         return $qb->getQuery()->execute();
     }

--- a/EMS/core-bundle/src/Repository/ReleaseRevisionRepository.php
+++ b/EMS/core-bundle/src/Repository/ReleaseRevisionRepository.php
@@ -87,13 +87,14 @@ final class ReleaseRevisionRepository extends ServiceEntityRepository
     public function findByRelease(Release $release, int $from, int $size, ?string $orderField, string $orderDirection, string $searchValue): array
     {
         $qb = $this->createQueryBuilder('rr');
-        $qb->where($qb->expr()->eq('rr.release', ':release'))
-            ->setParameters([
-                'release' => $release,
-            ]);
-        $qb->orderBy(\sprintf('rr.%s', $orderField ?? 'id'), $orderDirection);
-        $qb->setFirstResult($from);
-        $qb->setMaxResults($size);
+        $qb
+            ->join('rr.revision', 'r')
+            ->andWhere($qb->expr()->eq('r.deleted', $qb->expr()->literal(false)))
+            ->andWhere($qb->expr()->eq('rr.release', ':release'))
+            ->orderBy(\sprintf('rr.%s', $orderField ?? 'id'), $orderDirection)
+            ->setFirstResult($from)
+            ->setMaxResults($size)
+            ->setParameters([ 'release' => $release]);
 
         return $qb->getQuery()->execute();
     }
@@ -101,14 +102,14 @@ final class ReleaseRevisionRepository extends ServiceEntityRepository
     public function countByRelease(Release $release, string $searchValue): int
     {
         $qb = $this->createQueryBuilder('rr');
-        $qb->where($qb->expr()->eq('rr.release', ':release'))
-            ->setParameters([
-                'release' => $release,
-            ]);
-        $qb->select('count(rr)');
-        $query = $qb->getQuery();
+        $qb
+            ->select('count(rr)')
+            ->join('rr.revision', 'r')
+            ->andWhere($qb->expr()->eq('r.deleted', $qb->expr()->literal(false)))
+            ->andWhere($qb->expr()->eq('rr.release', ':release'))
+            ->setParameters(['release' => $release]);
 
-        return \intval($query->getSingleScalarResult());
+        return \intval($qb->getQuery()->getSingleScalarResult());
     }
 
     /**

--- a/EMS/core-bundle/src/Resources/DoctrineMigrations/pdo_mysql/Version20240612125911.php
+++ b/EMS/core-bundle/src/Resources/DoctrineMigrations/pdo_mysql/Version20240612125911.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240612125911 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Release revision add type and rename column';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof MySQLPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MySQLPlatform'."
+        );
+
+        $this->addSql('ALTER TABLE release_revision DROP FOREIGN KEY FK_3663CEADFBFE9068');
+        $this->addSql('DROP INDEX IDX_3663CEADFBFE9068 ON release_revision');
+        $this->addSql('ALTER TABLE release_revision CHANGE revision_id revision_id INT NOT NULL, CHANGE revision_before_publish_id rollback_revision_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE release_revision ADD CONSTRAINT FK_3663CEAD5B35C530 FOREIGN KEY (rollback_revision_id) REFERENCES revision (id)');
+        $this->addSql('CREATE INDEX IDX_3663CEAD5B35C530 ON release_revision (rollback_revision_id)');
+
+        $this->addSql('ALTER TABLE release_revision ADD type LONGTEXT DEFAULT NULL');
+        $this->addSql('UPDATE release_revision SET type = \'publish\' WHERE revision_id IS NOT NULL');
+        $this->addSql('UPDATE release_revision SET type = \'unpublish\' WHERE revision_id IS NULL');
+        $this->addSql('ALTER TABLE release_revision CHANGE type type LONGTEXT NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof MySQLPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MySQLPlatform'."
+        );
+
+        $this->addSql('ALTER TABLE release_revision DROP FOREIGN KEY FK_3663CEAD5B35C530');
+        $this->addSql('DROP INDEX IDX_3663CEAD5B35C530 ON release_revision');
+        $this->addSql('ALTER TABLE release_revision DROP type, CHANGE revision_id revision_id INT DEFAULT NULL, CHANGE rollback_revision_id revision_before_publish_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE release_revision ADD CONSTRAINT FK_3663CEADFBFE9068 FOREIGN KEY (revision_before_publish_id) REFERENCES revision (id)');
+        $this->addSql('CREATE INDEX IDX_3663CEADFBFE9068 ON release_revision (revision_before_publish_id)');
+    }
+}

--- a/EMS/core-bundle/src/Resources/DoctrineMigrations/pdo_pgsql/Version20240612124507.php
+++ b/EMS/core-bundle/src/Resources/DoctrineMigrations/pdo_pgsql/Version20240612124507.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240612124507 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Release revision add type and rename column';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\PostgreSQLPlatform'."
+        );
+
+        $this->addSql('ALTER TABLE release_revision DROP CONSTRAINT fk_3663ceadfbfe9068');
+        $this->addSql('DROP INDEX idx_3663ceadfbfe9068');
+        $this->addSql('ALTER TABLE release_revision RENAME COLUMN revision_before_publish_id TO rollback_revision_id');
+        $this->addSql('ALTER TABLE release_revision ADD CONSTRAINT FK_3663CEAD5B35C530 FOREIGN KEY (rollback_revision_id) REFERENCES revision (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('CREATE INDEX IDX_3663CEAD5B35C530 ON release_revision (rollback_revision_id)');
+
+        $this->addSql('ALTER TABLE release_revision ADD type TEXT DEFAULT NULL');
+        $this->addSql('UPDATE release_revision SET type = \'publish\' WHERE revision_id IS NOT NULL');
+        $this->addSql('UPDATE release_revision SET type = \'unpublish\' WHERE revision_id IS NULL');
+        $this->addSql('ALTER TABLE release_revision ALTER type SET NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\PostgreSQLPlatform'."
+        );
+
+        $this->addSql('ALTER TABLE release_revision DROP CONSTRAINT FK_3663CEAD5B35C530');
+        $this->addSql('DROP INDEX IDX_3663CEAD5B35C530');
+        $this->addSql('ALTER TABLE release_revision RENAME COLUMN rollback_revision_id TO revision_before_publish_id');
+        $this->addSql('ALTER TABLE release_revision ADD CONSTRAINT fk_3663ceadfbfe9068 FOREIGN KEY (revision_before_publish_id) REFERENCES revision (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('CREATE INDEX idx_3663ceadfbfe9068 ON release_revision (revision_before_publish_id)');
+
+        $this->addSql('ALTER TABLE release_revision DROP type');
+    }
+}

--- a/EMS/core-bundle/src/Resources/views/release/columns/release-revisions.html.twig
+++ b/EMS/core-bundle/src/Resources/views/release/columns/release-revisions.html.twig
@@ -41,17 +41,13 @@
 {% endblock revision %}
 
 {% block action %}
-    {% if data.revision %}
-        {{ 'release.release-revisison.publish'|trans }}
-    {% else %}
-        {{ 'release.release-revisison.unpublish'|trans }}
-    {% endif %}
+    {{ "release.release-revisison.#{data.type.value}"|trans }}
 {% endblock action %}
 
 {% block previous %}
-    {% if data.revisionBeforePublish %}
-        <a href="{{ path('emsco_view_revisions', {ouuid: data.revisionBeforePublish.ouuid, type: data.revisionBeforePublish.contentType.name, revisionId: data.revisionBeforePublish.id}) }}">
-            {{ 'release.release-revisison.revision'|trans({ '%date%' : data.revisionBeforePublish.created|date(date_time_format) ,'%user%' : data.revisionBeforePublish.finalizedBy|default('')|displayname }) }}
+    {% if data.revisionRollback %}
+        <a href="{{ path('emsco_view_revisions', {ouuid: data.revisionRollback.ouuid, type: data.revisionRollback.contentType.name, revisionId: data.revisionRollback.id}) }}">
+            {{ 'release.release-revisison.revision'|trans({ '%date%' : data.revisionRollback.created|date(date_time_format) ,'%user%' : data.revisionRollback.finalizedBy|default('')|displayname }) }}
         </a>
     {% else %}
         <span class="text-muted">
@@ -72,8 +68,8 @@
         {% set stil_in_target = (revisionTarget ? true : false) %}
     {% endif %}
     {%  if stil_in_target %}
-        <i class="fa fa-check-square"><span class="sr-only"</span>{{ 'release.release-revisison.still_in_target'|trans({'%target%': data.release.environmentTarget.label}) }}</i>
+        <i class="fa fa-check-square"><span class="sr-only">{{ 'release.release-revisison.still_in_target'|trans({'%target%': data.release.environmentTarget.label}) }}</span></i>
     {% else %}
-        <i class="fa fa-square-o"><span class="sr-only"</span>{{ 'release.release-revisison.no_more_in_target'|trans({'%target%': data.release.environmentTarget.label})  }}</i>
+        <i class="fa fa-square-o"><span class="sr-only">{{ 'release.release-revisison.no_more_in_target'|trans({'%target%': data.release.environmentTarget.label})  }}</span></i>
     {% endif %}
 {% endblock stil_in_target %}

--- a/EMS/core-bundle/src/Resources/views/release/columns/release-revisions.html.twig
+++ b/EMS/core-bundle/src/Resources/views/release/columns/release-revisions.html.twig
@@ -45,9 +45,9 @@
 {% endblock action %}
 
 {% block previous %}
-    {% if data.revisionRollback %}
-        <a href="{{ path('emsco_view_revisions', {ouuid: data.revisionRollback.ouuid, type: data.revisionRollback.contentType.name, revisionId: data.revisionRollback.id}) }}">
-            {{ 'release.release-revisison.revision'|trans({ '%date%' : data.revisionRollback.created|date(date_time_format) ,'%user%' : data.revisionRollback.finalizedBy|default('')|displayname }) }}
+    {% if data.rollbackRevision %}
+        <a href="{{ path('emsco_view_revisions', {ouuid: data.rollbackRevision.ouuid, type: data.rollbackRevision.contentType.name, revisionId: data.rollbackRevision.id}) }}">
+            {{ 'release.release-revisison.revision'|trans({ '%date%' : data.rollbackRevision.created|date(date_time_format) ,'%user%' : data.rollbackRevision.finalizedBy|default('')|displayname }) }}
         </a>
     {% else %}
         <span class="text-muted">
@@ -61,7 +61,7 @@
     {% if data.revision %}
         {% set info = data.revision.emsLink|emsco_document_info %}
         {% set revision = info.getRevision(data.release.environmentTarget) %}
-        {% set stil_in_target = (data.revision.id is same as (revision.id)) %}
+        {% set stil_in_target = (data.revision.id is same as (revision.id|default(null))) %}
     {% else %}
         {% set info = data.emsId|emsco_document_info %}
         {% set revisionTarget = info.getRevision(data.release.environmentTarget.name) %}


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  |  n |
| Fixed tickets? | #843  |
| Documentation? | n  |

- Renamed column revision_before_publish_id -> rollback_revision_id
- Revision on ReleaseRevision not nullable
- Add new type on releaseRevision managed by enum
- Rework publish and unpublish
- Rework rollback publish and unpublish

Extra:
Introduced ` AbstractCoreController`, the idea is that in the future all core controllers extends this one.
Currently this coreController class adds a helper function for getting the clicked button in a submitted form
