### PR TITLE
fix(core/mediaLib): wrong import inputOption

### DIFF
--- a/EMS/core-bundle/src/Command/MediaLibrary/AbstractMediaLibraryCommand.php
+++ b/EMS/core-bundle/src/Command/MediaLibrary/AbstractMediaLibraryCommand.php
@@ -8,7 +8,7 @@ use EMS\CommonBundle\Common\Command\AbstractCommand;
 use EMS\CoreBundle\Core\Component\MediaLibrary\Config\MediaLibraryConfig;
 use EMS\CoreBundle\Core\Component\MediaLibrary\Config\MediaLibraryConfigFactory;
 use EMS\CoreBundle\Core\Component\MediaLibrary\MediaLibraryService;
-use MonorepoBuilderPrefix202311\Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 

--- a/EMS/core-bundle/src/Command/MediaLibrary/MediaLibraryFolderDeleteCommand.php
+++ b/EMS/core-bundle/src/Command/MediaLibrary/MediaLibraryFolderDeleteCommand.php
@@ -7,7 +7,7 @@ namespace EMS\CoreBundle\Command\MediaLibrary;
 use EMS\CoreBundle\Command\JobOutput;
 use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Core\Component\MediaLibrary\Folder\MediaLibraryFolder;
-use MonorepoBuilderPrefix202311\Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;

--- a/EMS/core-bundle/src/Command/MediaLibrary/MediaLibraryFolderRenameCommand.php
+++ b/EMS/core-bundle/src/Command/MediaLibrary/MediaLibraryFolderRenameCommand.php
@@ -8,7 +8,7 @@ use EMS\CoreBundle\Command\JobOutput;
 use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Core\Component\MediaLibrary\Folder\MediaLibraryFolder;
 use EMS\CoreBundle\Core\Component\MediaLibrary\MediaLibraryDocument;
-use MonorepoBuilderPrefix202311\Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

My bad wrong import in media lib commands.
This makes the rename and delete folder command not working inside our images.
This is in from version 5.14.0
