### PR TITLE
fix(common/storage): S3StreamPromise read

### DIFF
--- a/EMS/common-bundle/src/Storage/Processor/Config.php
+++ b/EMS/common-bundle/src/Storage/Processor/Config.php
@@ -66,7 +66,7 @@ final class Config
         }
 
         if (null === $this->filename) {
-            throw new NotFoundHttpException('File not found');
+            throw new NotFoundHttpException(\sprintf('File %s not found', $this->filename));
         }
 
         if ($this->hasDefaultMimeType()) {

--- a/EMS/common-bundle/src/Storage/Processor/Processor.php
+++ b/EMS/common-bundle/src/Storage/Processor/Processor.php
@@ -8,6 +8,7 @@ use EMS\CommonBundle\Helper\Cache;
 use EMS\CommonBundle\Helper\EmsFields;
 use EMS\CommonBundle\Storage\NotFoundException;
 use EMS\CommonBundle\Storage\StorageManager;
+use EMS\Helpers\File\File;
 use EMS\Helpers\Html\Headers;
 use EMS\Helpers\Standard\Json;
 use GuzzleHttp\Psr7\Stream;
@@ -23,8 +24,6 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class Processor
 {
-    final public const BUFFER_SIZE = 8192;
-
     public function __construct(
         private readonly StorageManager $storageManager,
         private readonly LoggerInterface $logger,
@@ -237,7 +236,7 @@ class Processor
             }
 
             while (!$stream->eof()) {
-                echo $stream->read(self::BUFFER_SIZE);
+                echo $stream->read(File::DEFAULT_CHUNK_SIZE);
             }
             $stream->close();
         });
@@ -267,7 +266,7 @@ class Processor
 
             $response->setCallback(function () use ($stream, $streamRange) {
                 $offset = $streamRange->getStart();
-                $buffer = self::BUFFER_SIZE;
+                $buffer = File::DEFAULT_CHUNK_SIZE;
                 $stream->seek($offset);
                 while (!$stream->eof() && ($offset = $stream->tell()) < $streamRange->getEnd()) {
                     if ($offset + $buffer > $streamRange->getEnd()) {

--- a/EMS/common-bundle/src/Storage/Service/S3Storage.php
+++ b/EMS/common-bundle/src/Storage/Service/S3Storage.php
@@ -172,7 +172,7 @@ class S3Storage extends AbstractUrlStorage
             $confirmed = true;
         }
 
-        return parent::read($hash, $confirmed);
+        return new S3StreamPromise($this->getS3Client(), $this->bucket, $confirmed ? $this->key($hash) : $this->uploadKey($hash));
     }
 
     public function initFinalize(string $hash): void

--- a/EMS/common-bundle/src/Storage/Service/S3StreamPromise.php
+++ b/EMS/common-bundle/src/Storage/Service/S3StreamPromise.php
@@ -62,7 +62,7 @@ class S3StreamPromise implements StreamInterface
         return $this->offset;
     }
 
-    public function eof()
+    public function eof(): bool
     {
         return $this->offset >= $this->getSize();
     }
@@ -99,7 +99,7 @@ class S3StreamPromise implements StreamInterface
         return false;
     }
 
-    public function write(string $string)
+    public function write(string $string): never
     {
         throw new \RuntimeException('Write is not supported');
     }
@@ -135,7 +135,7 @@ class S3StreamPromise implements StreamInterface
         return $this->read($this->getSize() - $this->offset);
     }
 
-    public function getMetadata(?string $key = null)
+    public function getMetadata(?string $key = null): never
     {
         throw new \RuntimeException('Metadata are not supported in ElasticMS storage services');
     }

--- a/EMS/common-bundle/src/Storage/Service/S3StreamPromise.php
+++ b/EMS/common-bundle/src/Storage/Service/S3StreamPromise.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CommonBundle\Storage\Service;
+
+use Aws\S3\S3Client;
+use EMS\Helpers\Standard\Type;
+use Psr\Http\Message\StreamInterface;
+
+class S3StreamPromise implements StreamInterface
+{
+    private ?int $size = null;
+    private int $offset = 0;
+    private string $contents;
+
+    public function __construct(private readonly S3Client $s3Client, private readonly string $bucket, private readonly string $key)
+    {
+    }
+
+    public function __toString(): string
+    {
+        $result = $this->s3Client->getObject([
+            'Bucket' => $this->bucket,
+            'Key' => $this->key,
+        ]);
+        $stream = $result['Body'] ?? null;
+        if (!$stream instanceof StreamInterface) {
+            throw new \RuntimeException('Unexpected non StreamInterface from S3 bucket');
+        }
+
+        return $stream->getContents();
+    }
+
+    public function close(): void
+    {
+    }
+
+    public function detach()
+    {
+        return null;
+    }
+
+    public function getSize(): int
+    {
+        if (null !== $this->size) {
+            return $this->size;
+        }
+        $result = $this->s3Client->getObject([
+            'Bucket' => $this->bucket,
+            'Key' => $this->key,
+            'Range' => 'bytes=0-0',
+        ]);
+        $contentRangeExploded = \explode('/', Type::string($result['ContentRange'] ?? null));
+        $this->size = \intval(\end($contentRangeExploded));
+
+        return $this->size;
+    }
+
+    public function tell(): int
+    {
+        return $this->offset;
+    }
+
+    public function eof()
+    {
+        return $this->offset >= $this->getSize();
+    }
+
+    public function isSeekable(): bool
+    {
+        return true;
+    }
+
+    public function seek(int $offset, int $whence = SEEK_SET): void
+    {
+        switch ($whence) {
+            case SEEK_SET:
+                $this->offset = $offset;
+                break;
+            case SEEK_CUR:
+                $this->offset += $offset;
+                break;
+            case SEEK_END:
+                $this->offset = $this->getSize() + $offset;
+                break;
+            default:
+                throw new \InvalidArgumentException('Invalid whence');
+        }
+    }
+
+    public function rewind(): void
+    {
+        $this->offset = 0;
+    }
+
+    public function isWritable(): bool
+    {
+        return false;
+    }
+
+    public function write(string $string)
+    {
+        throw new \RuntimeException('Write is not supported');
+    }
+
+    public function isReadable(): bool
+    {
+        return true;
+    }
+
+    public function read(int $length): string
+    {
+        $endOffset = \min($this->offset + $length - 1, $this->getSize() - 1);
+        $result = $this->s3Client->getObject([
+            'Bucket' => $this->bucket,
+            'Key' => $this->key,
+            'Range' => \sprintf('bytes=%d-%d', $this->offset, $endOffset),
+        ]);
+        $this->offset += $length;
+        if ($this->offset > $this->getSize()) {
+            $this->offset = $this->getSize();
+        }
+        $stream = $result['Body'] ?? null;
+        if (!$stream instanceof StreamInterface) {
+            throw new \RuntimeException('Unexpected non StreamInterface from S3 bucket');
+        }
+        $this->contents = $stream->getContents();
+
+        return $this->contents;
+    }
+
+    public function getContents(): string
+    {
+        return $this->read($this->getSize() - $this->offset);
+    }
+
+    public function getMetadata(?string $key = null)
+    {
+        throw new \RuntimeException('Metadata are not supported in ElasticMS storage services');
+    }
+}

--- a/EMS/common-bundle/src/Storage/StorageManager.php
+++ b/EMS/common-bundle/src/Storage/StorageManager.php
@@ -10,6 +10,7 @@ use EMS\CommonBundle\Storage\File\FileInterface;
 use EMS\CommonBundle\Storage\File\LocalFile;
 use EMS\CommonBundle\Storage\File\StorageFile;
 use EMS\CommonBundle\Storage\Service\StorageInterface;
+use EMS\Helpers\File\File;
 use EMS\Helpers\Standard\Json;
 use Psr\Http\Message\StreamInterface;
 use Psr\Log\LoggerInterface;
@@ -193,7 +194,7 @@ class StorageManager
         }
         $hashContext = \hash_init($this->hashAlgo);
         while (!$handler->eof()) {
-            \hash_update($hashContext, $handler->read(1024 * 1024));
+            \hash_update($hashContext, $handler->read(File::DEFAULT_CHUNK_SIZE));
         }
 
         return \hash_final($hashContext);

--- a/EMS/helpers/src/File/File.php
+++ b/EMS/helpers/src/File/File.php
@@ -14,7 +14,7 @@ class File
     public string $mimeType;
     public int $size;
 
-    public const DEFAULT_CHUNK_SIZE = 8 * 1024 * 1024;
+    public const DEFAULT_CHUNK_SIZE = 4 * 1024 * 1024;
 
     public function __construct(private readonly \SplFileInfo $file)
     {


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

The default  S3 StreamWrapper need tmp space, as big as the file, to be able to seek. As the range values are not known in the getStream we can't just return the Stream from the getObject.
