### PR TITLE
fix(cli): load twig bundle for (ems:batch) command

### DIFF
--- a/EMS/common-bundle/composer.json
+++ b/EMS/common-bundle/composer.json
@@ -51,6 +51,7 @@
 		"symfony/serializer": "^5.4",
 		"symfony/stopwatch": "^5.4",
 		"symfony/translation": "^5.4",
+        "symfony/twig-bundle": "^5.4",
 		"twig/cache-extra": "^3.4",
 		"twig/cssinliner-extra": "^3.4",
 		"twig/extra-bundle": "^3.4",

--- a/elasticms-cli/config/bundles.php
+++ b/elasticms-cli/config/bundles.php
@@ -2,7 +2,9 @@
 
 return [
     Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
+    Symfony\Bundle\TwigBundle\TwigBundle::class => ['all' => true],
     Doctrine\Bundle\DoctrineBundle\DoctrineBundle::class => ['all' => true],
     EMS\CommonBundle\EMSCommonBundle::class => ['all' => true],
     Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle::class => ['all' => true],
+    Twig\Extra\TwigExtraBundle\TwigExtraBundle::class => ['all' => true],
 ];

--- a/elasticms-cli/config/packages/twig.yaml
+++ b/elasticms-cli/config/packages/twig.yaml
@@ -1,0 +1,5 @@
+twig:
+    debug: '%kernel.debug%'
+    strict_variables: '%kernel.debug%'
+    auto_reload: true
+    exception_controller: null


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

CLI app now needs twig, used by ems:batch command
