### PR TITLE
fix(core): environment modal(s) showing on page load

### DIFF
--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/environment/index.html.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/environment/index.html.twig
@@ -238,7 +238,7 @@
 
 
             {% for environment in environments %}
-                <div class="modal fade in" id="modal-environment-{{ environment.id }}">
+                <div class="modal fade" id="modal-environment-{{ environment.id }}">
                     <div class="modal-dialog">
                         <div class="modal-content">
                             <div class="modal-header">

--- a/EMS/core-bundle/src/Resources/views/environment/index.html.twig
+++ b/EMS/core-bundle/src/Resources/views/environment/index.html.twig
@@ -125,7 +125,7 @@
 
 
             {% for environment in environments %}
-                <div class="modal fade in" id="modal-environment-{{ environment.id }}">
+                <div class="modal fade" id="modal-environment-{{ environment.id }}">
                     <div class="modal-dialog">
                         <div class="modal-content">
                             <div class="modal-header">


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

In previous pr https://github.com/ems-project/elasticms/pull/925:

We added modal-size-auto for supporting responsive modals, but environment modals already have the class in on page load.
This is not correct.

