### PR TITLE
fix(admin): environment not existing thows 500 error

### DIFF
--- a/EMS/common-bundle/src/Service/ElasticaService.php
+++ b/EMS/common-bundle/src/Service/ElasticaService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace EMS\CommonBundle\Service;
 
 use Elastica\Aggregation\Terms as TermsAggregation;
+use Elastica\Index;
 use Elastica\Query;
 use Elastica\Query\AbstractQuery;
 use Elastica\Query\BoolQuery;
@@ -317,6 +318,11 @@ class ElasticaService
         }
 
         return $this->client->getIndex($indexName)->getAliases();
+    }
+
+    public function getIndex(string $alias): Index
+    {
+        return $this->client->getIndex($alias);
     }
 
     public function getIndexFromAlias(string $alias): string

--- a/EMS/common-bundle/src/Service/ElasticaService.php
+++ b/EMS/common-bundle/src/Service/ElasticaService.php
@@ -426,6 +426,10 @@ class ElasticaService
      */
     public function getDocument(string $index, ?string $contentType, string $id, array $sourceIncludes = [], array $sourcesExcludes = [], ?AbstractQuery $query = null): Document
     {
+        if (!$this->getIndex($index)->exists()) {
+            throw new NotFoundException($id, $index);
+        }
+
         $contentTypes = [];
         if (null !== $contentType) {
             $contentTypes[] = $contentType;
@@ -444,7 +448,7 @@ class ElasticaService
             return $this->singleSearch($search);
         } catch (NotSingleResultException $e) {
             if (0 === $e->getTotal()) {
-                throw new NotFoundException();
+                throw new NotFoundException($id, $index);
             }
             throw $e;
         }

--- a/EMS/common-bundle/src/Service/ElasticaService.php
+++ b/EMS/common-bundle/src/Service/ElasticaService.php
@@ -210,7 +210,6 @@ class ElasticaService
         $search = clone $search;
         $search->setSort(null);
         $elasticaSearch = $this->createElasticaSearch($search, $search->getScrollOptions());
-        $elasticaSearch->addIndicesByName($this->getIndices($search));
 
         return new EmsScroll($elasticaSearch, $expiryTime);
     }

--- a/EMS/core-bundle/src/Controller/ContentManagement/ContentTypeController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/ContentTypeController.php
@@ -399,7 +399,7 @@ class ContentTypeController extends AbstractController
 
         $inputContentType = $request->request->all('content_type');
         try {
-            $mapping = $this->mappingService->getMapping([$environment->getName()]);
+            $mapping = $this->mappingService->getMapping($environment);
         } catch (\Throwable) {
             $this->logger->warning('log.contenttype.mapping.not_found', [
                 EmsFields::LOG_CONTENTTYPE_FIELD => $contentType->getName(),

--- a/EMS/core-bundle/src/Controller/ContentManagement/EnvironmentController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/EnvironmentController.php
@@ -502,7 +502,7 @@ class EnvironmentController extends AbstractController
         }
 
         try {
-            $info = $this->mapping->getMapping([$environment->getName()]);
+            $info = $this->mapping->getMapping($environment);
         } catch (NotFoundException $e) {
             $this->logger->error('log.environment.alias_missing', [
                 EmsFields::LOG_ERROR_MESSAGE_FIELD => $e->getMessage(),

--- a/EMS/core-bundle/src/Form/View/HierarchicalViewType.php
+++ b/EMS/core-bundle/src/Form/View/HierarchicalViewType.php
@@ -64,7 +64,7 @@ class HierarchicalViewType extends ViewType
         /** @var View $view */
         $view = $options['view'];
         $environment = $view->getContentType()->giveEnvironment();
-        $mapping = $this->mapping->getMapping([$environment->getName()]);
+        $mapping = $this->mapping->getMapping($environment);
 
         $fieldType = new FieldType();
 

--- a/EMS/core-bundle/src/Form/View/SorterViewType.php
+++ b/EMS/core-bundle/src/Form/View/SorterViewType.php
@@ -64,7 +64,7 @@ class SorterViewType extends ViewType
         $mapping = [];
 
         if (null !== $environment = $view->getContentType()->getEnvironment()) {
-            $mapping = $this->mapping->getMapping([$environment->getName()]);
+            $mapping = $this->mapping->getMapping($environment);
         }
 
         $builder

--- a/EMS/core-bundle/src/Resources/config/services.xml
+++ b/EMS/core-bundle/src/Resources/config/services.xml
@@ -252,7 +252,6 @@
         <service id="ems.service.mapping" class="EMS\CoreBundle\Service\Mapping">
             <argument type="service" id="emsco.logger" />
             <argument type="service" id="ems_common.elastica.client" />
-            <argument type="service" id="ems.service.environment" />
             <argument type="service" id="ems.form.fieldtype.fieldtypetype" />
             <argument type="service" id="ems.service.elasticsearch" />
             <argument type="service" id="ems_common.service.elastica" />

--- a/EMS/core-bundle/src/Service/Mapping.php
+++ b/EMS/core-bundle/src/Service/Mapping.php
@@ -43,7 +43,7 @@ class Mapping
     final public const INSTANCE_ID_META_FIELD = 'instance_id';
     final public const PUBLISHED_DATETIME_FIELD = '_published_datetime';
 
-    public function __construct(private readonly LoggerInterface $logger, private readonly Client $elasticaClient, private readonly EnvironmentService $environmentService, private readonly FieldTypeType $fieldTypeType, private readonly ElasticsearchService $elasticsearchService, private readonly ElasticaService $elasticaService, private readonly string $instanceId)
+    public function __construct(private readonly LoggerInterface $logger, private readonly Client $elasticaClient, private readonly FieldTypeType $fieldTypeType, private readonly ElasticsearchService $elasticsearchService, private readonly ElasticaService $elasticaService, private readonly string $instanceId)
     {
     }
 

--- a/EMS/core-bundle/src/Service/Mapping.php
+++ b/EMS/core-bundle/src/Service/Mapping.php
@@ -11,6 +11,7 @@ use EMS\CommonBundle\Helper\EmsFields;
 use EMS\CommonBundle\Service\ElasticaService;
 use EMS\CoreBundle\Entity\ContentType;
 use EMS\CoreBundle\Entity\DataField;
+use EMS\CoreBundle\Entity\Environment;
 use EMS\CoreBundle\Form\FieldType\FieldTypeType;
 use Psr\Log\LoggerInterface;
 
@@ -114,20 +115,14 @@ class Mapping
     }
 
     /**
-     * @param string[] $environmentNames
-     *
      * @return ?array<string, mixed>
      */
-    public function getMapping(array $environmentNames): ?array
+    public function getMapping(Environment ...$environments): ?array
     {
         $mergeMapping = [];
-        foreach ($environmentNames as $environmentName) {
+        foreach ($environments as $environment) {
             try {
-                $environment = $this->environmentService->getByName($environmentName);
-                if (false === $environment) {
-                    continue;
-                }
-                $mappings = $this->elasticaClient->getIndex($environment->getAlias())->getMapping();
+                $mappings = $this->elasticaService->getIndex($environment->getAlias())->getMapping();
 
                 if (isset($mappings['properties'])) {
                     $mergeMapping = $this->mergeMappings($mappings['properties'], $mergeMapping);

--- a/EMS/core-bundle/src/Service/SearchService.php
+++ b/EMS/core-bundle/src/Service/SearchService.php
@@ -57,7 +57,12 @@ class SearchService
 
     public function generateSearch(Search $search): CommonSearch
     {
-        $mapping = $this->mapping->getMapping($search->getEnvironments());
+        $environments = \array_filter(
+            \array_map(fn (string $name) => $this->environmentService->giveByName($name), $search->getEnvironments()),
+            fn (Environment $e) => $this->elasticaService->getIndex($e->getAlias())->exists()
+        );
+
+        $mapping = $this->mapping->getMapping(...$environments);
 
         $boolQuery = $this->elasticaService->getBoolQuery();
 
@@ -92,15 +97,7 @@ class SearchService
             $boolQuery = null;
         }
 
-        $indexes = [];
-        foreach ($search->getEnvironments() as $environmentName) {
-            $environment = $this->environmentService->getByName($environmentName);
-            if (!$environment instanceof Environment) {
-                throw new \RuntimeException(\sprintf('Environment %s not found', $environmentName));
-            }
-            $indexes[] = $environment->getAlias();
-        }
-
+        $indexes = \array_map(static fn (Environment $e) => $e->getAlias(), $environments);
         $commonSearch = new CommonSearch($indexes, $this->elasticaService->filterByContentTypes($boolQuery, $search->getContentTypes()));
 
         $sortBy = $search->getSortBy();

--- a/EMS/core-bundle/src/Service/SearchService.php
+++ b/EMS/core-bundle/src/Service/SearchService.php
@@ -59,7 +59,7 @@ class SearchService
     {
         $environments = \array_filter(
             \array_map(fn (string $name) => $this->environmentService->giveByName($name), $search->getEnvironments()),
-            fn (Environment $e) => $this->elasticaService->getIndex($e->getAlias())->exists()
+            fn (Environment $e) => $this->elasticaService->hasIndex($e->getAlias())
         );
 
         $mapping = $this->mapping->getMapping(...$environments);

--- a/EMS/core-bundle/src/Service/SearchService.php
+++ b/EMS/core-bundle/src/Service/SearchService.php
@@ -117,8 +117,7 @@ class SearchService
 
     public function getDocument(ContentType $contentType, string $ouuid, ?Environment $environment = null): ElasticsearchDocument
     {
-        $environment ??= $contentType->giveEnvironment();
-        $index = $this->contentTypeService->getIndex($contentType, $environment);
+        $index = $environment?->getAlias() ?? $contentType->giveEnvironment()->getAlias();
         $searchQuery = null;
 
         if ($contentType->hasVersionTags() && null !== $dateToField = $contentType->getVersionDateToField()) {


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

**Problem:**
When we have for example and external environment without an index. Revision detail pages are not working, because we are searching on the external environment for referrers. Also old search views throws errors.
Views making a dataLink to an external environment without an index is also not working.

**Solution:**
Check if the index is existing before searching

Check detailed commit messages
