### PR TITLE
fix(common/storage): return 404 response on not found

### DIFF
--- a/EMS/common-bundle/src/Storage/Processor/Processor.php
+++ b/EMS/common-bundle/src/Storage/Processor/Processor.php
@@ -80,9 +80,12 @@ class Processor
             return $cacheResponse;
         }
 
-        $stream = $this->getStream($config, $filename);
-
-        $response = $this->getResponseFromStreamInterface($stream, $request);
+        try {
+            $stream = $this->getStream($config, $filename);
+            $response = $this->getResponseFromStreamInterface($stream, $request);
+        } catch (NotFoundException) {
+            return new Response(null, Response::HTTP_NOT_FOUND);
+        }
 
         $response->headers->add([
             Headers::CONTENT_DISPOSITION => $config->getDisposition().'; '.HeaderUtils::toString(['filename' => $filename], ';'),


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  |  n |
| Fixed tickets? | n  |
| Documentation? | n  |

Problem:

/file/b693472833bc8d9771a3a17040e0546bb1f4d824/fe03ebfa30efdecc1434f4e67d4390397a037035/example.png is returning a 500 error instead of a 404 error.

Solution: 

Handle the exception and return a 404 response
