### PR TITLE
chore(admin/web): improve dev logging (doctrine)

### DIFF
--- a/elasticms-admin/bin/console
+++ b/elasticms-admin/bin/console
@@ -12,13 +12,14 @@ $_SERVER['ELASTICMS_PATH'] = file_exists(dirname(__DIR__).'/vendor/elasticms') ?
     dirname(__DIR__).'/vendor/elasticms' :
     dirname(__DIR__).'/../EMS';
 
+$_SERVER['LOG_LEVEL'] = 400;
 $_SERVER['APP_RUNTIME_OPTIONS'] = [
     'disable_dotenv' => ('true' === ($_SERVER['APP_DISABLE_DOTENV'] ?? false)),
     'prod_envs' => ['prod', 'redis', 'db', 'store_data'],
     'project_dir' => dirname(__DIR__),
 ];
 
-return function (array $context) {
+return static function (array $context) {
     $kernel = new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);
 
     return new Application($kernel);

--- a/elasticms-admin/config/packages/monolog.yaml
+++ b/elasticms-admin/config/packages/monolog.yaml
@@ -1,5 +1,6 @@
 parameters:
     env(LOG_OUTPUT): 'php://stdout'
+    env(LOG_LEVEL): 100
 
 when@dev:
     monolog:
@@ -7,12 +8,13 @@ when@dev:
             main:
                 type: stream
                 path: '%env(resolve:LOG_OUTPUT)%'
-                level: debug
+                level: '%env(resolve:LOG_LEVEL)%'
                 channels: ["!event", "!elastica"]
             console:
-                type:   console
+                type: console
                 process_psr_3_messages: false
-                channels: ["!event", "!doctrine", "!console"]
+                formatter: monolog.formatter.json
+                channels: ['!event', '!console']
             flash:
                 type: service
                 id: ems_core.core_ui.flash_message_logger

--- a/elasticms-web/bin/console
+++ b/elasticms-web/bin/console
@@ -8,13 +8,14 @@ file_exists(dirname(__DIR__).'/vendor/autoload_runtime.php') ?
     require_once dirname(__DIR__).'/vendor/autoload_runtime.php' :
     require_once dirname(__DIR__).'/../vendor/autoload_runtime.php';
 
+$_SERVER['LOG_LEVEL'] = 400;
 $_SERVER['APP_RUNTIME_OPTIONS'] = [
     'disable_dotenv' => ('true' === ($_SERVER['APP_DISABLE_DOTENV'] ?? false)),
     'prod_envs' => ['prod', 'redis', 'store_data'],
     'project_dir' => dirname(__DIR__),
 ];
 
-return function (array $context) {
+return static function (array $context) {
     $kernel = new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);
 
     return new Application($kernel);

--- a/elasticms-web/config/packages/monolog.yaml
+++ b/elasticms-web/config/packages/monolog.yaml
@@ -1,5 +1,6 @@
 parameters:
     env(LOG_OUTPUT): 'php://stdout'
+    env(LOG_LEVEL): 100
 
 when@dev:
     monolog:
@@ -7,12 +8,13 @@ when@dev:
             main:
                 type: stream
                 path: '%env(resolve:LOG_OUTPUT)%'
-                level: debug
+                level: '%env(resolve:LOG_LEVEL)%'
                 channels: ["!event", "!elastica"]
             console:
-                type:   console
+                type: console
                 process_psr_3_messages: false
-                channels: ["!event", "!doctrine", "!console"]
+                formatter: monolog.formatter.json
+                channels: ['!event', '!console']
 
 when@prod: &monolog_prod
     monolog:


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | n  |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Problem:
When we run a command (example ems:contenttype:recompute) in dev env, we see all query logs. Because the main stream is also writting to stdout.

Solution:
Overwrite the log level for the main handler in dev env, for not seeing default doctrine query logs when running a command.
If we want to see the queries we can run the command with  -vvv (VERBOSITY_DEBUG)
