### PR TITLE
refactor(core): new core controller trait

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .cache
-          key: ci-${{ github.ref_name }}-${{ github.run_id }}
-          restore-keys: |
-            ci-${{ github.ref_name }}-
+          key: ci-${{ github.ref_name }}
 
       - name: "Restore Composer Cache"
         uses: actions/cache/restore@v4
@@ -62,7 +60,7 @@ jobs:
         if: always()
         with:
           path: .cache
-          key: ci-${{ github.ref_name }}-${{ github.run_id }}
+          key: ci-${{ github.ref_name }}
 
       - name: "Save vendor directory"
         if: steps.restore-composer.outputs.cache-hit != 'true'

--- a/EMS/core-bundle/src/Controller/ChannelController.php
+++ b/EMS/core-bundle/src/Controller/ChannelController.php
@@ -20,11 +20,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 final class ChannelController extends AbstractController
 {
+    use CoreControllerTrait;
+
     public function __construct(
         private readonly LoggerInterface $logger,
         private readonly ChannelService $channelService,
-        private readonly DataTableFactory $dataTableFactory,
-        private readonly string $templateNamespace
+        private readonly DataTableFactory $dataTableFactory
     ) {
     }
 
@@ -54,7 +55,7 @@ final class ChannelController extends AbstractController
             return $this->redirectToRoute('ems_core_channel_index');
         }
 
-        return $this->render("@$this->templateNamespace/channel/index.html.twig", [
+        return $this->render('@EMSCore/channel/index.html.twig', [
             'form' => $form->createView(),
         ]);
     }
@@ -63,13 +64,13 @@ final class ChannelController extends AbstractController
     {
         $channel = new Channel();
 
-        return $this->edit($request, $channel, "@$this->templateNamespace/channel/add.html.twig");
+        return $this->edit($request, $channel, '@EMSCore/channel/add.html.twig');
     }
 
     public function edit(Request $request, Channel $channel, ?string $view = null): Response
     {
         if (null === $view) {
-            $view = "@$this->templateNamespace/channel/edit.html.twig";
+            $view = '@EMSCore/channel/edit.html.twig';
         }
         $form = $this->createForm(ChannelType::class, $channel);
         $form->handleRequest($request);
@@ -94,7 +95,7 @@ final class ChannelController extends AbstractController
 
     public function menu(): Response
     {
-        return $this->render("@$this->templateNamespace/channel/menu.html.twig", [
+        return $this->render('@EMSCore/channel/menu.html.twig', [
             'channels' => $this->channelService->getAll(),
         ]);
     }

--- a/EMS/core-bundle/src/Controller/ContentManagement/ActionController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/ActionController.php
@@ -6,6 +6,7 @@ namespace EMS\CoreBundle\Controller\ContentManagement;
 
 use EMS\CommonBundle\Helper\EmsFields;
 use EMS\CommonBundle\Helper\Text\Encoder;
+use EMS\CoreBundle\Controller\CoreControllerTrait;
 use EMS\CoreBundle\Core\DataTable\DataTableFactory;
 use EMS\CoreBundle\DataTable\Type\ContentType\ContentTypeActionDataTableType;
 use EMS\CoreBundle\Entity\ContentType;
@@ -28,13 +29,14 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 final class ActionController extends AbstractController
 {
+    use CoreControllerTrait;
+
     public function __construct(
         private readonly LoggerInterface $logger,
         private readonly ActionService $actionService,
         private readonly DataTableFactory $dataTableFactory,
         private readonly ContentTypeRepository $contentTypeRepository,
-        private readonly TemplateRepository $templateRepository,
-        private readonly string $templateNamespace
+        private readonly TemplateRepository $templateRepository
     ) {
     }
 
@@ -86,7 +88,7 @@ final class ActionController extends AbstractController
             return $this->redirectToRoute('ems_core_action_index', ['contentType' => $contentType->getId()]);
         }
 
-        return $this->render("@$this->templateNamespace/action/index.html.twig", [
+        return $this->render('@EMSCore/action/index.html.twig', [
             'form' => $form->createView(),
             'contentType' => $contentType,
         ]);
@@ -130,7 +132,7 @@ final class ActionController extends AbstractController
             ]);
         }
 
-        return $this->render("@$this->templateNamespace/action/add.html.twig", [
+        return $this->render('@EMSCore/action/add.html.twig', [
             'contentType' => $contentType,
             'form' => $form->createView(),
         ]);
@@ -161,7 +163,7 @@ final class ActionController extends AbstractController
             ]);
 
             if ('json' === $_format) {
-                return $this->render("@$this->templateNamespace/ajax/notification.json.twig", [
+                return $this->render('@EMSCore/ajax/notification.json.twig', [
                     'success' => true,
                 ]);
             }
@@ -178,12 +180,12 @@ final class ActionController extends AbstractController
                 }
             }
 
-            return $this->render("@$this->templateNamespace/ajax/notification.json.twig", [
+            return $this->render('@EMSCore/ajax/notification.json.twig', [
                 'success' => $form->isValid(),
             ]);
         }
 
-        return $this->render("@$this->templateNamespace/action/edit.html.twig", [
+        return $this->render('@EMSCore/action/edit.html.twig', [
             'form' => $form->createView(),
             'action' => $action,
             'contentType' => $action->giveContentType(),

--- a/EMS/core-bundle/src/Controller/ContentManagement/AnalyzerController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/AnalyzerController.php
@@ -3,6 +3,7 @@
 namespace EMS\CoreBundle\Controller\ContentManagement;
 
 use EMS\CommonBundle\Helper\EmsFields;
+use EMS\CoreBundle\Controller\CoreControllerTrait;
 use EMS\CoreBundle\Entity\Analyzer;
 use EMS\CoreBundle\Form\Form\AnalyzerType;
 use EMS\CoreBundle\Repository\AnalyzerRepository;
@@ -17,17 +18,18 @@ use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 class AnalyzerController extends AbstractController
 {
+    use CoreControllerTrait;
+
     public function __construct(
         private readonly LoggerInterface $logger,
         private readonly HelperService $helperService,
-        private readonly AnalyzerRepository $analyzerRepository,
-        private readonly string $templateNamespace
+        private readonly AnalyzerRepository $analyzerRepository
     ) {
     }
 
     public function index(): Response
     {
-        return $this->render("@$this->templateNamespace/analyzer/index.html.twig", [
+        return $this->render('@EMSCore/analyzer/index.html.twig', [
                 'paging' => $this->helperService->getPagingTool(Analyzer::class, 'ems_analyzer_index', 'name'),
         ]);
     }
@@ -52,8 +54,8 @@ class AnalyzerController extends AbstractController
             ]);
         }
 
-        return $this->render("@$this->templateNamespace/analyzer/edit.html.twig", [
-                'form' => $form->createView(),
+        return $this->render('@EMSCore/analyzer/edit.html.twig', [
+            'form' => $form->createView(),
         ]);
     }
 
@@ -96,8 +98,8 @@ class AnalyzerController extends AbstractController
             }
         }
 
-        return $this->render("@$this->templateNamespace/analyzer/add.html.twig", [
-                'form' => $form->createView(),
+        return $this->render('@EMSCore/analyzer/add.html.twig', [
+            'form' => $form->createView(),
         ]);
     }
 

--- a/EMS/core-bundle/src/Controller/ContentManagement/ContentTypeController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/ContentTypeController.php
@@ -5,6 +5,7 @@ namespace EMS\CoreBundle\Controller\ContentManagement;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\ORMException;
 use EMS\CommonBundle\Helper\EmsFields;
+use EMS\CoreBundle\Controller\CoreControllerTrait;
 use EMS\CoreBundle\Core\Form\FieldTypeManager;
 use EMS\CoreBundle\Entity\ContentType;
 use EMS\CoreBundle\Entity\Environment;
@@ -46,6 +47,8 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class ContentTypeController extends AbstractController
 {
+    use CoreControllerTrait;
+
     public function __construct(
         private readonly LoggerInterface $logger,
         private readonly ContentTypeService $contentTypeService,
@@ -54,8 +57,7 @@ class ContentTypeController extends AbstractController
         private readonly ContentTypeRepository $contentTypeRepository,
         private readonly EnvironmentRepository $environmentRepository,
         private readonly FieldTypeRepository $fieldTypeRepository,
-        private readonly string $templateNamespace)
-    {
+    ) {
     }
 
     /**
@@ -88,7 +90,7 @@ class ContentTypeController extends AbstractController
             ]);
         }
 
-        return $this->render("@$this->templateNamespace/contenttype/json_update.html.twig", [
+        return $this->render('@EMSCore/contenttype/json_update.html.twig', [
             'form' => $form->createView(),
             'contentType' => $contentType,
         ]);
@@ -232,7 +234,7 @@ class ContentTypeController extends AbstractController
             ]);
         }
 
-        return $this->render("@$this->templateNamespace/contenttype/add.html.twig", [
+        return $this->render('@EMSCore/contenttype/add.html.twig', [
             'form' => $form->createView(),
         ]);
     }
@@ -287,7 +289,7 @@ class ContentTypeController extends AbstractController
             return $this->redirectToRoute('contenttype.index');
         }
 
-        return $this->render("@$this->templateNamespace/contenttype/index.html.twig", [
+        return $this->render('@EMSCore/contenttype/index.html.twig', [
             'form' => $form->createView(),
         ]);
     }
@@ -324,7 +326,7 @@ class ContentTypeController extends AbstractController
             return $this->redirectToRoute('contenttype.unreferenced');
         }
 
-        return $this->render("@$this->templateNamespace/contenttype/unreferenced.html.twig", [
+        return $this->render('@EMSCore/contenttype/unreferenced.html.twig', [
             'referencedContentTypes' => $this->contentTypeService->getUnreferencedContentTypes(),
         ]);
     }
@@ -350,7 +352,7 @@ class ContentTypeController extends AbstractController
             return $this->treatFieldSubmit($contentType, $field, $clickable->getName(), $subFieldName);
         }
 
-        return $this->render("@$this->templateNamespace/contenttype/field.html.twig", [
+        return $this->render('@EMSCore/contenttype/field.html.twig', [
             'form' => $form->createView(),
             'field' => $field,
             'contentType' => $contentType,
@@ -373,7 +375,7 @@ class ContentTypeController extends AbstractController
             return $this->redirectToRoute('contenttype.edit', ['id' => $contentType->getId()]);
         }
 
-        return $this->render("@$this->templateNamespace/contenttype/reorder.html.twig", [
+        return $this->render('@EMSCore/contenttype/reorder.html.twig', [
             'form' => $form->createView(),
             'contentType' => $contentType,
         ]);
@@ -453,7 +455,7 @@ class ContentTypeController extends AbstractController
             ]);
         }
 
-        return $this->render("@$this->templateNamespace/contenttype/edit.html.twig", [
+        return $this->render('@EMSCore/contenttype/edit.html.twig', [
             'form' => $form->createView(),
             'contentType' => $contentType,
             'mapping' => $mapping,
@@ -535,7 +537,7 @@ class ContentTypeController extends AbstractController
             ]);
         }
 
-        return $this->render("@$this->templateNamespace/contenttype/structure.html.twig", [
+        return $this->render('@EMSCore/contenttype/structure.html.twig', [
             'form' => $form->createView(),
             'contentType' => $contentType,
         ]);

--- a/EMS/core-bundle/src/Controller/ContentManagement/CrudController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/CrudController.php
@@ -3,6 +3,7 @@
 namespace EMS\CoreBundle\Controller\ContentManagement;
 
 use EMS\CommonBundle\Helper\EmsFields;
+use EMS\CoreBundle\Controller\CoreControllerTrait;
 use EMS\CoreBundle\Entity\ContentType;
 use EMS\CoreBundle\Entity\User;
 use EMS\CoreBundle\Exception\DataStateException;
@@ -22,8 +23,14 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class CrudController extends AbstractController
 {
-    public function __construct(private readonly LoggerInterface $logger, private readonly UserService $userService, private readonly DataService $dataService, private readonly ContentTypeService $contentTypeService, private readonly string $templateNamespace)
-    {
+    use CoreControllerTrait;
+
+    public function __construct(
+        private readonly LoggerInterface $logger,
+        private readonly UserService $userService,
+        private readonly DataService $dataService,
+        private readonly ContentTypeService $contentTypeService,
+    ) {
     }
 
     public function createAction(?string $ouuid, string $name, Request $request): Response
@@ -55,17 +62,17 @@ class CrudController extends AbstractController
                 ]);
             }
 
-            return $this->render("@$this->templateNamespace/ajax/notification.json.twig", [
-                    'success' => false,
-                    'ouuid' => $ouuid,
-                    'type' => $contentType->getName(),
+            return $this->render('@EMSCore/ajax/notification.json.twig', [
+                'success' => false,
+                'ouuid' => $ouuid,
+                'type' => $contentType->getName(),
             ]);
         }
 
-        return $this->render("@$this->templateNamespace/ajax/notification.json.twig", [
-                'success' => true,
-                'revision_id' => $newRevision->getId(),
-                'ouuid' => $newRevision->getOuuid(),
+        return $this->render('@EMSCore/ajax/notification.json.twig', [
+            'success' => true,
+            'revision_id' => $newRevision->getId(),
+            'ouuid' => $newRevision->getOuuid(),
         ]);
     }
 
@@ -85,18 +92,18 @@ class CrudController extends AbstractController
                 ]);
             }
 
-            return $this->render("@$this->templateNamespace/ajax/revision.json.twig", [
-                    'success' => false,
-                    'ouuid' => $ouuid,
-                    'type' => $contentType->getName(),
+            return $this->render('@EMSCore/ajax/revision.json.twig', [
+                'success' => false,
+                'ouuid' => $ouuid,
+                'type' => $contentType->getName(),
             ]);
         }
 
-        return $this->render("@$this->templateNamespace/ajax/revision.json.twig", [
-                'success' => true,
-                'revision' => $revision->getRawData(),
-                'ouuid' => $revision->getOuuid(),
-                'id' => $revision->getId(),
+        return $this->render('@EMSCore/ajax/revision.json.twig', [
+            'success' => true,
+            'revision' => $revision->getRawData(),
+            'ouuid' => $revision->getOuuid(),
+            'id' => $revision->getId(),
         ]);
     }
 
@@ -131,7 +138,7 @@ class CrudController extends AbstractController
             $out['success'] = false;
         }
 
-        return $this->render("@$this->templateNamespace/ajax/notification.json.twig", $out);
+        return $this->render('@EMSCore/ajax/notification.json.twig', $out);
     }
 
     /**
@@ -160,17 +167,17 @@ class CrudController extends AbstractController
                 ]);
             }
 
-            return $this->render("@$this->templateNamespace/ajax/notification.json.twig", [
-                    'success' => $isDiscard,
-                    'type' => $contentType->getName(),
-                    'revision_id' => $id,
+            return $this->render('@EMSCore/ajax/notification.json.twig', [
+                'success' => $isDiscard,
+                'type' => $contentType->getName(),
+                'revision_id' => $id,
             ]);
         }
 
-        return $this->render("@$this->templateNamespace/ajax/notification.json.twig", [
-                'success' => $isDiscard,
-                'type' => $contentType->getName(),
-                'revision_id' => $revision->getId(),
+        return $this->render('@EMSCore/ajax/notification.json.twig', [
+            'success' => $isDiscard,
+            'type' => $contentType->getName(),
+            'revision_id' => $revision->getId(),
         ]);
     }
 
@@ -202,10 +209,10 @@ class CrudController extends AbstractController
             }
         }
 
-        return $this->render("@$this->templateNamespace/ajax/notification.json.twig", [
-                'success' => $isDeleted,
-                'ouuid' => $ouuid,
-                'type' => $contentType->getName(),
+        return $this->render('@EMSCore/ajax/notification.json.twig', [
+            'success' => $isDeleted,
+            'ouuid' => $ouuid,
+            'type' => $contentType->getName(),
         ]);
     }
 
@@ -237,19 +244,19 @@ class CrudController extends AbstractController
                 ]);
             }
 
-            return $this->render("@$this->templateNamespace/ajax/notification.json.twig", [
-                    'success' => $isReplaced,
-                    'ouuid' => $ouuid,
-                    'type' => $contentType->getName(),
-                    'revision_id' => null,
-            ]);
-        }
-
-        return $this->render("@$this->templateNamespace/ajax/notification.json.twig", [
+            return $this->render('@EMSCore/ajax/notification.json.twig', [
                 'success' => $isReplaced,
                 'ouuid' => $ouuid,
                 'type' => $contentType->getName(),
-                'revision_id' => $newDraft->getId(),
+                'revision_id' => null,
+            ]);
+        }
+
+        return $this->render('@EMSCore/ajax/notification.json.twig', [
+            'success' => $isReplaced,
+            'ouuid' => $ouuid,
+            'type' => $contentType->getName(),
+            'revision_id' => $newDraft->getId(),
         ]);
     }
 
@@ -281,26 +288,26 @@ class CrudController extends AbstractController
             }
             $isMerged = false;
 
-            return $this->render("@$this->templateNamespace/ajax/notification.json.twig", [
-                    'success' => $isMerged,
-                    'ouuid' => $ouuid,
-                    'type' => $contentType->getName(),
-                    'revision_id' => null,
-            ]);
-        }
-
-        return $this->render("@$this->templateNamespace/ajax/notification.json.twig", [
+            return $this->render('@EMSCore/ajax/notification.json.twig', [
                 'success' => $isMerged,
                 'ouuid' => $ouuid,
                 'type' => $contentType->getName(),
-                'revision_id' => $newDraft->getId(),
+                'revision_id' => null,
+            ]);
+        }
+
+        return $this->render('@EMSCore/ajax/notification.json.twig', [
+            'success' => $isMerged,
+            'ouuid' => $ouuid,
+            'type' => $contentType->getName(),
+            'revision_id' => $newDraft->getId(),
         ]);
     }
 
     public function testAction(): Response
     {
-        return $this->render("@$this->templateNamespace/ajax/notification.json.twig", [
-                'success' => true,
+        return $this->render('@EMSCore/ajax/notification.json.twig', [
+            'success' => true,
         ]);
     }
 
@@ -308,9 +315,9 @@ class CrudController extends AbstractController
     {
         $contentType = $this->giveContentType($name);
 
-        return $this->render("@$this->templateNamespace/ajax/contenttype_info.json.twig", [
-                'success' => true,
-                'contentType' => $contentType,
+        return $this->render('@EMSCore/ajax/contenttype_info.json.twig', [
+            'success' => true,
+            'contentType' => $contentType,
         ]);
     }
 
@@ -368,7 +375,7 @@ class CrudController extends AbstractController
             $this->dataService->refresh($revision->giveContentType()->giveEnvironment());
         }
 
-        return new JsonResponse(Json::decode($this->renderView("@$this->templateNamespace/ajax/notification.json.twig", [
+        return new JsonResponse(Json::decode($this->renderView('@EMSCore/ajax/notification.json.twig', [
             'success' => !$revision->getDraft(),
             'ouuid' => $revision->getOuuid(),
             'type' => $revision->giveContentType()->getName(),

--- a/EMS/core-bundle/src/Controller/ContentManagement/DataController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/DataController.php
@@ -5,6 +5,7 @@ namespace EMS\CoreBundle\Controller\ContentManagement;
 use Doctrine\ORM\NoResultException;
 use EMS\CommonBundle\Helper\EmsFields;
 use EMS\CommonBundle\Helper\MimeTypeHelper;
+use EMS\CoreBundle\Controller\CoreControllerTrait;
 use EMS\CoreBundle\Core\ContentType\ContentTypeRoles;
 use EMS\CoreBundle\Core\ContentType\ViewTypes;
 use EMS\CoreBundle\Core\Log\LogRevisionContext;
@@ -52,6 +53,8 @@ use Twig\Environment as TwigEnvironment;
 
 class DataController extends AbstractController
 {
+    use CoreControllerTrait;
+
     public function __construct(
         private readonly LoggerInterface $logger,
         private readonly DataService $dataService,
@@ -67,8 +70,7 @@ class DataController extends AbstractController
         private readonly SearchRepository $searchRepository,
         private readonly RevisionRepository $revisionRepository,
         private readonly TemplateRepository $templateRepository,
-        private readonly EnvironmentRepository $environmentRepository,
-        private readonly string $templateNamespace
+        private readonly EnvironmentRepository $environmentRepository
     ) {
     }
 
@@ -181,7 +183,7 @@ class DataController extends AbstractController
             throw new NotFoundHttpException(\sprintf('Document %s with identifier %s not found in environment %s', $contentType->getSingularName(), $ouuid, $environmentName));
         }
 
-        return $this->render("@$this->templateNamespace/data/view-data.html.twig", [
+        return $this->render('@EMSCore/data/view-data.html.twig', [
             'document' => $document,
             'object' => $document->getRaw(),
             'environment' => $environment,
@@ -524,7 +526,7 @@ class DataController extends AbstractController
             ]);
         }
 
-        $response = $this->render("@$this->templateNamespace/ajax/notification.json.twig", [
+        $response = $this->render('@EMSCore/ajax/notification.json.twig', [
             'success' => $success,
         ]);
         $response->headers->set('Content-Type', 'application/json');
@@ -551,7 +553,7 @@ class DataController extends AbstractController
                 EmsFields::LOG_REVISION_ID_FIELD => $revision->getId(),
             ]);
 
-            $response = $this->render("@$this->templateNamespace/ajax/notification.json.twig", [
+            $response = $this->render('@EMSCore/ajax/notification.json.twig', [
                 'success' => false,
             ]);
             $response->headers->set('Content-Type', 'application/json');
@@ -613,7 +615,7 @@ class DataController extends AbstractController
             }
         }
 
-        $response = $this->render("@$this->templateNamespace/data/ajax-revision.json.twig", [
+        $response = $this->render('@EMSCore/data/ajax-revision.json.twig', [
             'success' => true,
             'formErrors' => $formErrors,
         ]);
@@ -773,7 +775,7 @@ class DataController extends AbstractController
             }
         }
 
-        return $this->render("@$this->templateNamespace/data/add.html.twig", [
+        return $this->render('@EMSCore/data/add.html.twig', [
             'contentType' => $contentType,
             'form' => $form->createView(),
         ]);

--- a/EMS/core-bundle/src/Controller/ContentManagement/DatatableController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/DatatableController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EMS\CoreBundle\Controller\ContentManagement;
 
+use EMS\CoreBundle\Controller\CoreControllerTrait;
 use EMS\CoreBundle\Core\DataTable\DataTableFactory;
 use EMS\CoreBundle\Core\DataTable\DataTableFormat;
 use EMS\CoreBundle\Core\DataTable\TableExporter;
@@ -20,13 +21,14 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 
 final class DatatableController extends AbstractController
 {
+    use CoreControllerTrait;
+
     public function __construct(
         private readonly DatatableService $datatableService,
         private readonly DataTableFactory $dataTableFactory,
         private readonly TableRenderer $tableRenderer,
         private readonly TableExporter $tableExporter,
-        private readonly TokenStorageInterface $tokenStorage,
-        private readonly string $templateNamespace
+        private readonly TokenStorageInterface $tokenStorage
     ) {
     }
 
@@ -36,7 +38,7 @@ final class DatatableController extends AbstractController
         $dataTableRequest = DataTableRequest::fromRequest($request);
         $table->resetIterator($dataTableRequest);
 
-        return $this->render("@$this->templateNamespace/datatable/ajax.html.twig", [
+        return $this->render('@EMSCore/datatable/ajax.html.twig', [
             'dataTableRequest' => $dataTableRequest,
             'table' => $table,
         ], new JsonResponse());

--- a/EMS/core-bundle/src/Controller/ContentManagement/EnvironmentController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/EnvironmentController.php
@@ -6,6 +6,7 @@ use Elasticsearch\Common\Exceptions\NoNodesAvailableException;
 use EMS\CommonBundle\Common\Standard\Type;
 use EMS\CommonBundle\Elasticsearch\Exception\NotFoundException;
 use EMS\CommonBundle\Helper\EmsFields;
+use EMS\CoreBundle\Controller\CoreControllerTrait;
 use EMS\CoreBundle\Core\ContentType\ContentTypeRoles;
 use EMS\CoreBundle\Core\DataTable\DataTableFactory;
 use EMS\CoreBundle\DataTable\Type\EnvironmentDataTableType;
@@ -47,6 +48,8 @@ use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 class EnvironmentController extends AbstractController
 {
+    use CoreControllerTrait;
+
     public function __construct(
         private readonly LoggerInterface $logger,
         private readonly SearchService $searchService,
@@ -65,7 +68,6 @@ class EnvironmentController extends AbstractController
         private readonly int $pagingSize,
         private readonly string $instanceId,
         private readonly ?string $circlesObject,
-        private readonly string $templateNamespace,
         private readonly DataTableFactory $dataTableFactory)
     {
     }
@@ -268,7 +270,7 @@ class EnvironmentController extends AbstractController
             $lastPage = 0;
         }
 
-        return $this->render("@$this->templateNamespace/environment/align.html.twig", [
+        return $this->render('@EMSCore/environment/align.html.twig', [
             'form' => $form->createView(),
             'results' => $results,
             'lastPage' => $lastPage,
@@ -458,7 +460,7 @@ class EnvironmentController extends AbstractController
             }
         }
 
-        return $this->render("@$this->templateNamespace/environment/add.html.twig", [
+        return $this->render('@EMSCore/environment/add.html.twig', [
                 'form' => $form->createView(),
         ]);
     }
@@ -486,7 +488,7 @@ class EnvironmentController extends AbstractController
             return $this->redirectToRoute('environment.index');
         }
 
-        return $this->render("@$this->templateNamespace/environment/edit.html.twig", [
+        return $this->render('@EMSCore/environment/edit.html.twig', [
             'environment' => $environment,
             'form' => $form->createView(),
         ]);
@@ -513,7 +515,7 @@ class EnvironmentController extends AbstractController
             $info = false;
         }
 
-        return $this->render("@$this->templateNamespace/environment/view.html.twig", [
+        return $this->render('@EMSCore/environment/view.html.twig', [
                 'environment' => $environment,
                 'info' => $info,
         ]);
@@ -563,9 +565,9 @@ class EnvironmentController extends AbstractController
             }
         }
 
-        return $this->render("@$this->templateNamespace/environment/rebuild.html.twig", [
-                'environment' => $environment,
-                'form' => $form->createView(),
+        return $this->render('@EMSCore/environment/rebuild.html.twig', [
+            'environment' => $environment,
+            'form' => $form->createView(),
         ]);
     }
 
@@ -614,7 +616,7 @@ class EnvironmentController extends AbstractController
                 $environments[] = $environment;
             }
 
-            return $this->render("@$this->templateNamespace/environment/index.html.twig", [
+            return $this->render('@EMSCore/environment/index.html.twig', [
                 'environments' => $environments,
                 'orphanIndexes' => $this->aliasService->getOrphanIndexes(),
                 'unreferencedAliases' => $this->aliasService->getUnreferencedAliases(),

--- a/EMS/core-bundle/src/Controller/ContentManagement/FileController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/FileController.php
@@ -4,6 +4,7 @@ namespace EMS\CoreBundle\Controller\ContentManagement;
 
 use EMS\CommonBundle\Helper\EmsFields;
 use EMS\CommonBundle\Storage\NotFoundException;
+use EMS\CoreBundle\Controller\CoreControllerTrait;
 use EMS\CoreBundle\Entity\UserInterface;
 use EMS\CoreBundle\Service\AssetExtractorService;
 use EMS\CoreBundle\Service\FileService;
@@ -25,11 +26,12 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class FileController extends AbstractController
 {
+    use CoreControllerTrait;
+
     public function __construct(
         private readonly FileService $fileService,
         private readonly AssetExtractorService $assetExtractorService,
         private readonly LoggerInterface $logger,
-        private readonly string $templateNamespace,
         private readonly string $themeColor,
     ) {
     }
@@ -70,7 +72,7 @@ class FileController extends AbstractController
             throw new NotFoundHttpException(\sprintf('Asset %s not found', $sha1));
         }
 
-        $response = $this->render("@$this->templateNamespace/ajax/extract-data-file.json.twig", [
+        $response = $this->render('@EMSCore/ajax/extract-data-file.json.twig', [
             'success' => !$data->isEmpty(),
             'data' => $data,
         ]);
@@ -116,12 +118,12 @@ class FileController extends AbstractController
                 EmsFields::LOG_ERROR_MESSAGE_FIELD => $e->getMessage(),
             ]);
 
-            return $this->render("@$this->templateNamespace/ajax/notification.json.twig", [
+            return $this->render('@EMSCore/ajax/notification.json.twig', [
                 'success' => false,
             ]);
         }
 
-        return $this->render("@$this->templateNamespace/ajax/file.json.twig", [
+        return $this->render('@EMSCore/ajax/file.json.twig', [
             'success' => true,
             'asset' => $uploadedAsset,
             'apiRoute' => $apiRoute,
@@ -155,12 +157,12 @@ class FileController extends AbstractController
                 EmsFields::LOG_ERROR_MESSAGE_FIELD => $e->getMessage(),
             ]);
 
-            return $this->render("@$this->templateNamespace/ajax/notification.json.twig", [
+            return $this->render('@EMSCore/ajax/notification.json.twig', [
                 'success' => false,
             ]);
         }
 
-        return $this->render("@$this->templateNamespace/ajax/file.json.twig", [
+        return $this->render('@EMSCore/ajax/file.json.twig', [
             'success' => true,
             'asset' => $uploadedAsset,
             'apiRoute' => $apiRoute,
@@ -171,7 +173,7 @@ class FileController extends AbstractController
     {
         $images = $this->fileService->getImages();
 
-        return $this->render("@$this->templateNamespace/ajax/images.json.twig", [
+        return $this->render('@EMSCore/ajax/images.json.twig', [
             'images' => $images,
         ]);
     }
@@ -255,12 +257,12 @@ class FileController extends AbstractController
                     EmsFields::LOG_ERROR_MESSAGE_FIELD => $e->getMessage(),
                 ]);
 
-                return $this->render("@$this->templateNamespace/ajax/notification.json.twig", [
+                return $this->render('@EMSCore/ajax/notification.json.twig', [
                     'success' => false,
                 ]);
             }
 
-            return $this->render("@$this->templateNamespace/ajax/multipart.json.twig", [
+            return $this->render('@EMSCore/ajax/multipart.json.twig', [
                 'success' => true,
                 'asset' => $uploadedAsset,
             ]);
@@ -268,12 +270,12 @@ class FileController extends AbstractController
             $this->logger->warning('log.file.upload_error', [
                 EmsFields::LOG_ERROR_MESSAGE_FIELD => $file->getError(),
             ]);
-            $this->render("@$this->templateNamespace/ajax/notification.json.twig", [
+            $this->render('@EMSCore/ajax/notification.json.twig', [
                 'success' => false,
             ]);
         }
 
-        return $this->render("@$this->templateNamespace/ajax/notification.json.twig", [
+        return $this->render('@EMSCore/ajax/notification.json.twig', [
             'success' => false,
         ]);
     }

--- a/EMS/core-bundle/src/Controller/ContentManagement/FilterController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/FilterController.php
@@ -2,6 +2,7 @@
 
 namespace EMS\CoreBundle\Controller\ContentManagement;
 
+use EMS\CoreBundle\Controller\CoreControllerTrait;
 use EMS\CoreBundle\Entity\Filter;
 use EMS\CoreBundle\Form\Form\FilterType;
 use EMS\CoreBundle\Repository\FilterRepository;
@@ -15,18 +16,19 @@ use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 class FilterController extends AbstractController
 {
+    use CoreControllerTrait;
+
     public function __construct(
         private readonly LoggerInterface $logger,
         private readonly HelperService $helperService,
-        private readonly FilterRepository $filterRepository,
-        private readonly string $templateNamespace,
+        private readonly FilterRepository $filterRepository
     ) {
     }
 
     public function indexAction(): Response
     {
-        return $this->render("@$this->templateNamespace/filter/index.html.twig", [
-                'paging' => $this->helperService->getPagingTool(Filter::class, 'ems_filter_index', 'name'),
+        return $this->render('@EMSCore/filter/index.html.twig', [
+            'paging' => $this->helperService->getPagingTool(Filter::class, 'ems_filter_index', 'name'),
         ]);
     }
 
@@ -40,12 +42,11 @@ class FilterController extends AbstractController
             $filter = $form->getData();
             $this->filterRepository->update($filter);
 
-            return $this->redirectToRoute('ems_filter_index', [
-            ]);
+            return $this->redirectToRoute('ems_filter_index');
         }
 
-        return $this->render("@$this->templateNamespace/filter/edit.html.twig", [
-                'form' => $form->createView(),
+        return $this->render('@EMSCore/filter/edit.html.twig', [
+            'form' => $form->createView(),
         ]);
     }
 
@@ -72,12 +73,11 @@ class FilterController extends AbstractController
             $filter = $form->getData();
             $this->filterRepository->update($filter);
 
-            return $this->redirectToRoute('ems_filter_index', [
-            ]);
+            return $this->redirectToRoute('ems_filter_index');
         }
 
-        return $this->render("@$this->templateNamespace/filter/add.html.twig", [
-                'form' => $form->createView(),
+        return $this->render('@EMSCore/filter/add.html.twig', [
+            'form' => $form->createView(),
         ]);
     }
 

--- a/EMS/core-bundle/src/Controller/ContentManagement/JobController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/JobController.php
@@ -3,6 +3,7 @@
 namespace EMS\CoreBundle\Controller\ContentManagement;
 
 use EMS\CommonBundle\Helper\Text\Encoder;
+use EMS\CoreBundle\Controller\CoreControllerTrait;
 use EMS\CoreBundle\Entity\Job;
 use EMS\CoreBundle\Form\Form\JobType;
 use EMS\CoreBundle\Helper\EmsCoreResponse;
@@ -22,12 +23,13 @@ use Symfony\Component\Security\Core\User\UserInterface;
 
 class JobController extends AbstractController
 {
+    use CoreControllerTrait;
+
     public function __construct(
         private readonly LoggerInterface $logger,
         private readonly JobService $jobService,
         private readonly int $pagingSize,
-        private readonly bool $triggerJobFromWeb,
-        private readonly string $templateNamespace
+        private readonly bool $triggerJobFromWeb
     ) {
     }
 
@@ -39,7 +41,7 @@ class JobController extends AbstractController
         $total = $this->jobService->count();
         $lastPage = \ceil($total / $size);
 
-        return $this->render("@$this->templateNamespace/job/index.html.twig", [
+        return $this->render('@EMSCore/job/index.html.twig', [
             'jobs' => $this->jobService->scroll($size, $from),
             'page' => $page,
             'size' => $size,
@@ -66,7 +68,7 @@ class JobController extends AbstractController
             ]);
         }
 
-        return $this->render("@$this->templateNamespace/job/status.html.twig", [
+        return $this->render('@EMSCore/job/status.html.twig', [
             'job' => $job,
             'status' => $encoder->encodeUrl($job->getStatus()),
             'output' => $encoder->encodeUrl($converter->convert($job->getOutput())),
@@ -86,7 +88,7 @@ class JobController extends AbstractController
             return $this->redirectToRoute('job.status', ['job' => $job->getId()]);
         }
 
-        return $this->render("@$this->templateNamespace/job/add.html.twig", ['form' => $form->createView()]);
+        return $this->render('@EMSCore/job/add.html.twig', ['form' => $form->createView()]);
     }
 
     public function delete(Job $job): RedirectResponse

--- a/EMS/core-bundle/src/Controller/ContentManagement/ManagedAliasController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/ManagedAliasController.php
@@ -2,6 +2,7 @@
 
 namespace EMS\CoreBundle\Controller\ContentManagement;
 
+use EMS\CoreBundle\Controller\CoreControllerTrait;
 use EMS\CoreBundle\Entity\ManagedAlias;
 use EMS\CoreBundle\Form\Form\ManagedAliasType;
 use EMS\CoreBundle\Repository\ManagedAliasRepository;
@@ -15,12 +16,13 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class ManagedAliasController extends AbstractController
 {
+    use CoreControllerTrait;
+
     public function __construct(
         private readonly LoggerInterface $logger,
         private readonly AliasService $aliasService,
         private readonly ManagedAliasRepository $managedAliasRepository,
         private readonly string $instanceId,
-        private readonly string $templateNamespace
     ) {
     }
 
@@ -40,7 +42,7 @@ class ManagedAliasController extends AbstractController
             return $this->redirectToRoute('environment.index');
         }
 
-        return $this->render("@$this->templateNamespace/environment/managed_alias.html.twig", [
+        return $this->render('@EMSCore/environment/managed_alias.html.twig', [
             'new' => true,
             'form' => $form->createView(),
         ]);
@@ -66,7 +68,7 @@ class ManagedAliasController extends AbstractController
             return $this->redirectToRoute('environment.index');
         }
 
-        return $this->render("@$this->templateNamespace/environment/managed_alias.html.twig", [
+        return $this->render('@EMSCore/environment/managed_alias.html.twig', [
             'new' => false,
             'form' => $form->createView(),
         ]);

--- a/EMS/core-bundle/src/Controller/ContentManagement/PublishController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/PublishController.php
@@ -7,6 +7,7 @@ use Elastica\Query\AbstractQuery;
 use EMS\CommonBundle\Service\ElasticaService;
 use EMS\CoreBundle\Command\Environment\AlignCommand;
 use EMS\CoreBundle\Commands;
+use EMS\CoreBundle\Controller\CoreControllerTrait;
 use EMS\CoreBundle\Entity\ContentType;
 use EMS\CoreBundle\Entity\Environment;
 use EMS\CoreBundle\Entity\Form\Search;
@@ -31,6 +32,8 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class PublishController extends AbstractController
 {
+    use CoreControllerTrait;
+
     public function __construct(
         private readonly PublishService $publishService,
         private readonly JobService $jobService,
@@ -38,8 +41,7 @@ class PublishController extends AbstractController
         private readonly ContentTypeService $contentTypeService,
         private readonly SearchService $searchService,
         private readonly ElasticaService $elasticaService,
-        private readonly string $templateNamespace)
-    {
+    ) {
     }
 
     public function publishToAction(Revision $revisionId, Environment $envId): Response
@@ -158,7 +160,7 @@ class PublishController extends AbstractController
             ]);
         }
 
-        return $this->render("@$this->templateNamespace/publish/publish-search-result.html.twig", [
+        return $this->render('@EMSCore/publish/publish-search-result.html.twig', [
             'form' => $form->createView(),
             'fromEnvironment' => $environment,
             'contentType' => $contentType,

--- a/EMS/core-bundle/src/Controller/ContentManagement/ReleaseController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/ReleaseController.php
@@ -31,8 +31,7 @@ final class ReleaseController extends AbstractController
     public function __construct(
         private readonly LoggerInterface $logger,
         private readonly ReleaseService $releaseService,
-        private readonly DataTableFactory $dataTableFactory,
-        private readonly string $templateNamespace
+        private readonly DataTableFactory $dataTableFactory
     ) {
     }
 

--- a/EMS/core-bundle/src/Controller/ContentManagement/ReleaseController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/ReleaseController.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace EMS\CoreBundle\Controller\ContentManagement;
 
-use EMS\CoreBundle\Controller\AbstractCoreController;
+use EMS\CoreBundle\Controller\CoreControllerTrait;
 use EMS\CoreBundle\Core\DataTable\DataTableFactory;
 use EMS\CoreBundle\Core\Revision\Release\ReleaseRevisionType;
 use EMS\CoreBundle\DataTable\Type\Release\ReleaseOverviewDataTableType;
@@ -20,11 +20,14 @@ use EMS\CoreBundle\Form\Form\TableType;
 use EMS\CoreBundle\Routes;
 use EMS\CoreBundle\Service\ReleaseService;
 use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-final class ReleaseController extends AbstractCoreController
+final class ReleaseController extends AbstractController
 {
+    use CoreControllerTrait;
+
     public function __construct(
         private readonly LoggerInterface $logger,
         private readonly ReleaseService $releaseService,

--- a/EMS/core-bundle/src/Controller/ContentManagement/ReleaseController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/ReleaseController.php
@@ -50,7 +50,7 @@ final class ReleaseController extends AbstractController
             return $this->redirectToRoute(Routes::RELEASE_INDEX);
         }
 
-        return $this->render("@$this->templateNamespace/release/index.html.twig", [
+        return $this->render('@EMSCore/release/index.html.twig', [
             'form' => $form->createView(),
         ]);
     }
@@ -65,7 +65,7 @@ final class ReleaseController extends AbstractController
             return $this->redirectToRoute(Routes::RELEASE_EDIT, ['release' => $release->getId()]);
         }
 
-        return $this->render("@$this->templateNamespace/release/add.html.twig", [
+        return $this->render('@EMSCore/release/add.html.twig', [
             'form_release' => $form->createView(),
         ]);
     }
@@ -101,7 +101,7 @@ final class ReleaseController extends AbstractController
             };
         }
 
-        return $this->render("@$this->templateNamespace/release/edit.html.twig", [
+        return $this->render('@EMSCore/release/edit.html.twig', [
             'form' => $revisionsForm->createView(),
             'form_release' => $releaseForm->createView(),
             'release' => $release,
@@ -130,7 +130,7 @@ final class ReleaseController extends AbstractController
             return $this->redirectToRoute(Routes::RELEASE_VIEW, ['release' => $release->getId()]);
         }
 
-        return $this->render("@$this->templateNamespace/release/view.html.twig", [
+        return $this->render('@EMSCore/release/view.html.twig', [
             'form' => $form->createView(),
             'release' => $release,
         ]);
@@ -196,7 +196,7 @@ final class ReleaseController extends AbstractController
             return $this->redirectToRoute(Routes::RELEASE_EDIT, ['release' => $release->getId()]);
         }
 
-        return $this->render("@$this->templateNamespace/release/revisions.html.twig", [
+        return $this->render('@EMSCore/release/revisions.html.twig', [
             'form' => $form->createView(),
             'type' => $releaseType->value,
         ]);
@@ -217,7 +217,7 @@ final class ReleaseController extends AbstractController
 
         $form = $this->createForm(TableType::class, $table);
 
-        return $this->render("@$this->templateNamespace/release/add-to-release.html.twig", [
+        return $this->render('@EMSCore/release/add-to-release.html.twig', [
             'form' => $form->createView(),
             'revision' => $revision,
         ]);

--- a/EMS/core-bundle/src/Controller/ContentManagement/ViewController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/ViewController.php
@@ -2,6 +2,7 @@
 
 namespace EMS\CoreBundle\Controller\ContentManagement;
 
+use EMS\CoreBundle\Controller\CoreControllerTrait;
 use EMS\CoreBundle\Core\ContentType\ViewDefinition;
 use EMS\CoreBundle\Core\DataTable\DataTableFactory;
 use EMS\CoreBundle\Core\View\ViewManager;
@@ -21,12 +22,13 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ViewController extends AbstractController
 {
+    use CoreControllerTrait;
+
     public function __construct(
         private readonly ContentTypeService $contentTypeService,
         private readonly ViewManager $viewManager,
         private readonly DataTableFactory $dataTableFactory,
-        private readonly LoggerInterface $logger,
-        private readonly string $templateNamespace
+        private readonly LoggerInterface $logger
     ) {
     }
 
@@ -69,7 +71,7 @@ class ViewController extends AbstractController
             ]);
         }
 
-        return $this->render("@$this->templateNamespace/view/index.html.twig", [
+        return $this->render('@EMSCore/view/index.html.twig', [
             'contentType' => $contentType,
             'form' => $form->createView(),
         ]);
@@ -121,7 +123,7 @@ class ViewController extends AbstractController
             ]);
         }
 
-        return $this->render("@$this->templateNamespace/view/add.html.twig", [
+        return $this->render('@EMSCore/view/add.html.twig', [
             'contentType' => $contentType,
             'form' => $form->createView(),
         ]);
@@ -153,7 +155,7 @@ class ViewController extends AbstractController
             ]);
 
             if ('json' === $_format) {
-                return $this->render("@$this->templateNamespace/ajax/notification.json.twig", [
+                return $this->render('@EMSCore/ajax/notification.json.twig', [
                     'success' => true,
                 ]);
             }
@@ -163,7 +165,7 @@ class ViewController extends AbstractController
             ]);
         }
 
-        return $this->render("@$this->templateNamespace/view/edit.html.twig", [
+        return $this->render('@EMSCore/view/edit.html.twig', [
             'form' => $form->createView(),
             'contentType' => $view->getContentType(),
             'view' => $view,

--- a/EMS/core-bundle/src/Controller/CoreControllerTrait.php
+++ b/EMS/core-bundle/src/Controller/CoreControllerTrait.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace EMS\CoreBundle\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormInterface;
 
-abstract class AbstractCoreController extends AbstractController
+trait CoreControllerTrait
 {
     protected function getClickedButtonName(FormInterface $form): ?string
     {

--- a/EMS/core-bundle/src/Controller/CoreControllerTrait.php
+++ b/EMS/core-bundle/src/Controller/CoreControllerTrait.php
@@ -6,7 +6,6 @@ namespace EMS\CoreBundle\Controller;
 
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormInterface;
-use Symfony\Component\HttpFoundation\Response;
 
 use function Symfony\Component\String\u;
 
@@ -23,17 +22,24 @@ trait CoreControllerTrait
         return $clickedButton instanceof FormInterface ? $clickedButton->getName() : null;
     }
 
-    /**
-     * @param array<string, mixed> $parameters
-     */
-    protected function render(string $view, array $parameters = [], ?Response $response = null): Response
+    protected function getTemplateNamespace(): string
     {
         $templateNamespace = parent::getParameter('ems_core.template_namespace');
 
-        if (\is_string($templateNamespace) && 'EMSCore' !== $templateNamespace) {
+        return \is_string($templateNamespace) ? $templateNamespace : 'EMSCore';
+    }
+
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    protected function renderView(string $view, array $parameters = []): string
+    {
+        $templateNamespace = $this->getTemplateNamespace();
+
+        if ('EMSCore' !== $templateNamespace) {
             $view = u($view)->replaceMatches('/^@EMSCore/', '@'.$templateNamespace)->toString();
         }
 
-        return parent::render($view, $parameters, $response);
+        return parent::renderView($view, $parameters);
     }
 }

--- a/EMS/core-bundle/src/Controller/CoreControllerTrait.php
+++ b/EMS/core-bundle/src/Controller/CoreControllerTrait.php
@@ -6,6 +6,9 @@ namespace EMS\CoreBundle\Controller;
 
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+use function Symfony\Component\String\u;
 
 trait CoreControllerTrait
 {
@@ -18,5 +21,19 @@ trait CoreControllerTrait
         $clickedButton = $form->getClickedButton();
 
         return $clickedButton instanceof FormInterface ? $clickedButton->getName() : null;
+    }
+
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    protected function render(string $view, array $parameters = [], ?Response $response = null): Response
+    {
+        $templateNamespace = parent::getParameter('ems_core.template_namespace');
+
+        if (\is_string($templateNamespace) && 'EMSCore' !== $templateNamespace) {
+            $view = u($view)->replaceMatches('/^@EMSCore/', '@'.$templateNamespace)->toString();
+        }
+
+        return parent::render($view, $parameters, $response);
     }
 }

--- a/EMS/core-bundle/src/Controller/CoreControllerTrait.php
+++ b/EMS/core-bundle/src/Controller/CoreControllerTrait.php
@@ -6,6 +6,7 @@ namespace EMS\CoreBundle\Controller;
 
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormInterface;
+use Twig\Environment;
 
 use function Symfony\Component\String\u;
 
@@ -34,12 +35,18 @@ trait CoreControllerTrait
      */
     protected function renderView(string $view, array $parameters = []): string
     {
+        /** @var Environment $twig */
+        $twig = $this->container->get('twig');
         $templateNamespace = $this->getTemplateNamespace();
 
         if ('EMSCore' !== $templateNamespace) {
-            $view = u($view)->replaceMatches('/^@EMSCore/', '@'.$templateNamespace)->toString();
+            $namespaceView = u($view)->replaceMatches('/^@EMSCore/', '@'.$templateNamespace)->toString();
+
+            if ($twig->getLoader()->exists($namespaceView)) {
+                return $twig->render($namespaceView, $parameters);
+            }
         }
 
-        return parent::renderView($view, $parameters);
+        return $twig->render($view, $parameters);
     }
 }

--- a/EMS/core-bundle/src/Controller/Dashboard/DashboardBrowserController.php
+++ b/EMS/core-bundle/src/Controller/Dashboard/DashboardBrowserController.php
@@ -4,36 +4,35 @@ declare(strict_types=1);
 
 namespace EMS\CoreBundle\Controller\Dashboard;
 
+use EMS\CoreBundle\Controller\CoreControllerTrait;
 use EMS\CoreBundle\Core\Dashboard\DashboardManager;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
-use Twig\Environment;
 
-class DashboardBrowserController
+class DashboardBrowserController extends AbstractController
 {
-    public function __construct(
-        private readonly DashboardManager $dashboardManager,
-        private readonly Environment $twig,
-        private readonly string $templateNamespace
-    ) {
+    use CoreControllerTrait;
+
+    public function __construct(private readonly DashboardManager $dashboardManager)
+    {
     }
 
     public function __invoke(string $dashboardName): Response
     {
         $dashboard = $this->dashboardManager->getByName($dashboardName);
-        $response = new Response();
 
         try {
-            $response->setContent($this->twig->render("@$this->templateNamespace/dashboard/browser/dashboard-browser-modal.html.twig", [
+            return $this->render('@EMSCore/dashboard/browser/dashboard-browser-modal.html.twig', [
                 'dashboard' => $dashboard,
-            ]));
+            ]);
         } catch (\Throwable $e) {
-            $response->setContent($this->twig->render("@$this->templateNamespace/dashboard/browser/dashboard-browser-modal-error.html.twig", [
+            $response = new Response();
+            $response->setStatusCode(Response::HTTP_INTERNAL_SERVER_ERROR);
+
+            return $this->render('@EMSCore/dashboard/browser/dashboard-browser-modal-error.html.twig', [
                 'exception' => $e,
                 'dashboard' => $dashboard,
-            ]));
-            $response->setStatusCode(Response::HTTP_INTERNAL_SERVER_ERROR);
+            ], $response);
         }
-
-        return $response;
     }
 }

--- a/EMS/core-bundle/src/Controller/Dashboard/DashboardController.php
+++ b/EMS/core-bundle/src/Controller/Dashboard/DashboardController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EMS\CoreBundle\Controller\Dashboard;
 
+use EMS\CoreBundle\Controller\CoreControllerTrait;
 use EMS\CoreBundle\Core\Dashboard\DashboardManager;
 use EMS\CoreBundle\Core\DataTable\DataTableFactory;
 use EMS\CoreBundle\DataTable\Type\DashboardDataTableType;
@@ -21,11 +22,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class DashboardController extends AbstractController
 {
+    use CoreControllerTrait;
+
     public function __construct(
         private readonly LoggerInterface $logger,
         private readonly DashboardManager $dashboardManager,
-        private readonly DataTableFactory $dataTableFactory,
-        private readonly string $templateNamespace
+        private readonly DataTableFactory $dataTableFactory
     ) {
     }
 
@@ -55,7 +57,7 @@ class DashboardController extends AbstractController
             return $this->redirectToRoute(Routes::DASHBOARD_ADMIN_INDEX);
         }
 
-        return $this->render("@$this->templateNamespace/dashboard/index.html.twig", [
+        return $this->render('@EMSCore/dashboard/index.html.twig', [
             'form' => $form->createView(),
         ]);
     }
@@ -84,7 +86,7 @@ class DashboardController extends AbstractController
             return $this->redirectToRoute(Routes::DASHBOARD_ADMIN_INDEX);
         }
 
-        return $this->render($create ? "@$this->templateNamespace/dashboard/add.html.twig" : "@$this->templateNamespace/dashboard/edit.html.twig", [
+        return $this->render($create ? '@EMSCore/dashboard/add.html.twig' : '@EMSCore/dashboard/edit.html.twig', [
             'form' => $form->createView(),
             'dashboard' => $dashboard,
         ]);

--- a/EMS/core-bundle/src/Controller/DefaultController.php
+++ b/EMS/core-bundle/src/Controller/DefaultController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EMS\CoreBundle\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -7,12 +9,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 class DefaultController extends AbstractController
 {
-    public function __construct(private readonly string $templateNamespace)
-    {
-    }
+    use CoreControllerTrait;
 
     public function documentation(): Response
     {
-        return $this->render("@$this->templateNamespace/default/documentation.html.twig");
+        return $this->render('@EMSCore/default/documentation.html.twig');
     }
 }

--- a/EMS/core-bundle/src/Controller/ElasticsearchController.php
+++ b/EMS/core-bundle/src/Controller/ElasticsearchController.php
@@ -51,6 +51,8 @@ use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 class ElasticsearchController extends AbstractController
 {
+    use CoreControllerTrait;
+
     /**
      * @param string[] $elasticsearchCluster
      */
@@ -73,9 +75,8 @@ class ElasticsearchController extends AbstractController
         private readonly EnvironmentRepository $environmentRepository,
         private readonly int $pagingSize,
         private readonly ?string $healthCheckAllowOrigin,
-        private readonly array $elasticsearchCluster,
-        private readonly string $templateNamespace)
-    {
+        private readonly array $elasticsearchCluster
+    ) {
     }
 
     public function addAliasAction(string $name, Request $request): Response
@@ -104,7 +105,7 @@ class ElasticsearchController extends AbstractController
             return $this->redirectToRoute('environment.index');
         }
 
-        return $this->render("@$this->templateNamespace/elasticsearch/add-alias.html.twig", [
+        return $this->render('@EMSCore/elasticsearch/add-alias.html.twig', [
             'form' => $form->createView(),
             'name' => $name,
         ]);
@@ -115,7 +116,7 @@ class ElasticsearchController extends AbstractController
         try {
             $health = $this->elasticaService->getClusterHealth();
 
-            $response = $this->render("@$this->templateNamespace/elasticsearch/status.$_format.twig", [
+            $response = $this->render('@EMSCore/elasticsearch/status.$_format.twig', [
                 'status' => $health,
                 'globalStatus' => $health['status'] ?? 'red',
             ]);
@@ -161,7 +162,7 @@ class ElasticsearchController extends AbstractController
                 }
             }
 
-            return $this->render("@$this->templateNamespace/elasticsearch/status.$_format.twig", [
+            return $this->render('@EMSCore/elasticsearch/status.$_format.twig', [
                 'status' => $status,
                 'certificate' => $certificateInformation,
                 'tika' => $tika,
@@ -170,7 +171,7 @@ class ElasticsearchController extends AbstractController
                 'specifiedVersion' => $this->elasticaService->getVersion(),
             ]);
         } catch (NoNodesAvailableException) {
-            return $this->render("@$this->templateNamespace/elasticsearch/no-nodes-available.$_format.twig", [
+            return $this->render('@EMSCore/elasticsearch/no-nodes-available.$_format.twig', [
                 'cluster' => $this->elasticsearchCluster,
             ]);
         }
@@ -178,7 +179,7 @@ class ElasticsearchController extends AbstractController
 
     public function indexSearch(): Response
     {
-        return $this->render("@$this->templateNamespace/elasticsearch/index.html.twig", [
+        return $this->render('@EMSCore/elasticsearch/index.html.twig', [
             'data' => $this->searchService->getAll(),
         ]);
     }
@@ -495,7 +496,7 @@ class ElasticsearchController extends AbstractController
                     ])
                     ->getForm();
 
-                return $this->render("@$this->templateNamespace/elasticsearch/save-search.html.twig", [
+                return $this->render('@EMSCore/elasticsearch/save-search.html.twig', [
                     'form' => $form->createView(),
                 ]);
             } elseif ($form->isSubmitted() && $form->isValid() && $request->query->get('search_form') && \array_key_exists('delete', $request->query->all('search_form'))) {
@@ -563,7 +564,7 @@ class ElasticsearchController extends AbstractController
                     $exportForms[] = $exportForm->createView();
                 }
 
-                return $this->render("@$this->templateNamespace/elasticsearch/export-search.html.twig", [
+                return $this->render('@EMSCore/elasticsearch/export-search.html.twig', [
                     'exportForms' => $exportForms,
                 ]);
             }
@@ -588,7 +589,7 @@ class ElasticsearchController extends AbstractController
                 }
             }
 
-            return $this->render("@$this->templateNamespace/elasticsearch/search.html.twig", [
+            return $this->render('@EMSCore/elasticsearch/search.html.twig', [
                 'response' => $response ?? null,
                 'lastPage' => $lastPage,
                 'paginationPath' => 'elasticsearch.search',

--- a/EMS/core-bundle/src/Controller/Form/FormController.php
+++ b/EMS/core-bundle/src/Controller/Form/FormController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EMS\CoreBundle\Controller\Form;
 
+use EMS\CoreBundle\Controller\CoreControllerTrait;
 use EMS\CoreBundle\Core\DataTable\DataTableFactory;
 use EMS\CoreBundle\Core\Form\FieldTypeManager;
 use EMS\CoreBundle\Core\Form\FormManager;
@@ -24,12 +25,13 @@ use Symfony\Component\HttpFoundation\Response;
 
 class FormController extends AbstractController
 {
+    use CoreControllerTrait;
+
     public function __construct(
         private readonly LoggerInterface $logger,
         private readonly FormManager $formManager,
         private readonly FieldTypeManager $fieldTypeManager,
-        private readonly DataTableFactory $dataTableFactory,
-        private readonly string $templateNamespace
+        private readonly DataTableFactory $dataTableFactory
     ) {
     }
 
@@ -59,7 +61,7 @@ class FormController extends AbstractController
             return $this->redirectToRoute(Routes::FORM_ADMIN_INDEX);
         }
 
-        return $this->render("@$this->templateNamespace/admin-form/index.html.twig", [
+        return $this->render('@EMSCore/admin-form/index.html.twig', [
             'form' => $form->createView(),
         ]);
     }
@@ -104,7 +106,7 @@ class FormController extends AbstractController
             ]));
         }
 
-        return $this->render($create ? "@$this->templateNamespace/admin-form/add.html.twig" : "@$this->templateNamespace/admin-form/edit.html.twig", [
+        return $this->render($create ? '@EMSCore/admin-form/add.html.twig' : '@EMSCore/admin-form/edit.html.twig', [
             'form' => $formType->createView(),
             'entity' => $form,
         ]);
@@ -123,7 +125,7 @@ class FormController extends AbstractController
             return $this->redirectToRoute(Routes::FORM_ADMIN_INDEX);
         }
 
-        return $this->render("@$this->templateNamespace/admin-form/reorder.html.twig", [
+        return $this->render('@EMSCore/admin-form/reorder.html.twig', [
             'form' => $formType->createView(),
             'entity' => $form,
         ]);

--- a/EMS/core-bundle/src/Controller/Form/SubmissionController.php
+++ b/EMS/core-bundle/src/Controller/Form/SubmissionController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace EMS\CoreBundle\Controller\Form;
 
 use EMS\CommonBundle\Contracts\SpreadsheetGeneratorServiceInterface;
+use EMS\CoreBundle\Controller\CoreControllerTrait;
 use EMS\CoreBundle\Core\DataTable\DataTableFactory;
 use EMS\CoreBundle\DataTable\Type\FormSubmissionDataTableType;
 use EMS\CoreBundle\Form\Data\TableAbstract;
@@ -27,14 +28,15 @@ use ZipStream\Stream;
 
 final class SubmissionController extends AbstractController
 {
+    use CoreControllerTrait;
+
     final public const BUFFER_SIZE = 8192;
 
     public function __construct(
         private readonly FormSubmissionService $formSubmissionService,
         private readonly LoggerInterface $logger,
         private readonly SpreadsheetGeneratorServiceInterface $spreadsheetGeneratorService,
-        private readonly DataTableFactory $dataTableFactory,
-        private readonly string $templateNamespace
+        private readonly DataTableFactory $dataTableFactory
     ) {
     }
 
@@ -66,7 +68,7 @@ final class SubmissionController extends AbstractController
             return $this->redirectToRoute('form.submissions');
         }
 
-        return $this->render("@$this->templateNamespace/form-submission/index.html.twig", [
+        return $this->render('@EMSCore/form-submission/index.html.twig', [
             'form' => $form->createView(),
         ]);
     }

--- a/EMS/core-bundle/src/Controller/I18nController.php
+++ b/EMS/core-bundle/src/Controller/I18nController.php
@@ -14,8 +14,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class I18nController extends AbstractController
 {
-    public function __construct(private readonly I18nService $i18nService, private readonly int $pagingSize, private readonly string $templateNamespace)
-    {
+    use CoreControllerTrait;
+
+    public function __construct(
+        private readonly I18nService $i18nService,
+        private readonly int $pagingSize
+    ) {
     }
 
     public function indexAction(Request $request): Response
@@ -40,7 +44,7 @@ class I18nController extends AbstractController
 
         $i18ns = $this->i18nService->findAll(($page - 1) * $paging_size, $paging_size, $filters);
 
-        return $this->render("@$this->templateNamespace/i18n/index.html.twig", [
+        return $this->render('@EMSCore/i18n/index.html.twig', [
             'i18nkeys' => $i18ns,
             'lastPage' => $lastPage,
             'paginationPath' => 'i18n_index',
@@ -64,7 +68,7 @@ class I18nController extends AbstractController
             return $this->redirectToRoute('i18n_index', ['id' => $i18n->getId()]);
         }
 
-        return $this->render("@$this->templateNamespace/i18n/new.html.twig", [
+        return $this->render('@EMSCore/i18n/new.html.twig', [
             'i18n' => $i18n,
             'form' => $form->createView(),
         ]);
@@ -91,7 +95,7 @@ class I18nController extends AbstractController
             return $this->redirectToRoute('i18n_index');
         }
 
-        return $this->render("@$this->templateNamespace/i18n/edit.html.twig", [
+        return $this->render('@EMSCore/i18n/edit.html.twig', [
             'i18n' => $i18n,
             'edit_form' => $editForm->createView(),
         ]);

--- a/EMS/core-bundle/src/Controller/Job/ScheduleController.php
+++ b/EMS/core-bundle/src/Controller/Job/ScheduleController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EMS\CoreBundle\Controller\Job;
 
+use EMS\CoreBundle\Controller\CoreControllerTrait;
 use EMS\CoreBundle\Core\DataTable\DataTableFactory;
 use EMS\CoreBundle\Core\Job\ScheduleManager;
 use EMS\CoreBundle\DataTable\Type\JobScheduleDataTableType;
@@ -19,13 +20,14 @@ use Symfony\Component\Form\SubmitButton;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-final class ScheduleController extends AbstractController
+class ScheduleController extends AbstractController
 {
+    use CoreControllerTrait;
+
     public function __construct(
         private readonly ScheduleManager $scheduleManager,
         private readonly LoggerInterface $logger,
-        private readonly DataTableFactory $dataTableFactory,
-        private readonly string $templateNamespace
+        private readonly DataTableFactory $dataTableFactory
     ) {
     }
 
@@ -55,7 +57,7 @@ final class ScheduleController extends AbstractController
             return $this->redirectToRoute(Routes::SCHEDULE_INDEX);
         }
 
-        return $this->render("@$this->templateNamespace/schedule/index.html.twig", [
+        return $this->render('@EMSCore/schedule/index.html.twig', [
             'form' => $form->createView(),
         ]);
     }
@@ -64,13 +66,13 @@ final class ScheduleController extends AbstractController
     {
         $schedule = new Schedule();
 
-        return $this->edit($request, $schedule, 'html', true, 'log.schedule.created', "@$this->templateNamespace/schedule/add.html.twig");
+        return $this->edit($request, $schedule, 'html', true, 'log.schedule.created', '@EMSCore/schedule/add.html.twig');
     }
 
     public function edit(Request $request, Schedule $schedule, string $_format, bool $create = false, string $logMessage = 'log.schedule.updated', ?string $template = null): Response
     {
         if (null === $template) {
-            $template = "@$this->templateNamespace/schedule/edit.html.twig";
+            $template = '@EMSCore/schedule/edit.html.twig';
         }
         $form = $this->createForm(ScheduleType::class, $schedule, [
             'create' => $create,
@@ -84,7 +86,7 @@ final class ScheduleController extends AbstractController
             ]);
 
             if ('json' === $_format) {
-                return $this->render("@$this->templateNamespace/ajax/notification.json.twig", [
+                return $this->render('@EMSCore/ajax/notification.json.twig', [
                     'success' => true,
                 ]);
             }

--- a/EMS/core-bundle/src/Controller/Log/LogController.php
+++ b/EMS/core-bundle/src/Controller/Log/LogController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace EMS\CoreBundle\Controller\Log;
 
 use EMS\CommonBundle\Entity\Log;
+use EMS\CoreBundle\Controller\CoreControllerTrait;
 use EMS\CoreBundle\Core\DataTable\DataTableFactory;
 use EMS\CoreBundle\Core\Log\LogManager;
 use EMS\CoreBundle\DataTable\Type\LogDataTableType;
@@ -20,11 +21,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class LogController extends AbstractController
 {
+    use CoreControllerTrait;
+
     public function __construct(
         private readonly LogManager $logManager,
         private readonly DataTableFactory $dataTableFactory,
-        private readonly LoggerInterface $logger,
-        private readonly string $templateNamespace
+        private readonly LoggerInterface $logger
     ) {
     }
 
@@ -47,14 +49,14 @@ class LogController extends AbstractController
             return $this->redirectToRoute(Routes::LOG_INDEX);
         }
 
-        return $this->render("@$this->templateNamespace/log/index.html.twig", [
+        return $this->render('@EMSCore/log/index.html.twig', [
             'form' => $form->createView(),
         ]);
     }
 
     public function view(Log $log): Response
     {
-        return $this->render("@$this->templateNamespace/log/view.html.twig", [
+        return $this->render('@EMSCore/log/view.html.twig', [
             'log' => $log,
         ]);
     }

--- a/EMS/core-bundle/src/Controller/NotificationController.php
+++ b/EMS/core-bundle/src/Controller/NotificationController.php
@@ -30,6 +30,8 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class NotificationController extends AbstractController
 {
+    use CoreControllerTrait;
+
     public function __construct(
         private readonly LoggerInterface $logger,
         private readonly PublishService $publishService,
@@ -38,9 +40,8 @@ class NotificationController extends AbstractController
         private readonly NotificationService $notificationService,
         private readonly DashboardManager $dashboardManager,
         private readonly NotificationRepository $notificationRepository,
-        private readonly int $pagingSize,
-        private readonly string $templateNamespace)
-    {
+        private readonly int $pagingSize
+    ) {
     }
 
     public function ajaxNotificationAction(Request $request): Response
@@ -80,7 +81,7 @@ class NotificationController extends AbstractController
 
         $success = $this->notificationService->addNotification($ct->getActionById(\intval($templateId)), $revision, $env);
 
-        return $this->render("@$this->templateNamespace/ajax/notification.json.twig", [
+        return $this->render('@EMSCore/ajax/notification.json.twig', [
                 'success' => $success,
         ]);
     }
@@ -146,7 +147,7 @@ class NotificationController extends AbstractController
 
     public function menuNotificationAction(): Response
     {
-        return $this->render("@$this->templateNamespace/notification/menu.html.twig", [
+        return $this->render('@EMSCore/notification/menu.html.twig', [
             'counter' => $this->notificationService->menuNotification(),
             'dashboardMenu' => $this->dashboardManager->getNotificationMenu(),
         ]);
@@ -194,7 +195,7 @@ class NotificationController extends AbstractController
                  'notifications' => $notifications,
          ]);
 
-        return $this->render("@$this->templateNamespace/notification/list.html.twig", [
+        return $this->render('@EMSCore/notification/list.html.twig', [
                 'counter' => $count,
                 'notifications' => $notifications,
                 'lastPage' => $lastPage,

--- a/EMS/core-bundle/src/Controller/QuerySearchController.php
+++ b/EMS/core-bundle/src/Controller/QuerySearchController.php
@@ -21,11 +21,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 final class QuerySearchController extends AbstractController
 {
+    use CoreControllerTrait;
+
     public function __construct(
         private readonly LoggerInterface $logger,
         private readonly QuerySearchService $querySearchService,
         private readonly DataTableFactory $dataTableFactory,
-        private readonly string $templateNamespace
     ) {
     }
 
@@ -55,7 +56,7 @@ final class QuerySearchController extends AbstractController
             return $this->redirectToRoute('ems_core_query_search_index');
         }
 
-        return $this->render("@$this->templateNamespace/query-search/index.html.twig", [
+        return $this->render('@EMSCore/query-search/index.html.twig', [
             'form' => $form->createView(),
         ]);
     }
@@ -64,13 +65,13 @@ final class QuerySearchController extends AbstractController
     {
         $querySearch = new QuerySearch();
 
-        return $this->edit($request, $querySearch, "@$this->templateNamespace/query-search/add.html.twig");
+        return $this->edit($request, $querySearch, '@EMSCore/query-search/add.html.twig');
     }
 
     public function edit(Request $request, QuerySearch $querySearch, ?string $view = null): Response
     {
-        if (null == $view) {
-            $view = "@$this->templateNamespace/query-search/edit.html.twig";
+        if (null === $view) {
+            $view = '@EMSCore/query-search/edit.html.twig';
         }
         $form = $this->createForm(QuerySearchType::class, $querySearch);
         $form->handleRequest($request);

--- a/EMS/core-bundle/src/Controller/Revision/DetailController.php
+++ b/EMS/core-bundle/src/Controller/Revision/DetailController.php
@@ -6,6 +6,7 @@ namespace EMS\CoreBundle\Controller\Revision;
 
 use EMS\CommonBundle\Elasticsearch\Response\Response as CommonResponse;
 use EMS\CommonBundle\Service\ElasticaService;
+use EMS\CoreBundle\Controller\CoreControllerTrait;
 use EMS\CoreBundle\Core\DataTable\DataTableFactory;
 use EMS\CoreBundle\Core\Log\LogRevisionContext;
 use EMS\CoreBundle\DataTable\Type\Revision\RevisionAuditDataTableType;
@@ -28,6 +29,8 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class DetailController extends AbstractController
 {
+    use CoreControllerTrait;
+
     public function __construct(
         private readonly ContentTypeService $contentTypeService,
         private readonly DataService $dataService,
@@ -36,9 +39,8 @@ class DetailController extends AbstractController
         private readonly ElasticaService $elasticaService,
         private readonly SearchService $searchService,
         private readonly DataTableFactory $dataTableFactory,
-        private readonly LoggerInterface $logger,
-        private readonly string $templateNamespace)
-    {
+        private readonly LoggerInterface $logger
+    ) {
     }
 
     public function detailRevision(Request $request, string $type, string $ouuid, int $revisionId, int $compareId): Response
@@ -151,7 +153,7 @@ class DetailController extends AbstractController
             $auditTableForm->handleRequest($request);
         }
 
-        return $this->render("@$this->templateNamespace/data/revisions-data.html.twig", [
+        return $this->render('@EMSCore/data/revisions-data.html.twig', [
             'revision' => $revision,
             'revisionsSummary' => $revisionsSummary,
             'latestVersion' => $latestVersion ?? null,

--- a/EMS/core-bundle/src/Controller/Revision/EditController.php
+++ b/EMS/core-bundle/src/Controller/Revision/EditController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EMS\CoreBundle\Controller\Revision;
 
+use EMS\CoreBundle\Controller\CoreControllerTrait;
 use EMS\CoreBundle\Core\ContentType\ContentTypeRoles;
 use EMS\CoreBundle\Core\DataTable\DataTableFactory;
 use EMS\CoreBundle\Core\Log\LogRevisionContext;
@@ -37,6 +38,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class EditController extends AbstractController
 {
+    use CoreControllerTrait;
+
     public function __construct(
         private readonly DataService $dataService,
         private readonly LoggerInterface $logger,
@@ -44,8 +47,7 @@ class EditController extends AbstractController
         private readonly RevisionService $revisionService,
         private readonly TranslatorInterface $translator,
         private readonly DataTableFactory $dataTableFactory,
-        private readonly ContentTypeService $contentTypeService,
-        private readonly string $templateNamespace
+        private readonly ContentTypeService $contentTypeService
     ) {
     }
 
@@ -82,7 +84,7 @@ class EditController extends AbstractController
             ]);
         }
 
-        return $this->render("@$this->templateNamespace/data/edit-json-revision.html.twig", [
+        return $this->render('@EMSCore/data/edit-json-revision.html.twig', [
             'revision' => $revision,
             'form' => $form->createView(),
         ]);
@@ -244,7 +246,7 @@ class EditController extends AbstractController
             ]);
         }
 
-        return $this->render("@$this->templateNamespace/data/edit-revision.html.twig", [
+        return $this->render('@EMSCore/data/edit-revision.html.twig', [
             'revision' => $revision,
             'form' => $form->createView(),
         ]);
@@ -286,7 +288,7 @@ class EditController extends AbstractController
             return $this->redirectToRoute(Routes::DRAFT_IN_PROGRESS, ['contentTypeId' => $contentTypeId->getId()]);
         }
 
-        return $this->render("@$this->templateNamespace/data/draft-in-progress.html.twig", [
+        return $this->render('@EMSCore/data/draft-in-progress.html.twig', [
             'form' => $form->createView(),
             'contentType' => $contentTypeId,
         ]);

--- a/EMS/core-bundle/src/Controller/Revision/TrashController.php
+++ b/EMS/core-bundle/src/Controller/Revision/TrashController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EMS\CoreBundle\Controller\Revision;
 
+use EMS\CoreBundle\Controller\CoreControllerTrait;
 use EMS\CoreBundle\Core\ContentType\ContentTypeRoles;
 use EMS\CoreBundle\Core\DataTable\DataTableFactory;
 use EMS\CoreBundle\DataTable\Type\Revision\RevisionTrashDataTableType;
@@ -21,11 +22,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class TrashController extends AbstractController
 {
+    use CoreControllerTrait;
+
     public function __construct(
         private readonly DataService $dataService,
         private readonly DataTableFactory $dataTableFactory,
-        private readonly LoggerInterface $logger,
-        private readonly string $templateNamespace
+        private readonly LoggerInterface $logger
     ) {
     }
 
@@ -57,7 +59,7 @@ class TrashController extends AbstractController
             };
         }
 
-        return $this->render("@$this->templateNamespace/data/trash.html.twig", [
+        return $this->render('@EMSCore/data/trash.html.twig', [
             'contentType' => $contentType,
             'revisions' => $this->dataService->getAllDeleted($contentType),
             'form' => $form->createView(),

--- a/EMS/core-bundle/src/Controller/SearchController.php
+++ b/EMS/core-bundle/src/Controller/SearchController.php
@@ -23,13 +23,14 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class SearchController extends AbstractController
 {
+    use CoreControllerTrait;
+
     public function __construct(
         private readonly SortOptionService $sortOptionService,
         private readonly AggregateOptionService $aggregateOptionService,
         private readonly SearchFieldOptionService $searchFieldOptionService,
-        private readonly TranslatorInterface $translator,
-        private readonly string $templateNamespace)
-    {
+        private readonly TranslatorInterface $translator
+    ) {
     }
 
     public function indexAction(Request $request): Response
@@ -58,13 +59,13 @@ class SearchController extends AbstractController
             return $this->redirectToRoute('ems_search_options_index');
         }
 
-        return $this->render("@$this->templateNamespace/search-options/index.html.twig", [
-                'sortOptions' => $this->sortOptionService->getAll(),
-                'aggregateOptions' => $this->aggregateOptionService->getAll(),
-                'searchFieldOptions' => $this->searchFieldOptionService->getAll(),
-                'sortOptionReorderForm' => $reorderSortOptionForm->createView(),
-                'aggregateOptionReorderForm' => $reorderAggregateOptionForm->createView(),
-                'searchFieldOptionReorderForm' => $searchFieldOptionForm->createView(),
+        return $this->render('@EMSCore/search-options/index.html.twig', [
+            'sortOptions' => $this->sortOptionService->getAll(),
+            'aggregateOptions' => $this->aggregateOptionService->getAll(),
+            'searchFieldOptions' => $this->searchFieldOptionService->getAll(),
+            'sortOptionReorderForm' => $reorderSortOptionForm->createView(),
+            'aggregateOptionReorderForm' => $reorderAggregateOptionForm->createView(),
+            'searchFieldOptionReorderForm' => $searchFieldOptionForm->createView(),
         ]);
     }
 
@@ -82,7 +83,7 @@ class SearchController extends AbstractController
             return $this->redirectToRoute('ems_search_options_index');
         }
 
-        return $this->render("@$this->templateNamespace/entity/new.html.twig", [
+        return $this->render('@EMSCore/entity/new.html.twig', [
             'entity_name' => $this->translator->trans('search.sort_option_label', [], EMSCoreExtension::TRANS_DOMAIN),
             'form' => $form->createView(),
         ]);
@@ -102,7 +103,7 @@ class SearchController extends AbstractController
             return $this->redirectToRoute('ems_search_options_index');
         }
 
-        return $this->render("@$this->templateNamespace/entity/new.html.twig", [
+        return $this->render('@EMSCore/entity/new.html.twig', [
             'entity_name' => $this->translator->trans('search.search_field_option_label', [], EMSCoreExtension::TRANS_DOMAIN),
             'form' => $form->createView(),
         ]);
@@ -112,7 +113,7 @@ class SearchController extends AbstractController
     {
         $aggregateOption = new AggregateOption();
         $form = $this->createForm(AggregateOptionType::class, $aggregateOption, [
-                'createform' => true,
+            'createform' => true,
         ]);
         $form->handleRequest($request);
 
@@ -122,9 +123,9 @@ class SearchController extends AbstractController
             return $this->redirectToRoute('ems_search_options_index');
         }
 
-        return $this->render("@$this->templateNamespace/entity/new.html.twig", [
-                'entity_name' => $this->translator->trans('search.aggregate_option_label', [], EMSCoreExtension::TRANS_DOMAIN),
-                'form' => $form->createView(),
+        return $this->render('@EMSCore/entity/new.html.twig', [
+            'entity_name' => $this->translator->trans('search.aggregate_option_label', [], EMSCoreExtension::TRANS_DOMAIN),
+            'form' => $form->createView(),
         ]);
     }
 
@@ -148,9 +149,9 @@ class SearchController extends AbstractController
             }
         }
 
-        return $this->render("@$this->templateNamespace/entity/edit.html.twig", [
-                'entity_name' => $this->translator->trans('search.sort_option_label', [], EMSCoreExtension::TRANS_DOMAIN),
-                'form' => $form->createView(),
+        return $this->render('@EMSCore/entity/edit.html.twig', [
+            'entity_name' => $this->translator->trans('search.sort_option_label', [], EMSCoreExtension::TRANS_DOMAIN),
+            'form' => $form->createView(),
         ]);
     }
 
@@ -174,9 +175,9 @@ class SearchController extends AbstractController
             }
         }
 
-        return $this->render("@$this->templateNamespace/entity/edit.html.twig", [
-                'entity_name' => $this->translator->trans('search.search_field_option_label', [], EMSCoreExtension::TRANS_DOMAIN),
-                'form' => $form->createView(),
+        return $this->render('@EMSCore/entity/edit.html.twig', [
+            'entity_name' => $this->translator->trans('search.search_field_option_label', [], EMSCoreExtension::TRANS_DOMAIN),
+            'form' => $form->createView(),
         ]);
     }
 
@@ -200,9 +201,9 @@ class SearchController extends AbstractController
             }
         }
 
-        return $this->render("@$this->templateNamespace/entity/edit.html.twig", [
-                'entity_name' => $this->translator->trans('search.aggregate_option_label', [], EMSCoreExtension::TRANS_DOMAIN),
-                'form' => $form->createView(),
+        return $this->render('@EMSCore/entity/edit.html.twig', [
+            'entity_name' => $this->translator->trans('search.aggregate_option_label', [], EMSCoreExtension::TRANS_DOMAIN),
+            'form' => $form->createView(),
         ]);
     }
 }

--- a/EMS/core-bundle/src/Controller/TwigElementsController.php
+++ b/EMS/core-bundle/src/Controller/TwigElementsController.php
@@ -16,6 +16,8 @@ use Symfony\Component\HttpFoundation\Response;
 
 class TwigElementsController extends AbstractController
 {
+    use CoreControllerTrait;
+
     final public const ASSET_EXTRACTOR_STATUS_CACHE_ID = 'status.asset_extractor.result';
 
     public function __construct(
@@ -25,8 +27,7 @@ class TwigElementsController extends AbstractController
         private readonly JobService $jobService,
         private readonly DashboardManager $dashboardManager,
         private readonly ContentTypeService $contentTypeService,
-        private readonly string $templateNamespace)
-    {
+    ) {
     }
 
     public function sideMenuAction(): Response
@@ -36,32 +37,26 @@ class TwigElementsController extends AbstractController
             $status = $this->getAssetExtractorStatus();
         }
 
-        return $this->render(
-            "@$this->templateNamespace/elements/side-menu.html.twig",
-            [
-                'status' => $status,
-                'menu' => [
-                    $this->userService->getSidebarMenu(),
-                    $this->dashboardManager->getSidebarMenu(),
-                    $this->contentTypeService->getContentTypeMenu(),
-                    $this->getPublisherMenu(),
-                    $this->getCrmMenu(),
-                    $this->getUserAdminMenu(),
-                    $this->getAdminMenu(),
-                    $this->getOtherMenu(),
-                ],
-            ]
-        );
+        return $this->render('@EMSCore/elements/side-menu.html.twig', [
+            'status' => $status,
+            'menu' => [
+                $this->userService->getSidebarMenu(),
+                $this->dashboardManager->getSidebarMenu(),
+                $this->contentTypeService->getContentTypeMenu(),
+                $this->getPublisherMenu(),
+                $this->getCrmMenu(),
+                $this->getUserAdminMenu(),
+                $this->getAdminMenu(),
+                $this->getOtherMenu(),
+            ],
+        ]);
     }
 
     public function jobsAction(string $username): Response
     {
-        return $this->render(
-            "@$this->templateNamespace/elements/jobs-list.html.twig",
-            [
-                'jobs' => $this->jobService->findByUser($username),
-            ]
-        );
+        return $this->render('@EMSCore/elements/jobs-list.html.twig', [
+            'jobs' => $this->jobService->findByUser($username),
+        ]);
     }
 
     private function getAssetExtractorStatus(): string

--- a/EMS/core-bundle/src/Controller/UploadedFileController.php
+++ b/EMS/core-bundle/src/Controller/UploadedFileController.php
@@ -23,6 +23,8 @@ use Symfony\Component\HttpFoundation\Response;
 
 class UploadedFileController extends AbstractController
 {
+    use CoreControllerTrait;
+
     /** @var string */
     final public const SOFT_DELETE_ACTION = 'soft_delete';
     /** @var string */
@@ -32,7 +34,6 @@ class UploadedFileController extends AbstractController
         private readonly LoggerInterface $logger,
         private readonly FileService $fileService,
         private readonly DataTableFactory $dataTableFactory,
-        private readonly string $templateNamespace
     ) {
     }
 
@@ -42,7 +43,7 @@ class UploadedFileController extends AbstractController
         $dataTableRequest = DataTableRequest::fromRequest($request);
         $table->resetIterator($dataTableRequest);
 
-        return $this->render("@$this->templateNamespace/datatable/ajax.html.twig", [
+        return $this->render('@EMSCore/datatable/ajax.html.twig', [
             'dataTableRequest' => $dataTableRequest,
             'table' => $table,
         ], new JsonResponse());
@@ -74,7 +75,7 @@ class UploadedFileController extends AbstractController
             return $this->redirectToRoute('ems_core_uploaded_file_index');
         }
 
-        return $this->render("@$this->templateNamespace/uploaded-file/index.html.twig", [
+        return $this->render('@EMSCore/uploaded-file/index.html.twig', [
             'form' => $form->createView(),
         ]);
     }
@@ -110,7 +111,7 @@ class UploadedFileController extends AbstractController
             return $this->redirectToRoute('ems_core_uploaded_file_logs');
         }
 
-        return $this->render("@$this->templateNamespace/uploaded-file-logs/index.html.twig", [
+        return $this->render('@EMSCore/uploaded-file-logs/index.html.twig', [
             'form' => $form->createView(),
         ]);
     }
@@ -153,7 +154,7 @@ class UploadedFileController extends AbstractController
 
     private function initFileTable(): QueryTable
     {
-        $table = new QueryTable($this->templateNamespace, $this->fileService, 'uploaded-files-grouped-by-hash', $this->generateUrl('ems_core_uploaded_file_ajax'));
+        $table = new QueryTable($this->getTemplateNamespace(), $this->fileService, 'uploaded-files-grouped-by-hash', $this->generateUrl('ems_core_uploaded_file_ajax'));
         $table->addColumn('uploaded-file.index.column.name', 'name')
             ->setRoute('ems_file_download', function (array $data) {
                 if (!\is_string($data['id'] ?? null) || !\is_string($data['type'] ?? null) || !\is_string($data['name'] ?? null)) {

--- a/EMS/core-bundle/src/Controller/UploadedFileWysiwygController.php
+++ b/EMS/core-bundle/src/Controller/UploadedFileWysiwygController.php
@@ -14,10 +14,11 @@ use Symfony\Component\HttpFoundation\Response;
 
 final class UploadedFileWysiwygController extends AbstractController
 {
+    use CoreControllerTrait;
+
     public function __construct(
         private readonly AjaxService $ajax,
-        private readonly DataTableFactory $dataTableFactory,
-        private readonly string $templateNamespace
+        private readonly DataTableFactory $dataTableFactory
     ) {
     }
 
@@ -27,7 +28,7 @@ final class UploadedFileWysiwygController extends AbstractController
         $form = $this->createForm(TableType::class, $table);
         $form->handleRequest($request);
 
-        return $this->render("@$this->templateNamespace/uploaded-file-wysiwyg/index.html.twig", [
+        return $this->render('@EMSCore/uploaded-file-wysiwyg/index.html.twig', [
             'form' => $form->createView(),
             'CKEditorFuncNum' => $request->query->get('CKEditorFuncNum') ?: 0,
         ]);
@@ -38,7 +39,7 @@ final class UploadedFileWysiwygController extends AbstractController
         $table = $this->dataTableFactory->create(WysiwygUploadedFileDataTableType::class);
         $form = $this->createForm(TableType::class, $table);
 
-        return $this->ajax->newAjaxModel("@$this->templateNamespace/uploaded-file-wysiwyg/modal.html.twig")
+        return $this->ajax->newAjaxModel('@'.$this->getTemplateNamespace().'/uploaded-file-wysiwyg/modal.html.twig')
             ->setBody('modalBody', ['form' => $form->createView()])
             ->getResponse();
     }

--- a/EMS/core-bundle/src/Controller/User/LoginController.php
+++ b/EMS/core-bundle/src/Controller/User/LoginController.php
@@ -4,25 +4,24 @@ declare(strict_types=1);
 
 namespace EMS\CoreBundle\Controller\User;
 
+use EMS\CoreBundle\Controller\CoreControllerTrait;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
-use Twig\Environment;
 
-class LoginController
+class LoginController extends AbstractController
 {
-    public function __construct(private readonly Environment $twig, private readonly string $templateNamespace)
-    {
-    }
+    use CoreControllerTrait;
 
     public function login(AuthenticationUtils $authenticationUtils): Response
     {
         $error = $authenticationUtils->getLastAuthenticationError();
         $lastUsername = $authenticationUtils->getLastUsername();
 
-        return new Response($this->twig->render("@$this->templateNamespace/user/login.html.twig", [
+        return $this->render('@EMSCore/user/login.html.twig', [
             'last_username' => $lastUsername,
             'error' => $error,
-        ]));
+        ]);
     }
 
     public function logout(): never

--- a/EMS/core-bundle/src/Controller/User/ProfileController.php
+++ b/EMS/core-bundle/src/Controller/User/ProfileController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EMS\CoreBundle\Controller\User;
 
+use EMS\CoreBundle\Controller\CoreControllerTrait;
 use EMS\CoreBundle\Core\User\UserManager;
 use EMS\CoreBundle\Form\User\ChangePasswordType;
 use EMS\CoreBundle\Form\User\UserProfileType;
@@ -15,13 +16,17 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ProfileController extends AbstractController
 {
-    public function __construct(private readonly UserManager $userManager, private readonly LoggerInterface $logger, private readonly string $templateNamespace)
-    {
+    use CoreControllerTrait;
+
+    public function __construct(
+        private readonly UserManager $userManager,
+        private readonly LoggerInterface $logger
+    ) {
     }
 
     public function show(): Response
     {
-        return $this->render("@$this->templateNamespace/user/profile/show.html.twig", [
+        return $this->render('@EMSCore/user/profile/show.html.twig', [
             'user' => $this->userManager->getAuthenticatedUser(),
         ]);
     }
@@ -39,7 +44,7 @@ class ProfileController extends AbstractController
             return $this->redirectToRoute(Routes::USER_PROFILE);
         }
 
-        return $this->render("@$this->templateNamespace/user/profile/edit.html.twig", [
+        return $this->render('@EMSCore/user/profile/edit.html.twig', [
             'form' => $form->createView(),
         ]);
     }
@@ -58,7 +63,7 @@ class ProfileController extends AbstractController
             return $this->redirectToRoute(Routes::USER_PROFILE);
         }
 
-        return $this->render("@$this->templateNamespace/user/profile/change_password.html.twig", [
+        return $this->render('@EMSCore/user/profile/change_password.html.twig', [
             'form' => $form->createView(),
         ]);
     }

--- a/EMS/core-bundle/src/Controller/User/ResettingController.php
+++ b/EMS/core-bundle/src/Controller/User/ResettingController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EMS\CoreBundle\Controller\User;
 
+use EMS\CoreBundle\Controller\CoreControllerTrait;
 use EMS\CoreBundle\Core\User\UserManager;
 use EMS\CoreBundle\Form\User\ResettingRequestType;
 use EMS\CoreBundle\Form\User\ResettingResetType;
@@ -16,8 +17,13 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ResettingController extends AbstractController
 {
-    public function __construct(private readonly UserManager $userManager, private readonly Authenticator $authenticator, private readonly LoggerInterface $logger, private readonly string $templateNamespace)
-    {
+    use CoreControllerTrait;
+
+    public function __construct(
+        private readonly UserManager $userManager,
+        private readonly Authenticator $authenticator,
+        private readonly LoggerInterface $logger
+    ) {
     }
 
     public function request(Request $request): Response
@@ -36,7 +42,7 @@ class ResettingController extends AbstractController
             }
         }
 
-        return $this->render("@$this->templateNamespace/user/resetting/request.html.twig", [
+        return $this->render('@EMSCore/user/resetting/request.html.twig', [
             'form' => $form->createView(),
         ]);
     }
@@ -49,7 +55,7 @@ class ResettingController extends AbstractController
             return $this->redirectToRoute('emsco_user_resetting_request');
         }
 
-        return $this->render("@$this->templateNamespace/user/resetting/check_email.html.twig", [
+        return $this->render('@EMSCore/user/resetting/check_email.html.twig', [
             'tokenLifetime' => UserManager::PASSWORD_RETRY_TTL,
         ]);
     }
@@ -75,7 +81,7 @@ class ResettingController extends AbstractController
             return $this->redirectToRoute(Routes::USER_PROFILE);
         }
 
-        return $this->render("@$this->templateNamespace/user/resetting/reset.html.twig", [
+        return $this->render('@EMSCore/user/resetting/reset.html.twig', [
             'form' => $form->createView(),
         ]);
     }

--- a/EMS/core-bundle/src/Controller/UserController.php
+++ b/EMS/core-bundle/src/Controller/UserController.php
@@ -22,6 +22,8 @@ use Symfony\Component\HttpFoundation\Response;
 
 class UserController extends AbstractController
 {
+    use CoreControllerTrait;
+
     public function __construct(
         private readonly LoggerInterface $logger,
         private readonly UserService $userService,
@@ -30,7 +32,6 @@ class UserController extends AbstractController
         private readonly DataTableFactory $dataTableFactory,
         private readonly AuthTokenRepository $authTokenRepository,
         private readonly WysiwygProfileRepository $wysiwygProfileRepository,
-        private readonly string $templateNamespace,
         private readonly string $dateTimeFormat
     ) {
     }
@@ -42,7 +43,7 @@ class UserController extends AbstractController
         $form = $this->createForm(TableType::class, $table);
         $form->handleRequest($request);
 
-        return $this->render("@$this->templateNamespace/user/index.html.twig", [
+        return $this->render('@EMSCore/user/index.html.twig', [
             'form' => $form->createView(),
         ]);
     }
@@ -70,7 +71,7 @@ class UserController extends AbstractController
             }
         }
 
-        return $this->render("@$this->templateNamespace/user/add.html.twig", [
+        return $this->render('@EMSCore/user/add.html.twig', [
             'form' => $form->createView(),
         ]);
     }
@@ -96,7 +97,7 @@ class UserController extends AbstractController
             return $this->redirectToRoute(Routes::USER_INDEX);
         }
 
-        return $this->render("@$this->templateNamespace/user/edit.html.twig", [
+        return $this->render('@EMSCore/user/edit.html.twig', [
             'form' => $form->createView(),
             'user' => $user,
         ]);
@@ -181,7 +182,7 @@ class UserController extends AbstractController
         $user->setSidebarCollapse($collapsed);
         $this->userService->updateUser($user);
 
-        return $this->render("@$this->templateNamespace/ajax/notification.json.twig", [
+        return $this->render('@EMSCore/ajax/notification.json.twig', [
             'success' => true,
         ]);
     }

--- a/EMS/core-bundle/src/Controller/Views/CalendarController.php
+++ b/EMS/core-bundle/src/Controller/Views/CalendarController.php
@@ -4,6 +4,7 @@ namespace EMS\CoreBundle\Controller\Views;
 
 use EMS\CommonBundle\Helper\EmsFields;
 use EMS\CommonBundle\Service\ElasticaService;
+use EMS\CoreBundle\Controller\CoreControllerTrait;
 use EMS\CoreBundle\Entity\Form\Search;
 use EMS\CoreBundle\Entity\View;
 use EMS\CoreBundle\Form\Form\SearchFormType;
@@ -17,8 +18,14 @@ use Symfony\Component\HttpFoundation\Response;
 
 class CalendarController extends AbstractController
 {
-    public function __construct(private readonly LoggerInterface $logger, private readonly ElasticaService $elasticaService, private readonly DataService $dataService, private readonly SearchService $searchService, private readonly string $templateNamespace)
-    {
+    use CoreControllerTrait;
+
+    public function __construct(
+        private readonly LoggerInterface $logger,
+        private readonly ElasticaService $elasticaService,
+        private readonly DataService $dataService,
+        private readonly SearchService $searchService
+    ) {
     }
 
     public function update(View $view, Request $request): Response
@@ -54,7 +61,7 @@ class CalendarController extends AbstractController
             $revision->setRawData($rawData);
             $this->dataService->finalizeDraft($revision);
 
-            return $this->render("@$this->templateNamespace/view/custom/calendar_replan.json.twig", [
+            return $this->render('@EMSCore/view/custom/calendar_replan.json.twig', [
                 'success' => true,
             ]);
         } catch (\Exception $e) {
@@ -63,7 +70,7 @@ class CalendarController extends AbstractController
                 EmsFields::LOG_EXCEPTION_FIELD => $e,
             ]);
 
-            return $this->render("@$this->templateNamespace/ajax/notification.json.twig", [
+            return $this->render('@EMSCore/ajax/notification.json.twig', [
                 'success' => false,
             ]);
         }
@@ -135,7 +142,7 @@ class CalendarController extends AbstractController
 
         $search = $this->elasticaService->convertElasticsearchSearch($searchQuery);
 
-        return $this->render("@$this->templateNamespace/view/custom/calendar_search.json.twig", [
+        return $this->render('@EMSCore/view/custom/calendar_search.json.twig', [
             'success' => true,
             'data' => $this->elasticaService->search($search)->getResponse()->getData(),
             'field' => $view->getContentType()->getFieldType()->get('ems_'.$view->getOptions()['dateRangeField']),

--- a/EMS/core-bundle/src/Controller/Views/CriteriaController.php
+++ b/EMS/core-bundle/src/Controller/Views/CriteriaController.php
@@ -7,6 +7,7 @@ use EMS\CommonBundle\Elasticsearch\Response\Response as EmsResponse;
 use EMS\CommonBundle\Helper\EmsFields;
 use EMS\CommonBundle\Search\Search;
 use EMS\CommonBundle\Service\ElasticaService;
+use EMS\CoreBundle\Controller\CoreControllerTrait;
 use EMS\CoreBundle\Core\ContentType\ContentTypeRoles;
 use EMS\CoreBundle\Entity\DataField;
 use EMS\CoreBundle\Entity\FieldType;
@@ -40,6 +41,8 @@ use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 class CriteriaController extends AbstractController
 {
+    use CoreControllerTrait;
+
     public function __construct(
         private readonly LoggerInterface $logger,
         private readonly ElasticaService $elasticaService,
@@ -50,8 +53,7 @@ class CriteriaController extends AbstractController
         private readonly FormRegistryInterface $formRegistry,
         private readonly FieldTypeRepository $fieldTypeRepository,
         private readonly RevisionRepository $revisionRepository,
-        private readonly string $templateNamespace)
-    {
+    ) {
     }
 
     public function align(View $view, Request $request): Response
@@ -265,7 +267,7 @@ class CriteriaController extends AbstractController
         }
 
         if (!$valid) {
-            return $this->render("@$this->templateNamespace/view/custom/criteria_view.html.twig", [
+            return $this->render('@EMSCore/view/custom/criteria_view.html.twig', [
                     'view' => $view,
                     'form' => $form->createView(),
                     'contentType' => $contentType,
@@ -307,7 +309,7 @@ class CriteriaController extends AbstractController
 
         $tables = $this->generateCriteriaTable($view, $criteriaUpdateConfig);
 
-        return $this->render("@$this->templateNamespace/view/custom/criteria_table.html.twig", [
+        return $this->render('@EMSCore/view/custom/criteria_table.html.twig', [
             'table' => $tables['table'],
             'rowFieldType' => $rowField,
             'columnFieldType' => $columnField,
@@ -513,8 +515,8 @@ class CriteriaController extends AbstractController
                     EmsFields::LOG_REVISION_ID_FIELD => $revision->getId(),
                 ]);
 
-                return $this->render("@$this->templateNamespace/ajax/notification.json.twig", [
-                        'success' => false,
+                return $this->render('@EMSCore/ajax/notification.json.twig', [
+                    'success' => false,
                 ]);
             }
 
@@ -526,8 +528,8 @@ class CriteriaController extends AbstractController
                     'count' => 0,
                 ]);
 
-                return $this->render("@$this->templateNamespace/ajax/notification.json.twig", [
-                        'success' => false,
+                return $this->render('@EMSCore/ajax/notification.json.twig', [
+                    'success' => false,
                 ]);
             }
 
@@ -548,8 +550,8 @@ class CriteriaController extends AbstractController
                     'locked_by' => $revision->getLockBy(),
                 ]);
 
-                return $this->render("@$this->templateNamespace/ajax/notification.json.twig", [
-                        'success' => false,
+                return $this->render('@EMSCore/ajax/notification.json.twig', [
+                    'success' => false,
                 ]);
             }
         } else {
@@ -570,8 +572,8 @@ class CriteriaController extends AbstractController
             }
         }
 
-        return $this->render("@$this->templateNamespace/ajax/notification.json.twig", [
-                'success' => true,
+        return $this->render('@EMSCore/ajax/notification.json.twig', [
+            'success' => true,
         ]);
     }
 
@@ -805,7 +807,7 @@ class CriteriaController extends AbstractController
                     'count' => 0,
                 ]);
 
-                return $this->render("@$this->templateNamespace/ajax/notification.json.twig", [
+                return $this->render('@EMSCore/ajax/notification.json.twig', [
                         'success' => false,
                 ]);
             }
@@ -827,7 +829,7 @@ class CriteriaController extends AbstractController
                     'locked_by' => $revision->getLockBy(),
                 ]);
 
-                return $this->render("@$this->templateNamespace/ajax/notification.json.twig", [
+                return $this->render('@EMSCore/ajax/notification.json.twig', [
                         'success' => false,
                 ]);
             }
@@ -849,7 +851,7 @@ class CriteriaController extends AbstractController
             }
         }
 
-        return $this->render("@$this->templateNamespace/ajax/notification.json.twig", [
+        return $this->render('@EMSCore/ajax/notification.json.twig', [
             'success' => true,
         ]);
     }

--- a/EMS/core-bundle/src/Controller/Views/HierarchicalController.php
+++ b/EMS/core-bundle/src/Controller/Views/HierarchicalController.php
@@ -3,17 +3,21 @@
 namespace EMS\CoreBundle\Controller\Views;
 
 use EMS\CommonBundle\Elasticsearch\Exception\NotFoundException;
+use EMS\CoreBundle\Controller\CoreControllerTrait;
 use EMS\CoreBundle\Entity\View;
 use EMS\CoreBundle\Service\ContentTypeService;
 use EMS\CoreBundle\Service\SearchService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class HierarchicalController extends AbstractController
 {
-    public function __construct(private readonly ContentTypeService $contentTypeService, private readonly SearchService $searchService, private readonly string $templateNamespace)
-    {
+    use CoreControllerTrait;
+
+    public function __construct(
+        private readonly ContentTypeService $contentTypeService,
+        private readonly SearchService $searchService
+    ) {
     }
 
     public function item(View $view, string $key): Response
@@ -21,20 +25,20 @@ class HierarchicalController extends AbstractController
         $ouuid = \explode(':', $key);
         $contentType = $this->contentTypeService->getByName($ouuid[0]);
         if (false === $contentType) {
-            throw new NotFoundHttpException(\sprintf('Content type %s not found', $ouuid[0]));
+            throw $this->createNotFoundException(\sprintf('Content type %s not found', $ouuid[0]));
         }
         try {
             $document = $this->searchService->getDocument($contentType, $ouuid[1]);
         } catch (NotFoundException) {
-            throw new NotFoundHttpException(\sprintf('Document %s not found', $ouuid[1]));
+            throw $this->createNotFoundException(\sprintf('Document %s not found', $ouuid[1]));
         }
 
-        return $this->render("@$this->templateNamespace/view/custom/hierarchical_add_item.html.twig", [
-                'data' => $document->getSource(),
-                'view' => $view,
-                'contentType' => $contentType,
-                'key' => $ouuid,
-                'child' => $key,
+        return $this->render('@EMSCore/view/custom/hierarchical_add_item.html.twig', [
+            'data' => $document->getSource(),
+            'view' => $view,
+            'contentType' => $contentType,
+            'key' => $ouuid,
+            'child' => $key,
         ]);
     }
 }

--- a/EMS/core-bundle/src/Controller/Wysiwyg/StylesetController.php
+++ b/EMS/core-bundle/src/Controller/Wysiwyg/StylesetController.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace EMS\CoreBundle\Controller\Wysiwyg;
 
+use EMS\CoreBundle\Controller\CoreControllerTrait;
 use EMS\CoreBundle\Service\WysiwygStylesSetService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 
 class StylesetController extends AbstractController
 {
-    public function __construct(private readonly WysiwygStylesSetService $wysiwygStylesSetService, private readonly string $templateNamespace)
+    use CoreControllerTrait;
+
+    public function __construct(private readonly WysiwygStylesSetService $wysiwygStylesSetService)
     {
     }
 
@@ -18,7 +21,7 @@ class StylesetController extends AbstractController
     {
         $splitLanguage = \explode('_', $language);
 
-        return $this->render("@$this->templateNamespace/wysiwyg_styles_set/iframe.html.twig", [
+        return $this->render('@EMSCore/wysiwyg_styles_set/iframe.html.twig', [
             'styleSet' => $this->wysiwygStylesSetService->getByName($name),
             'language' => \array_shift($splitLanguage),
         ]);

--- a/EMS/core-bundle/src/Controller/WysiwygController.php
+++ b/EMS/core-bundle/src/Controller/WysiwygController.php
@@ -27,11 +27,13 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class WysiwygController extends AbstractController
 {
-    public function __construct(private readonly LoggerInterface $logger,
+    use CoreControllerTrait;
+
+    public function __construct(
+        private readonly LoggerInterface $logger,
         private readonly WysiwygProfileService $wysiwygProfileService,
         private readonly WysiwygStylesSetService $wysiwygStylesSetService,
         private readonly TranslatorInterface $translator,
-        private readonly string $templateNamespace,
         private readonly DataTableFactory $dataTableFactory,
         private readonly FormFactoryInterface $formFactory,
     ) {
@@ -91,7 +93,7 @@ class WysiwygController extends AbstractController
             return $this->redirectToRoute('ems_wysiwyg_index');
         }
 
-        return $this->render("@$this->templateNamespace/wysiwygprofile/index.html.twig", [
+        return $this->render('@EMSCore/wysiwygprofile/index.html.twig', [
                 'profiles' => $this->wysiwygProfileService->getProfiles(),
                 'stylesSets' => $this->wysiwygStylesSetService->getStylesSets(),
                 'formProfiles' => $formProfiles->createView(),
@@ -120,7 +122,7 @@ class WysiwygController extends AbstractController
             }
         }
 
-        return $this->render("@$this->templateNamespace/wysiwygprofile/new.html.twig", [
+        return $this->render('@EMSCore/wysiwygprofile/new.html.twig', [
             'form' => $form->createView(),
         ]);
     }
@@ -146,8 +148,8 @@ class WysiwygController extends AbstractController
             }
         }
 
-        return $this->render("@$this->templateNamespace/wysiwyg_styles_set/new.html.twig", [
-                'form' => $form->createView(),
+        return $this->render('@EMSCore/wysiwyg_styles_set/new.html.twig', [
+            'form' => $form->createView(),
         ]);
     }
 
@@ -176,8 +178,8 @@ class WysiwygController extends AbstractController
             }
         }
 
-        return $this->render("@$this->templateNamespace/wysiwyg_styles_set/edit.html.twig", [
-                'form' => $form->createView(),
+        return $this->render('@EMSCore/wysiwyg_styles_set/edit.html.twig', [
+            'form' => $form->createView(),
         ]);
     }
 
@@ -206,8 +208,8 @@ class WysiwygController extends AbstractController
             }
         }
 
-        return $this->render("@$this->templateNamespace/wysiwygprofile/edit.html.twig", [
-                'form' => $form->createView(),
+        return $this->render('@EMSCore/wysiwygprofile/edit.html.twig', [
+            'form' => $form->createView(),
         ]);
     }
 }

--- a/EMS/core-bundle/src/Resources/config/controllers.xml
+++ b/EMS/core-bundle/src/Resources/config/controllers.xml
@@ -233,7 +233,6 @@
             <argument type="service" id="logger" />
             <argument type="service" id="ems.service.release" />
             <argument type="service" id="emsco.data_table.factory" />
-            <argument>%ems_core.template_namespace%</argument>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>

--- a/EMS/core-bundle/src/Resources/config/controllers.xml
+++ b/EMS/core-bundle/src/Resources/config/controllers.xml
@@ -75,7 +75,6 @@
             <argument type="service" id="emsco.data_table.factory" />
             <argument type="service" id="EMS\CoreBundle\Repository\ContentTypeRepository" />
             <argument type="service" id="EMS\CoreBundle\Repository\TemplateRepository" />
-            <argument>%ems_core.template_namespace%</argument>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
@@ -84,7 +83,6 @@
             <argument type="service" id="emsco.logger" />
             <argument type="service" id="ems.service.helper" />
             <argument type="service" id="ems.repository.analyzer" />
-            <argument>%ems_core.template_namespace%</argument>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
@@ -105,7 +103,6 @@
             <argument type="service" id="EMS\CoreBundle\Repository\ContentTypeRepository" />
             <argument type="service" id="EMS\CoreBundle\Repository\EnvironmentRepository" />
             <argument type="service" id="ems.repository.field_type" />
-            <argument>%ems_core.template_namespace%</argument>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
@@ -115,9 +112,9 @@
             <argument type="service" id="ems.service.user" />
             <argument type="service" id="ems.service.data" />
             <argument type="service" id="ems.service.contenttype" />
-            <argument>%ems_core.template_namespace%</argument>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
+            <tag name="controller.service_arguments"/>
         </service>
         <service id="EMS\CoreBundle\Controller\ContentManagement\DataController" public="true">
             <argument type="service" id="logger" />
@@ -135,7 +132,6 @@
             <argument type="service" id="EMS\CoreBundle\Repository\RevisionRepository" />
             <argument type="service" id="EMS\CoreBundle\Repository\TemplateRepository" />
             <argument type="service" id="EMS\CoreBundle\Repository\EnvironmentRepository" />
-            <argument>%ems_core.template_namespace%</argument>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
@@ -146,7 +142,6 @@
             <argument type="service" id="ems_core.core_data_table.table_renderer" />
             <argument type="service" id="ems_core.core_data_table.table_exporter" />
             <argument type="service" id="security.token_storage" />
-            <argument>%ems_core.template_namespace%</argument>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
@@ -169,16 +164,15 @@
             <argument>%ems_core.paging_size%</argument>
             <argument>%ems_core.instance_id%</argument>
             <argument>%ems_core.circles_object%</argument>
-            <argument>%ems_core.template_namespace%</argument>
             <argument type="service" id="emsco.data_table.factory" />
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
+            <tag name="controller.service_arguments"/>
         </service>
         <service id="EMS\CoreBundle\Controller\ContentManagement\FileController" public="true">
             <argument type="service" id="ems.service.file" />
             <argument type="service" id="ems.service.asset_extractor" />
             <argument type="service" id="emsco.logger" />
-            <argument>%ems_core.template_namespace%</argument>
             <argument>%ems_core.theme_color%</argument>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
@@ -187,7 +181,6 @@
             <argument type="service" id="emsco.logger" />
             <argument type="service" id="ems.service.helper" />
             <argument type="service" id="ems.repository.filter" />
-            <argument>%ems_core.template_namespace%</argument>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
@@ -202,7 +195,6 @@
             <argument type="service" id="ems.service.job" />
             <argument>%ems_core.paging_size%</argument>
             <argument>%ems_core.trigger_job_from_web%</argument>
-            <argument>%ems_core.template_namespace%</argument>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
@@ -212,7 +204,6 @@
             <argument type="service" id="ems.service.alias" />
             <argument type="service" id="EMS\CoreBundle\Repository\ManagedAliasRepository" />
             <argument>%ems_core.instance_id%</argument>
-            <argument>%ems_core.template_namespace%</argument>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
@@ -224,7 +215,6 @@
             <argument type="service" id="ems.service.contenttype" />
             <argument type="service" id="ems.service.search" />
             <argument type="service" id="ems_common.service.elastica" />
-            <argument>%ems_core.template_namespace%</argument>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
@@ -242,7 +232,6 @@
             <argument type="service" id="ems.view.manager" />
             <argument type="service" id="emsco.data_table.factory" />
             <argument type="service" id="logger"/>
-            <argument>%ems_core.template_namespace%</argument>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
@@ -253,15 +242,14 @@
             <argument type="service" id="logger"/>
             <argument type="service" id="ems.dashboard.manager" />
             <argument type="service" id="emsco.data_table.factory" />
-            <argument>%ems_core.template_namespace%</argument>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
         <service id="EMS\CoreBundle\Controller\Dashboard\DashboardBrowserController" public="true">
             <argument type="service" id="ems.dashboard.manager" />
-            <argument type="service" id="twig"/>
-            <argument>%ems_core.template_namespace%</argument>
+            <call method="setContainer"/>
+            <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
 
@@ -271,7 +259,6 @@
             <argument type="service" id="ems.form.manager" />
             <argument type="service" id="ems.form.field-type.manager" />
             <argument type="service" id="emsco.data_table.factory" />
-            <argument>%ems_core.template_namespace%</argument>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
@@ -283,7 +270,6 @@
             <argument type="service" id="logger" />
             <argument type="service" id="EMS\CommonBundle\Contracts\SpreadsheetGeneratorServiceInterface"/>
             <argument type="service" id="emsco.data_table.factory"/>
-            <argument>%ems_core.template_namespace%</argument>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
@@ -294,7 +280,6 @@
             <argument type="service" id="ems.schedule.manager" />
             <argument type="service" id="logger"/>
             <argument type="service" id="emsco.data_table.factory" />
-            <argument>%ems_core.template_namespace%</argument>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
@@ -305,7 +290,6 @@
             <argument type="service" id="ems.log.manager" />
             <argument type="service" id="emsco.data_table.factory" />
             <argument type="service" id="logger" />
-            <argument>%ems_core.template_namespace%</argument>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
@@ -320,7 +304,9 @@
             <argument type="service" id="ems_common.service.spreadsheet_generator_service" />
             <argument type="service" id="logger" />
             <argument type="service" id="twig" />
-            <argument>%ems_core.template_namespace%</argument>
+            <call method="setContainer"/>
+            <tag name="container.service_subscriber"/>
+            <tag name="controller.service_arguments"/>
         </service>
         <service id="EMS\CoreBundle\Controller\Revision\Action\ActionImportController" public="true">
             <argument type="service" id="EMS\CoreBundle\Repository\TemplateRepository" />
@@ -342,7 +328,6 @@
             <argument type="service" id="ems.service.search" />
             <argument type="service" id="emsco.data_table.factory"/>
             <argument type="service" id="logger" />
-            <argument>%ems_core.template_namespace%</argument>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
@@ -355,7 +340,6 @@
             <argument type="service" id="translator" />
             <argument type="service" id="emsco.data_table.factory" />
             <argument type="service" id="EMS\CoreBundle\Service\ContentTypeService" />
-            <argument>%ems_core.template_namespace%</argument>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
@@ -386,7 +370,6 @@
             <argument type="service" id="ems.service.data" />
             <argument type="service" id="emsco.data_table.factory" />
             <argument type="service" id="emsco.logger" />
-            <argument>%ems_core.template_namespace%</argument>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
@@ -403,25 +386,25 @@
         </service>
 
         <!-- User -->
-        <service id="EMS\CoreBundle\Controller\User\LoginController">
-            <argument type="service" id="twig"/>
-            <argument>%ems_core.template_namespace%</argument>
+        <service id="EMS\CoreBundle\Controller\User\LoginController" public="true">
+            <call method="setContainer"/>
+            <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
         </service>
         <service id="EMS\CoreBundle\Controller\User\ProfileController" public="true">
             <argument type="service" id="emsco.manager.user" />
             <argument type="service" id="emsco.logger" />
-            <argument>%ems_core.template_namespace%</argument>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
+            <tag name="controller.service_arguments"/>
         </service>
         <service id="EMS\CoreBundle\Controller\User\ResettingController" public="true">
             <argument type="service" id="emsco.manager.user" />
             <argument type="service" id="ems_core.security.authenticator" />
             <argument type="service" id="emsco.logger" />
-            <argument>%ems_core.template_namespace%</argument>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
+            <tag name="controller.service_arguments"/>
         </service>
 
         <!-- Views -->
@@ -430,7 +413,6 @@
             <argument type="service" id="ems_common.service.elastica" />
             <argument type="service" id="ems.service.data" />
             <argument type="service" id="ems.service.search" />
-            <argument>%ems_core.template_namespace%</argument>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
@@ -445,7 +427,6 @@
             <argument type="service" id="form.registry" />
             <argument type="service" id="ems.repository.field_type" />
             <argument type="service" id="EMS\CoreBundle\Repository\RevisionRepository" />
-            <argument>%ems_core.template_namespace%</argument>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
@@ -453,7 +434,6 @@
         <service id="EMS\CoreBundle\Controller\Views\HierarchicalController" public="true">
             <argument type="service" id="ems.service.contenttype" />
             <argument type="service" id="ems.service.search" />
-            <argument>%ems_core.template_namespace%</argument>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
@@ -467,7 +447,6 @@
         </service>
         <service id="EMS\CoreBundle\Controller\Wysiwyg\StylesetController" public="true">
             <argument type="service" id="ems.service.wysiwyg_styles_set" />
-            <argument>%ems_core.template_namespace%</argument>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
@@ -478,7 +457,6 @@
             <argument type="service" id="logger" />
             <argument type="service" id="ems.service.channel" />
             <argument type="service" id="emsco.data_table.factory" />
-            <argument>%ems_core.template_namespace%</argument>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
@@ -491,9 +469,9 @@
             <tag name="controller.service_arguments"/>
         </service>
         <service id="EMS\CoreBundle\Controller\DefaultController" public="true">
-            <argument>%ems_core.template_namespace%</argument>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
+            <tag name="controller.service_arguments"/>
         </service>
         <service id="EMS\CoreBundle\Controller\ElasticsearchController" public="true">
             <argument type="service" id="logger" />
@@ -515,7 +493,6 @@
             <argument>%ems_core.paging_size%</argument>
             <argument>%ems_core.health_check_allow_origin%</argument>
             <argument>%ems_core.elasticsearch_cluster%</argument>
-            <argument>%ems_core.template_namespace%</argument>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
@@ -523,7 +500,6 @@
         <service id="EMS\CoreBundle\Controller\I18nController" public="true">
             <argument type="service" id="ems.service.i18n" />
             <argument>%ems_core.paging_size%</argument>
-            <argument>%ems_core.template_namespace%</argument>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
@@ -537,7 +513,6 @@
             <argument type="service" id="ems.dashboard.manager"/>
             <argument type="service" id="EMS\CoreBundle\Repository\NotificationRepository"/>
             <argument>%ems_core.paging_size%</argument>
-            <argument>%ems_core.template_namespace%</argument>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
@@ -546,7 +521,6 @@
             <argument type="service" id="logger" />
             <argument type="service" id="ems.service.query_search" />
             <argument type="service" id="emsco.data_table.factory" />
-            <argument>%ems_core.template_namespace%</argument>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
@@ -556,7 +530,6 @@
             <argument type="service" id="ems.service.aggregate_option" />
             <argument type="service" id="ems.service.search_field_option" />
             <argument type="service" id="translator" />
-            <argument>%ems_core.template_namespace%</argument>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
@@ -568,7 +541,6 @@
             <argument type="service" id="ems.service.job"/>
             <argument type="service" id="ems.dashboard.manager"/>
             <argument type="service" id="ems.service.contenttype"/>
-            <argument>%ems_core.template_namespace%</argument>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
@@ -577,14 +549,12 @@
             <argument type="service" id="emsco.logger" />
             <argument type="service" id="ems.service.file" />
             <argument type="service" id="emsco.data_table.factory" />
-            <argument>%ems_core.template_namespace%</argument>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
         </service>
         <service id="EMS\CoreBundle\Controller\UploadedFileWysiwygController" public="true">
             <argument type="service" id="ems_core.core_ui.ajax_service" />
             <argument type="service" id="emsco.data_table.factory"/>
-            <argument>%ems_core.template_namespace%</argument>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
             <tag name="controller.service_arguments"/>
@@ -597,7 +567,6 @@
             <argument type="service" id="emsco.data_table.factory"/>
             <argument type="service" id="ems.repository.auth_token" />
             <argument type="service" id="ems.repository.wysiwyg_profile" />
-            <argument>%ems_core.template_namespace%</argument>
             <argument>%ems_core.date_time_format%</argument>
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
@@ -608,7 +577,6 @@
             <argument type="service" id="ems.service.wysiwyg_profile" />
             <argument type="service" id="ems.service.wysiwyg_styles_set" />
             <argument type="service" id="translator" />
-            <argument>%ems_core.template_namespace%</argument>
             <argument type="service" id="emsco.data_table.factory" />
             <argument type="service" id="form.factory" />
             <call method="setContainer"/>

--- a/EMS/core-bundle/src/Resources/config/routing/data.xml
+++ b/EMS/core-bundle/src/Resources/config/routing/data.xml
@@ -55,7 +55,7 @@
            methods="GET|POST"
         />
     <route id="emsco_data_private_action" path="/action/{environmentName}/{templateId}/{ouuid}/{_download}"
-           controller="EMS\CoreBundle\Controller\Revision\Action\ActionController::render"
+           controller="EMS\CoreBundle\Controller\Revision\Action\ActionController::renderAction"
            methods="GET">
         <default key="public">0</default>
         <default key="_download">0</default>
@@ -182,13 +182,13 @@
         <default key="public">0</default>
     </route>
     <route id="data.customview" path="/custom-view/{environmentName}/{templateId}/{ouuid}/{_download}"
-           controller="EMS\CoreBundle\Controller\Revision\Action\ActionController::render"
+           controller="EMS\CoreBundle\Controller\Revision\Action\ActionController::renderAction"
            methods="GET">
         <default key="public">0</default>
         <default key="_download">0</default>
     </route>
     <route id="ems_data_custom_template_protected" path="/template/{environmentName}/{templateId}/{ouuid}/{_download}"
-           controller="EMS\CoreBundle\Controller\Revision\Action\ActionController::render"
+           controller="EMS\CoreBundle\Controller\Revision\Action\ActionController::renderAction"
            methods="GET">
         <default key="public">0</default>
         <default key="_download">0</default>

--- a/EMS/core-bundle/src/Resources/config/routing/public.xml
+++ b/EMS/core-bundle/src/Resources/config/routing/public.xml
@@ -10,7 +10,7 @@
         <default key="public">1</default>
     </route>
     <route id="emsco_data_public_action" path="/public/action/{environmentName}/{templateId}/{ouuid}/{_download}"
-           controller="EMS\CoreBundle\Controller\Revision\Action\ActionController::render"
+           controller="EMS\CoreBundle\Controller\Revision\Action\ActionController::renderAction"
            methods="GET">
         <default key="public">1</default>
         <default key="_download">0</default>
@@ -27,7 +27,7 @@
     </route>
     <route id="ems_data_custom_template_public"
            path="/public/template/{environmentName}/{templateId}/{ouuid}/{_download}"
-           controller="EMS\CoreBundle\Controller\Revision\Action\ActionController::render"
+           controller="EMS\CoreBundle\Controller\Revision\Action\ActionController::renderAction"
            methods="GET">
         <default key="public">1</default>
         <default key="_download">0</default>


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  n |
| New feature?   |  n |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Remove AbstractCoreController.php in favor for trait.
The trait also overwrites the renderView method of Symfony abstractController.

All our controller should just extend the Symfony AbstractController and use the CoreControllerTrait.
In this case we do not need to inject the templateNamespace anymore.

Only a couple of place: MediaLibraryController, RevisionTaskController, .. I was not able to remove the templateNamespace injection (not yet).


