### PR TITLE
fix(admin/revision): collection enter key triggers delete first item

### DIFF
--- a/EMS/core-bundle/src/Form/DataField/CollectionItemFieldType.php
+++ b/EMS/core-bundle/src/Form/DataField/CollectionItemFieldType.php
@@ -6,7 +6,6 @@ use EMS\CoreBundle\Entity\DataField;
 use EMS\CoreBundle\Entity\FieldType;
 use EMS\CoreBundle\Form\DataTransformer\DataFieldModelTransformer;
 use EMS\CoreBundle\Form\DataTransformer\DataFieldViewTransformer;
-use EMS\CoreBundle\Form\Field\SubmitEmsType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
 
@@ -80,14 +79,6 @@ class CollectionItemFieldType extends DataFieldType
                     ->addModelTransformer(new DataFieldModelTransformer($fieldType, $this->formRegistry));
             }
         }
-
-        $builder->add('remove_collection_item', SubmitEmsType::class, [
-                'attr' => [
-                        'class' => 'btn btn-danger btn-sm remove-content-button',
-                ],
-                'label' => 'Remove',
-                'icon' => 'fa fa-trash',
-        ]);
     }
 
     /**

--- a/EMS/core-bundle/src/Resources/views/form/fields.html.twig
+++ b/EMS/core-bundle/src/Resources/views/form/fields.html.twig
@@ -616,7 +616,9 @@
 		<div class="panel-heading ems-handle">
 			{{ form_label(form) }}
 	  		<div class="btn-group pull-right">
-	  			{{- form_widget(form.remove_collection_item) -}}
+				<button type="button" class="btn btn-danger btn-sm remove-content-button">
+					<span class="fa fa-trash"></span>&nbsp;Remove
+				</button>
                 {% if collapsible %}
                     <div class="pull-right">
                         <div class="btn-group toggle-group" role="group">
@@ -631,7 +633,7 @@
 
 	  	<div class="panel-body {% if collapsible %}collapse{% endif %}">
 	  		<div class="row">
-	  		{% for child in form.iterator|filter(c => c.vars.name not in ['remove_collection_item', '_ems_internal_deleted']) %}
+	  		{% for child in form.iterator|filter(c => c.vars.name not in ['_ems_internal_deleted']) %}
 				<div class="{% if child.vars.data.fieldType.options.displayOptions.class is defined %}{{ child.vars.data.fieldType.options.displayOptions.class }}{% endif %}">
     				{{- form_row(child) -}}
 				</div>

--- a/EMS/core-bundle/src/Service/DataService.php
+++ b/EMS/core-bundle/src/Service/DataService.php
@@ -405,7 +405,7 @@ class DataService
 
     public static function isInternalField(string $fieldName): bool
     {
-        return \in_array($fieldName, ['_ems_internal_deleted', 'remove_collection_item']);
+        return '_ems_internal_deleted' === $fieldName;
     }
 
     public function generateInputValues(DataField $dataField): void


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   |  n |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? | #936   |
| Documentation? |  n |

Because the remove collection item button is a submit button. It's better to just define in the button in twig.
Javascript is listining for a button with the class 'remove-content-button'

