### PR TITLE
fix(admin/revision): duplicate ouuid put back deleted revision

### DIFF
--- a/EMS/core-bundle/src/Controller/ContentManagement/CrudController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/CrudController.php
@@ -45,20 +45,20 @@ class CrudController extends AbstractController
                 $this->dataService->refresh($newRevision->giveContentType()->giveEnvironment());
             }
         } catch (\Exception $e) {
-            if (($e instanceof NotFoundHttpException) or ($e instanceof BadRequestHttpException)) {
+            if ($e instanceof NotFoundHttpException || $e instanceof BadRequestHttpException) {
                 throw $e;
-            } else {
-                $this->logger->error('log.crud.create_error', [
-                    EmsFields::LOG_CONTENTTYPE_FIELD => $contentType->getName(),
-                    EmsFields::LOG_ERROR_MESSAGE_FIELD => $e->getMessage(),
-                    EmsFields::LOG_EXCEPTION_FIELD => $e,
-                ]);
             }
 
+            $this->logger->error('log.crud.create_error', [
+                EmsFields::LOG_CONTENTTYPE_FIELD => $contentType->getName(),
+                EmsFields::LOG_ERROR_MESSAGE_FIELD => $e->getMessage(),
+                EmsFields::LOG_EXCEPTION_FIELD => $e,
+            ]);
+
             return $this->render("@$this->templateNamespace/ajax/notification.json.twig", [
-                    'success' => false,
-                    'ouuid' => $ouuid,
-                    'type' => $contentType->getName(),
+                'success' => false,
+                'ouuid' => $ouuid,
+                'type' => $contentType->getName(),
             ]);
         }
 

--- a/EMS/core-bundle/src/Controller/Revision/TrashController.php
+++ b/EMS/core-bundle/src/Controller/Revision/TrashController.php
@@ -81,9 +81,13 @@ class TrashController extends AbstractController
             throw $this->createAccessDeniedException();
         }
 
-        $revisionId = $this->dataService->trashPutBack($contentType, $ouuid);
+        $restoredRevision = $this->dataService->trashPutBackAsDraft($contentType, $ouuid);
 
-        return $this->redirectToRoute(Routes::EDIT_REVISION, ['revisionId' => $revisionId]);
+        if (!$restoredRevision) {
+            throw new \RuntimeException(\sprintf('Put back failed for ouuid "%s"', $ouuid));
+        }
+
+        return $this->redirectToRoute(Routes::EDIT_REVISION, ['revisionId' => $restoredRevision->getId()]);
     }
 
     private function emptyTrashSelection(ContentType $contentType, string ...$ouuids): Response
@@ -103,10 +107,10 @@ class TrashController extends AbstractController
             throw $this->createAccessDeniedException();
         }
 
-        $revisionId = $this->dataService->trashPutBack($contentType, ...$ouuids);
+        $restoredRevision = $this->dataService->trashPutBackAsDraft($contentType, ...$ouuids);
 
-        if ($revisionId) {
-            return $this->redirectToRoute(Routes::EDIT_REVISION, ['revisionId' => $revisionId]);
+        if ($restoredRevision) {
+            return $this->redirectToRoute(Routes::EDIT_REVISION, ['revisionId' => $restoredRevision->getId()]);
         }
 
         return $this->redirectToRoute(Routes::DRAFT_IN_PROGRESS, ['contentTypeId' => $contentType->getId()]);

--- a/EMS/core-bundle/src/Exception/DuplicateOuuidException.php
+++ b/EMS/core-bundle/src/Exception/DuplicateOuuidException.php
@@ -1,7 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EMS\CoreBundle\Exception;
 
 class DuplicateOuuidException extends ElasticmsException
 {
+    public function __construct(string $ouuid, string $contentTypeName)
+    {
+        parent::__construct(
+            message: \sprintf('Duplicate ouuid "%s" for content type "%s"', $ouuid, $contentTypeName)
+        );
+    }
 }

--- a/EMS/core-bundle/src/Repository/RevisionRepository.php
+++ b/EMS/core-bundle/src/Repository/RevisionRepository.php
@@ -835,6 +835,7 @@ class RevisionRepository extends EntityRepository
             ->andWhere($qb->expr()->eq('c.id', ':content_type_id'))
             ->andWhere($qb->expr()->in('r.ouuid', ':ouuids'))
             ->andWhere($qb->expr()->eq('r.deleted', $qb->expr()->literal(true)))
+            ->orderBy('r.startTime', 'DESC')
             ->setParameter('content_type_id', $contentType->getId())
             ->setParameter('ouuids', $ouuids, ArrayParameterType::STRING)
         ;

--- a/EMS/core-bundle/src/Repository/RevisionRepository.php
+++ b/EMS/core-bundle/src/Repository/RevisionRepository.php
@@ -488,7 +488,7 @@ class RevisionRepository extends EntityRepository
                 'contentType' => $contentType,
             ]);
 
-        $revision = $qb->getQuery()->getSingleResult();
+        $revision = $qb->getQuery()->getOneOrNullResult();
 
         return $revision instanceof Revision ? $revision : null;
     }

--- a/EMS/core-bundle/src/Repository/RevisionRepository.php
+++ b/EMS/core-bundle/src/Repository/RevisionRepository.php
@@ -349,12 +349,15 @@ class RevisionRepository extends EntityRepository
 
     public function countRevisions(string $ouuid, ContentType $contentType): int
     {
-        $qb = $this->createQueryBuilder('r')
-            ->select('COUNT(r)');
-        $qb->where($qb->expr()->eq('r.ouuid', ':ouuid'));
-        $qb->andWhere($qb->expr()->eq('r.contentType', ':contentType'));
-        $qb->setParameter('ouuid', $ouuid);
-        $qb->setParameter('contentType', $contentType);
+        $qb = $this->createQueryBuilder('r');
+        $qb
+            ->select('COUNT(r.id)')
+            ->andWhere($qb->expr()->eq('r.ouuid', ':ouuid'))
+            ->andWhere($qb->expr()->eq('r.contentType', ':contentType'))
+            ->setParameters([
+                'ouuid' => $ouuid,
+                'contentType' => $contentType,
+            ]);
 
         return (int) $qb->getQuery()->getSingleScalarResult();
     }

--- a/EMS/core-bundle/src/Repository/RevisionRepository.php
+++ b/EMS/core-bundle/src/Repository/RevisionRepository.php
@@ -478,20 +478,19 @@ class RevisionRepository extends EntityRepository
 
     public function getCurrentRevision(ContentType $contentType, string $ouuid): ?Revision
     {
-        $qb = $this->createQueryBuilder('r')->select()
-            ->where('r.contentType = ?2')
-            ->andWhere('r.ouuid = ?3')
-            ->andWhere('r.endTime is null')
-            ->setParameter(2, $contentType)
-            ->setParameter(3, $ouuid);
+        $qb = $this->createQueryBuilder('r');
+        $qb
+            ->andWhere($qb->expr()->eq('r.ouuid', ':ouuid'))
+            ->andWhere($qb->expr()->eq('r.contentType', ':contentType'))
+            ->andWhere($qb->expr()->isNull('r.endTime'))
+            ->setParameters([
+                'ouuid' => $ouuid,
+                'contentType' => $contentType,
+            ]);
 
-        /** @var Revision[] $currentRevision */
-        $currentRevision = $qb->getQuery()->execute();
-        if (isset($currentRevision[0])) {
-            return $currentRevision[0];
-        } else {
-            return null;
-        }
+        $revision = $qb->getQuery()->getSingleResult();
+
+        return $revision instanceof Revision ? $revision : null;
     }
 
     public function publishRevision(Revision $revision, bool $draft = false): int


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | y  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? |  #891  |
| Documentation? | n  |

Situation:
- Create a new document from UI (contentType ask OUUID), but the ouuid is a deleted revision
- Create a new document from API (emsch:local:push), but the ouuid is a deleted revision

In both cases we should throw the DuplicatedOuuidException, but only if the revision is not deleted.
If the revision is deleted we put it back. see https://github.com/ems-project/elasticms/issues/891
