### PR TITLE
refactor(admin): coreControllerTrait instead of abstract class

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .cache
-          key: ci-${{ github.ref_name }}-${{ github.run_id }}
-          restore-keys: |
-            ci-${{ github.ref_name }}-
+          key: ci-${{ github.ref_name }}
 
       - name: "Restore Composer Cache"
         uses: actions/cache/restore@v4
@@ -62,7 +60,7 @@ jobs:
         if: always()
         with:
           path: .cache
-          key: ci-${{ github.ref_name }}-${{ github.run_id }}
+          key: ci-${{ github.ref_name }}
 
       - name: "Save vendor directory"
         if: steps.restore-composer.outputs.cache-hit != 'true'

--- a/EMS/core-bundle/src/Controller/ContentManagement/ReleaseController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/ReleaseController.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace EMS\CoreBundle\Controller\ContentManagement;
 
-use EMS\CoreBundle\Controller\AbstractCoreController;
+use EMS\CoreBundle\Controller\CoreControllerTrait;
 use EMS\CoreBundle\Core\DataTable\DataTableFactory;
 use EMS\CoreBundle\Core\Revision\Release\ReleaseRevisionType;
 use EMS\CoreBundle\DataTable\Type\Release\ReleaseOverviewDataTableType;
@@ -20,11 +20,14 @@ use EMS\CoreBundle\Form\Form\TableType;
 use EMS\CoreBundle\Routes;
 use EMS\CoreBundle\Service\ReleaseService;
 use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-final class ReleaseController extends AbstractCoreController
+final class ReleaseController extends AbstractController
 {
+    use CoreControllerTrait;
+
     public function __construct(
         private readonly LoggerInterface $logger,
         private readonly ReleaseService $releaseService,

--- a/EMS/core-bundle/src/Controller/CoreControllerTrait.php
+++ b/EMS/core-bundle/src/Controller/CoreControllerTrait.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace EMS\CoreBundle\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormInterface;
 
-abstract class AbstractCoreController extends AbstractController
+trait CoreControllerTrait
 {
     protected function getClickedButtonName(FormInterface $form): ?string
     {


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | n  |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  |  n |
| Fixed tickets? | n  |
| Documentation? |  n |

Remove the AbstractcoreController, better to use a trait for easy resuability.
