### PR TITLE
refactor(common/log): use translateMessage in LocalizedLogger

### DIFF
--- a/EMS/common-bundle/src/Common/Log/LocalizedLogger.php
+++ b/EMS/common-bundle/src/Common/Log/LocalizedLogger.php
@@ -57,6 +57,10 @@ class LocalizedLogger extends AbstractLogger implements LocalizedLoggerInterface
         $context['translation_message'] = $message;
         $translation = $this->translator->trans((string) $message, [], $this->translationDomain);
 
-        return \preg_replace_callback(self::PATTERN, fn ($match) => $context[$match['parameter']] ?? $match['parameter'], $translation) ?? (string) $message;
+        return \preg_replace_callback(
+            pattern: self::PATTERN,
+            callback: static fn ($match) => $context[$match['parameter']] ?? $match['parameter'],
+            subject: $translation
+        ) ?? (string) $message;
     }
 }

--- a/EMS/common-bundle/src/Common/Log/LocalizedLogger.php
+++ b/EMS/common-bundle/src/Common/Log/LocalizedLogger.php
@@ -7,14 +7,38 @@ namespace EMS\CommonBundle\Common\Log;
 use EMS\CommonBundle\Contracts\Log\LocalizedLoggerInterface;
 use Psr\Log\AbstractLogger;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Translation\TranslatableMessage;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class LocalizedLogger extends AbstractLogger implements LocalizedLoggerInterface
 {
     private const PATTERN = '/%(?<parameter>(_|)[[:alnum:]_]*)%/m';
 
-    public function __construct(private readonly LoggerInterface $logger, private readonly TranslatorInterface $translator, private readonly string $translationDomain)
+    public function __construct(
+        private readonly LoggerInterface $logger,
+        private readonly TranslatorInterface $translator,
+        private readonly string $translationDomain
+    ) {
+    }
+
+    public function message(string $level, TranslatableMessage $message, array $context = []): void
     {
+        $this->logger->log($level, $message->trans($this->translator), $context);
+    }
+
+    public function messageError(TranslatableMessage $message, array $context = []): void
+    {
+        $this->message('error', $message, $context);
+    }
+
+    public function messageWarning(TranslatableMessage $message, array $context = []): void
+    {
+        $this->message('warning', $message, $context);
+    }
+
+    public function messageNotice(TranslatableMessage $message, array $context = []): void
+    {
+        $this->message('notice', $message, $context);
     }
 
     /**

--- a/EMS/common-bundle/src/Contracts/Log/LocalizedLoggerInterface.php
+++ b/EMS/common-bundle/src/Contracts/Log/LocalizedLoggerInterface.php
@@ -1,9 +1,31 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EMS\CommonBundle\Contracts\Log;
 
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Translation\TranslatableMessage;
 
 interface LocalizedLoggerInterface extends LoggerInterface
 {
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function message(string $level, TranslatableMessage $message, array $context = []): void;
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function messageError(TranslatableMessage $message, array $context = []): void;
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function messageWarning(TranslatableMessage $message, array $context = []): void;
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function messageNotice(TranslatableMessage $message, array $context = []): void;
 }

--- a/EMS/core-bundle/src/Controller/Revision/EditController.php
+++ b/EMS/core-bundle/src/Controller/Revision/EditController.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace EMS\CoreBundle\Controller\Revision;
 
+use EMS\CommonBundle\Contracts\Log\LocalizedLoggerInterface;
+use EMS\CoreBundle\Controller\CoreControllerTrait;
 use EMS\CoreBundle\Core\ContentType\ContentTypeRoles;
 use EMS\CoreBundle\Core\DataTable\DataTableFactory;
 use EMS\CoreBundle\Core\Log\LogRevisionContext;
@@ -14,6 +16,7 @@ use EMS\CoreBundle\Entity\ContentType;
 use EMS\CoreBundle\Entity\Revision;
 use EMS\CoreBundle\Entity\UserInterface;
 use EMS\CoreBundle\Exception\ElasticmsException;
+use EMS\CoreBundle\Form\Data\TableInterface;
 use EMS\CoreBundle\Form\Form\RevisionJsonType;
 use EMS\CoreBundle\Form\Form\RevisionType;
 use EMS\CoreBundle\Form\Form\TableType;
@@ -24,10 +27,7 @@ use EMS\CoreBundle\Service\DataService;
 use EMS\CoreBundle\Service\PublishService;
 use EMS\CoreBundle\Service\Revision\RevisionService;
 use EMS\Helpers\Standard\Json;
-use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\Form\Form;
-use Symfony\Component\Form\SubmitButton;
 use Symfony\Component\HttpFoundation\File\Exception\AccessDeniedException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -35,11 +35,15 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+use function Symfony\Component\Translation\t;
+
 class EditController extends AbstractController
 {
+    use CoreControllerTrait;
+
     public function __construct(
         private readonly DataService $dataService,
-        private readonly LoggerInterface $logger,
+        private readonly LocalizedLoggerInterface $logger,
         private readonly PublishService $publishService,
         private readonly RevisionService $revisionService,
         private readonly TranslatorInterface $translator,
@@ -259,29 +263,10 @@ class EditController extends AbstractController
         $form = $this->createForm(TableType::class, $table);
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {
-            if ($form instanceof Form && ($action = $form->getClickedButton()) instanceof SubmitButton) {
-                switch ($action->getName()) {
-                    case DraftInProgress::DISCARD_SELECTED_DRAFT:
-                        foreach ($table->getSelected() as $revisionId) {
-                            try {
-                                $revision = $this->dataService->getRevisionById(\intval($revisionId), $contentTypeId);
-                                if (!$revision->getDraft()) {
-                                    continue;
-                                }
-                                $label = $revision->getLabel();
-                                $this->dataService->discardDraft($revision);
-                                $this->logger->notice('log.controller.draft-in-progress.discard_draft', ['revision' => $label]);
-                            } catch (NotFoundHttpException) {
-                                $this->logger->warning('log.controller.draft-in-progress.draft-not-found', ['revisionId' => $revisionId]);
-                            }
-                        }
-                        break;
-                    default:
-                        $this->logger->error('log.controller.draft-in-progress.unknown_action');
-                }
-            } else {
-                $this->logger->error('log.controller.draft-in-progress.unknown_action');
-            }
+            match ($this->getClickedButtonName($form)) {
+                DraftInProgress::DISCARD_SELECTED_DRAFT => $this->discardRevisions($table, $contentTypeId),
+                default => $this->logger->messageError(t('log.error.invalid_table_action', [], 'emsco-core'))
+            };
 
             return $this->redirectToRoute(Routes::DRAFT_IN_PROGRESS, ['contentTypeId' => $contentTypeId->getId()]);
         }
@@ -335,6 +320,24 @@ class EditController extends AbstractController
         }
         foreach ($input as &$elem) {
             $this->reorderCollection($elem);
+        }
+    }
+
+    private function discardRevisions(TableInterface $table, ContentType $contentType): void
+    {
+        foreach ($table->getSelected() as $revisionId) {
+            try {
+                $revision = $this->dataService->getRevisionById(\intval($revisionId), $contentType);
+                if (!$revision->getDraft()) {
+                    continue;
+                }
+                $label = $this->revisionService->display($revision);
+                $this->dataService->discardDraft($revision);
+
+                $this->logger->messageNotice(t('log.notice.draft_deleted', ['revision' => $label], 'emsco-core'));
+            } catch (NotFoundHttpException) {
+                $this->logger->messageWarning(t('log.warning.draft_not_found', ['revisionId' => $revisionId], 'emsco-core'));
+            }
         }
     }
 }

--- a/EMS/core-bundle/src/Resources/config/controllers.xml
+++ b/EMS/core-bundle/src/Resources/config/controllers.xml
@@ -350,7 +350,7 @@
         </service>
         <service id="EMS\CoreBundle\Controller\Revision\EditController" public="true">
             <argument type="service" id="ems.service.data" />
-            <argument type="service" id="logger" />
+            <argument type="service" id="emsco.logger" />
             <argument type="service" id="ems.service.publish" />
             <argument type="service" id="ems.service.revision" />
             <argument type="service" id="translator" />

--- a/EMS/core-bundle/src/Resources/translations/EMSCoreBundle.en.yml
+++ b/EMS/core-bundle/src/Resources/translations/EMSCoreBundle.en.yml
@@ -78,10 +78,6 @@ log:
             unknown_action: 'Unknown action'
         uploaded-file-logs:
             unknown_action: 'Unknown action'
-        draft-in-progress:
-            discard_draft: 'Draft "%revision%" has been deleted'
-            unknown_action: 'Unknown action'
-            draft-not-found: 'Draft (%revisionId%) not found'
         schedule:
             unknown_action: 'Unknown action'
     crud:

--- a/EMS/core-bundle/src/Resources/translations/emsco-core+intl-icu.en.yml
+++ b/EMS/core-bundle/src/Resources/translations/emsco-core+intl-icu.en.yml
@@ -1,2 +1,9 @@
 core:
     version: 'Version {core} with Symfony {symfony}'
+log:
+    error:
+        invalid_table_action: 'Unknown table action'
+    notice:
+        draft_deleted: 'Draft "{revision}" has been deleted'
+    warning:
+        draft_not_found: 'Draft not found with id "{revisionId}"'


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | n  |
| New feature?   |  n |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

In the past we already created a common LocalizedLogger, but now we want to be able to translated with translatable messages.

Because then the sf crawler can scan the code for keys and detect unused keys.

The emsco.logger is already used in multiple places, but not all. Now we have a new reason to start using the emsco.logger everywhere. 