### PR TITLE
chore(translations): support building multiline translations

### DIFF
--- a/EMS/admin-ui-bundle/src/Resources/translations/elements+intl-icu.en.xlf
+++ b/EMS/admin-ui-bundle/src/Resources/translations/elements+intl-icu.en.xlf
@@ -5,61 +5,45 @@
       <tool tool-id="symfony" tool-name="Symfony"/>
     </header>
     <body>
-      <trans-unit id="xqKPd7Z" resname="side_menu.anonymous-user">
-        <source>side_menu.anonymous-user</source>
-        <target>Anonymous User</target>
+      <trans-unit id="DhTAWbW" resname="elements.status.green">
+        <source>elements.status.green</source>
+        <target>Green, systems are working as expected</target>
       </trans-unit>
-      <trans-unit id="GmlMrFL" resname="side-menu.quick-search.placeholder">
-        <source>side-menu.quick-search.placeholder</source>
-        <target>Search</target>
+      <trans-unit id="fXaszH." resname="elements.status.red">
+        <source>elements.status.red</source>
+        <target>Red, systems are facing issues. Please contact your system administrator.</target>
+      </trans-unit>
+      <trans-unit id="kEabPyR" resname="elements.status.yellow">
+        <source>elements.status.yellow</source>
+        <target>Yellow, systems are indexing documents. This status can't stay like this forever.</target>
+      </trans-unit>
+      <trans-unit id="tVomn.Q" resname="elements.user-image.anonymous">
+        <source>elements.user-image.anonymous</source>
+        <target>Anonymous user</target>
+      </trans-unit>
+      <trans-unit id="H1u5eRo" resname="hide">
+        <source>hide</source>
+        <target>Hide</target>
+      </trans-unit>
+      <trans-unit id="HGMzUJ3" resname="show">
+        <source>show</source>
+        <target>Show</target>
       </trans-unit>
       <trans-unit id="t2TEeYb" resname="side-menu.quick-search.label">
         <source>side-menu.quick-search.label</source>
+        <target>Search</target>
+      </trans-unit>
+      <trans-unit id="GmlMrFL" resname="side-menu.quick-search.placeholder">
+        <source>side-menu.quick-search.placeholder</source>
         <target>Search</target>
       </trans-unit>
       <trans-unit id="hdKGv9Q" resname="side-menu.search.btn">
         <source>side-menu.search.btn</source>
         <target>Search</target>
       </trans-unit>
-      <trans-unit id="Pg8GRAP" resname="topbar.search_form.show">
-        <source>topbar.search_form.show</source>
-        <target>Show search form</target>
-      </trans-unit>
-      <trans-unit id="HP2AROm" resname="topbar.search_form.submit">
-        <source>topbar.search_form.submit</source>
-        <target>Search</target>
-      </trans-unit>
-      <trans-unit id="U0fH.Ca" resname="topbar.search_form.close">
-        <source>topbar.search_form.close</source>
-        <target>Close</target>
-      </trans-unit>
-      <trans-unit id="Xry3p9y" resname="topbar.fullscreen.toggle">
-        <source>topbar.fullscreen.toggle</source>
-        <target>Toggle fullscreen</target>
-      </trans-unit>
-      <trans-unit id="fL.AXFq" resname="topbar.control_sidebar.toggle">
-        <source>topbar.control_sidebar.toggle</source>
-        <target>Toggle sidebar</target>
-      </trans-unit>
-      <trans-unit id="zaJht3l" resname="topbar.pushmenu.label">
-        <source>topbar.pushmenu.label</source>
-        <target>Push menu</target>
-      </trans-unit>
-      <trans-unit id="DhTAWbW" resname="elements.status.green">
-        <source>elements.status.green</source>
-        <target>Green, systems are working as expected</target>
-      </trans-unit>
-      <trans-unit id="kEabPyR" resname="elements.status.yellow">
-        <source>elements.status.yellow</source>
-        <target>Yellow, systems are indexing documents. This status can't stay like this forever.</target>
-      </trans-unit>
-      <trans-unit id="fXaszH." resname="elements.status.red">
-        <source>elements.status.red</source>
-        <target>Red, systems are facing issues. Please contact your system administrator.</target>
-      </trans-unit>
-      <trans-unit id="tVomn.Q" resname="elements.user-image.anonymous">
-        <source>elements.user-image.anonymous</source>
-        <target>Anonymous user</target>
+      <trans-unit id="xqKPd7Z" resname="side_menu.anonymous-user">
+        <source>side_menu.anonymous-user</source>
+        <target>Anonymous User</target>
       </trans-unit>
       <trans-unit id="l_C57Fy" resname="toats.level.error">
         <source>toats.level.error</source>
@@ -73,13 +57,29 @@
         <source>toats.level.warning</source>
         <target>Warning</target>
       </trans-unit>
-      <trans-unit id="H1u5eRo" resname="hide">
-        <source>hide</source>
-        <target>Hide</target>
+      <trans-unit id="fL.AXFq" resname="topbar.control_sidebar.toggle">
+        <source>topbar.control_sidebar.toggle</source>
+        <target>Toggle sidebar</target>
       </trans-unit>
-      <trans-unit id="HGMzUJ3" resname="show">
-        <source>show</source>
-        <target>Show</target>
+      <trans-unit id="Xry3p9y" resname="topbar.fullscreen.toggle">
+        <source>topbar.fullscreen.toggle</source>
+        <target>Toggle fullscreen</target>
+      </trans-unit>
+      <trans-unit id="zaJht3l" resname="topbar.pushmenu.label">
+        <source>topbar.pushmenu.label</source>
+        <target>Push menu</target>
+      </trans-unit>
+      <trans-unit id="U0fH.Ca" resname="topbar.search_form.close">
+        <source>topbar.search_form.close</source>
+        <target>Close</target>
+      </trans-unit>
+      <trans-unit id="Pg8GRAP" resname="topbar.search_form.show">
+        <source>topbar.search_form.show</source>
+        <target>Show search form</target>
+      </trans-unit>
+      <trans-unit id="HP2AROm" resname="topbar.search_form.submit">
+        <source>topbar.search_form.submit</source>
+        <target>Search</target>
       </trans-unit>
     </body>
   </file>

--- a/EMS/admin-ui-bundle/src/Resources/translations/notification+intl-icu.en.xlf
+++ b/EMS/admin-ui-bundle/src/Resources/translations/notification+intl-icu.en.xlf
@@ -5,12 +5,12 @@
       <tool tool-id="symfony" tool-name="Symfony"/>
     </header>
     <body>
-      <trans-unit id="o2BwiOu" resname="notification.menu.link_title">
-        <source>notification.menu.link_title</source>
-        <target>Notifications</target>
-      </trans-unit>
       <trans-unit id="8euyyEz" resname="notification.dashboard.title">
         <source>notification.dashboard.title</source>
+        <target>Notifications</target>
+      </trans-unit>
+      <trans-unit id="o2BwiOu" resname="notification.menu.link_title">
+        <source>notification.menu.link_title</source>
         <target>Notifications</target>
       </trans-unit>
     </body>

--- a/EMS/admin-ui-bundle/src/Resources/translations/revision+intl-icu.en.xlf
+++ b/EMS/admin-ui-bundle/src/Resources/translations/revision+intl-icu.en.xlf
@@ -5,13 +5,13 @@
       <tool tool-id="symfony" tool-name="Symfony"/>
     </header>
     <body>
-      <trans-unit id="yc4el3L" resname="revision.trash.title">
-        <source>revision.trash.title</source>
-        <target>Trash for content type %name%</target>
-      </trans-unit>
       <trans-unit id="f4HRCvl" resname="revision.trash.sub_title">
         <source>revision.trash.sub_title</source>
         <target>%pluralName% in trash</target>
+      </trans-unit>
+      <trans-unit id="yc4el3L" resname="revision.trash.title">
+        <source>revision.trash.title</source>
+        <target>Trash for content type %name%</target>
       </trans-unit>
     </body>
   </file>

--- a/EMS/admin-ui-bundle/src/Resources/translations/user+intl-icu.en.xlf
+++ b/EMS/admin-ui-bundle/src/Resources/translations/user+intl-icu.en.xlf
@@ -5,21 +5,21 @@
       <tool tool-id="symfony" tool-name="Symfony"/>
     </header>
     <body>
-      <trans-unit id="Xcx6f8R" resname="user.login.title">
-        <source>user.login.title</source>
-        <target>Welcome</target>
-      </trans-unit>
       <trans-unit id="oypjthn" resname="user.login.alt_logo">
         <source>user.login.alt_logo</source>
         <target>elasticMS's logo</target>
+      </trans-unit>
+      <trans-unit id="f2auv9x" resname="user.login.forgot">
+        <source>user.login.forgot</source>
+        <target>I forgot my password</target>
       </trans-unit>
       <trans-unit id="FuBdSqc" resname="user.login.message">
         <source>user.login.message</source>
         <target>Sign in to start your session</target>
       </trans-unit>
-      <trans-unit id="hkwAg9o" resname="user.login.user_placeholder">
-        <source>user.login.user_placeholder</source>
-        <target>Email or Username</target>
+      <trans-unit id="6GSzGeY" resname="user.login.password1_aria_label">
+        <source>user.login.password1_aria_label</source>
+        <target>Password</target>
       </trans-unit>
       <trans-unit id="RJsVc0L" resname="user.login.password_placeholder">
         <source>user.login.password_placeholder</source>
@@ -33,25 +33,49 @@
         <source>user.login.submit</source>
         <target>Sign In</target>
       </trans-unit>
-      <trans-unit id="f2auv9x" resname="user.login.forgot">
-        <source>user.login.forgot</source>
-        <target>I forgot my password</target>
+      <trans-unit id="Xcx6f8R" resname="user.login.title">
+        <source>user.login.title</source>
+        <target>Welcome</target>
       </trans-unit>
       <trans-unit id="IsHtnX7" resname="user.login.user_aria_label">
         <source>user.login.user_aria_label</source>
         <target>Email or Username</target>
       </trans-unit>
-      <trans-unit id="6GSzGeY" resname="user.login.password1_aria_label">
-        <source>user.login.password1_aria_label</source>
-        <target>Password</target>
+      <trans-unit id="hkwAg9o" resname="user.login.user_placeholder">
+        <source>user.login.user_placeholder</source>
+        <target>Email or Username</target>
       </trans-unit>
-      <trans-unit id="HdsKVq_" resname="user.profile.title">
-        <source>user.profile.title</source>
-        <target>Your profile</target>
+      <trans-unit id="T_3w8O5" resname="user.option.simplified_ui">
+        <source>user.option.simplified_ui</source>
+        <target>Simplified UI</target>
       </trans-unit>
-      <trans-unit id="0WswaCk" resname="user.profile.show.username">
-        <source>user.profile.show.username</source>
-        <target>Username</target>
+      <trans-unit id="En5VEV." resname="user.profile.change_password.cancel">
+        <source>user.profile.change_password.cancel</source>
+        <target>Cancel</target>
+      </trans-unit>
+      <trans-unit id="8Wwyiot" resname="user.profile.change_password.submit">
+        <source>user.profile.change_password.submit</source>
+        <target>Change password</target>
+      </trans-unit>
+      <trans-unit id="Uzm29Jz" resname="user.profile.change_password.title">
+        <source>user.profile.change_password.title</source>
+        <target>Change password</target>
+      </trans-unit>
+      <trans-unit id="ZWXcMxP" resname="user.profile.edit.breadcrumb_title">
+        <source>user.profile.edit.breadcrumb_title</source>
+        <target>Edit</target>
+      </trans-unit>
+      <trans-unit id="5yLxmZH" resname="user.profile.edit.title">
+        <source>user.profile.edit.title</source>
+        <target>Edit your profile</target>
+      </trans-unit>
+      <trans-unit id="QxXqqK_" resname="user.profile.show.action.cancel">
+        <source>user.profile.show.action.cancel</source>
+        <target>Cancel</target>
+      </trans-unit>
+      <trans-unit id="UqXqE.d" resname="user.profile.show.action.edit">
+        <source>user.profile.show.action.edit</source>
+        <target>Edit</target>
       </trans-unit>
       <trans-unit id="S0.jP35" resname="user.profile.show.display_name">
         <source>user.profile.show.display_name</source>
@@ -77,41 +101,17 @@
         <source>user.profile.show.roles</source>
         <target>Roles</target>
       </trans-unit>
+      <trans-unit id="0WswaCk" resname="user.profile.show.username">
+        <source>user.profile.show.username</source>
+        <target>Username</target>
+      </trans-unit>
       <trans-unit id="r60N1Qr" resname="user.profile.show.wysiwyg">
         <source>user.profile.show.wysiwyg</source>
         <target>WYSIWYG profile</target>
       </trans-unit>
-      <trans-unit id="UqXqE.d" resname="user.profile.show.action.edit">
-        <source>user.profile.show.action.edit</source>
-        <target>Edit</target>
-      </trans-unit>
-      <trans-unit id="QxXqqK_" resname="user.profile.show.action.cancel">
-        <source>user.profile.show.action.cancel</source>
-        <target>Cancel</target>
-      </trans-unit>
-      <trans-unit id="Uzm29Jz" resname="user.profile.change_password.title">
-        <source>user.profile.change_password.title</source>
-        <target>Change password</target>
-      </trans-unit>
-      <trans-unit id="8Wwyiot" resname="user.profile.change_password.submit">
-        <source>user.profile.change_password.submit</source>
-        <target>Change password</target>
-      </trans-unit>
-      <trans-unit id="En5VEV." resname="user.profile.change_password.cancel">
-        <source>user.profile.change_password.cancel</source>
-        <target>Cancel</target>
-      </trans-unit>
-      <trans-unit id="5yLxmZH" resname="user.profile.edit.title">
-        <source>user.profile.edit.title</source>
-        <target>Edit your profile</target>
-      </trans-unit>
-      <trans-unit id="ZWXcMxP" resname="user.profile.edit.breadcrumb_title">
-        <source>user.profile.edit.breadcrumb_title</source>
-        <target>Edit</target>
-      </trans-unit>
-      <trans-unit id="T_3w8O5" resname="user.option.simplified_ui">
-        <source>user.option.simplified_ui</source>
-        <target>Simplified UI</target>
+      <trans-unit id="HdsKVq_" resname="user.profile.title">
+        <source>user.profile.title</source>
+        <target>Your profile</target>
       </trans-unit>
     </body>
   </file>

--- a/build/translations
+++ b/build/translations
@@ -32,6 +32,8 @@ use Symfony\Component\Translation\Util\ArrayConverter;
 use Symfony\Component\Translation\Writer\TranslationWriter;
 use Symfony\Component\Yaml\Yaml;
 
+use function Symfony\Component\String\u;
+
 const IGNORE_PATHS = [
     'Command',
     'DependencyInjection',
@@ -194,7 +196,11 @@ $command = static function (InputInterface $input, OutputInterface $output): int
         $allKeys = \array_diff(\array_keys($operation->getMessages($domain)), $domainNewKeys);
         \sort($allKeys);
         foreach ($allKeys as $key) {
-            $rows[$domain][] = ['<fg=green>used</>', $domain, $key, $operation->getResult()->get($key, $domain)];
+            $message = u($operation->getResult()->get($key, $domain))
+                ->collapseWhitespace()
+                ->truncate(50, ' ...');
+
+            $rows[$domain][] = ['<fg=green>used</>', $domain, $key, $message->toString()];
         }
     }
 

--- a/build/translations
+++ b/build/translations
@@ -20,13 +20,17 @@ use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Stopwatch\Stopwatch;
 use Symfony\Component\Translation\Catalogue\TargetOperation;
+use Symfony\Component\Translation\Dumper\XliffFileDumper;
+use Symfony\Component\Translation\Dumper\YamlFileDumper;
 use Symfony\Component\Translation\Extractor\ExtractorInterface;
 use Symfony\Component\Translation\Extractor\PhpAstExtractor;
 use Symfony\Component\Translation\Extractor\Visitor;
 use Symfony\Component\Translation\MessageCatalogue;
 use Symfony\Component\Translation\MessageCatalogueInterface;
 use Symfony\Component\Translation\Reader\TranslationReaderInterface;
-use Symfony\Component\Translation\Writer\TranslationWriterInterface;
+use Symfony\Component\Translation\Util\ArrayConverter;
+use Symfony\Component\Translation\Writer\TranslationWriter;
+use Symfony\Component\Yaml\Yaml;
 
 const IGNORE_PATHS = [
     'Command',
@@ -146,8 +150,19 @@ $command = static function (InputInterface $input, OutputInterface $output): int
     if (true === $input->getOption('write')) {
         $io->writeln('Writing translations');
 
-        /** @var TranslationWriterInterface $translationWriter */
-        $translationWriter = $container->get('translation.writer');
+        $translationWriter = new TranslationWriter();
+        $translationWriter->addDumper('xlf', new XliffFileDumper());
+        $translationWriter->addDumper('yml', new class() extends YamlFileDumper {
+            public function formatCatalogue(MessageCatalogue $messages, string $domain, array $options = []): string
+            {
+                return Yaml::dump(
+                    input: ArrayConverter::expandToTree($messages->all($domain)),
+                    inline: 5,
+                    flags: Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK
+                );
+            }
+        });
+
         $translationWriter->write($sortedMessages, $format, match ($format) {
             'yml' => [
                 'path' => $bundleDir.'/Resources/translations',


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   |  n |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n |

Want to be able to create translations keys like:

```yaml
invitation_title: |
    {organizer_gender, select,
        female   {{organizer_name} has invited you to her party!}
        male     {{organizer_name} has invited you to his party!}
        multiple {{organizer_name} have invited you to their party!}
        other    {{organizer_name} has invited you to their party!}
    }
```

But the symfony translation  yaml dumper was putting it on one line after rebuild.
