### PR TITLE
fix(emsco/media-lib): rename/delete command username with space

### DIFF
--- a/EMS/core-bundle/src/Core/Component/MediaLibrary/MediaLibraryService.php
+++ b/EMS/core-bundle/src/Core/Component/MediaLibrary/MediaLibraryService.php
@@ -160,7 +160,7 @@ class MediaLibraryService
 
         $this->revisionService->lock($revision, $user, new \DateTime('+1 hour'));
 
-        $command = \vsprintf('%s --hash=%s --username=%s -- %s', [
+        $command = \vsprintf("%s --hash=%s --username='%s' -- %s", [
             Commands::MEDIA_LIB_FOLDER_DELETE,
             $this->getConfig()->getHash(),
             $user->getUserIdentifier(),
@@ -179,7 +179,7 @@ class MediaLibraryService
 
         $this->revisionService->lock($revision, $user, new \DateTime('+1 hour'));
 
-        $command = \vsprintf("%s --hash=%s --username=%s -- %s '%s'", [
+        $command = \vsprintf("%s --hash=%s --username='%s' -- %s '%s'", [
             Commands::MEDIA_LIB_FOLDER_RENAME,
             $this->getConfig()->getHash(),
             $user->getUserIdentifier(),


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  |  n |
| Fixed tickets? | n  |
| Documentation? | n  |

A username can contain a space, we need to quote the command option
