### PR TITLE
fix(admin/revision): skip the FormFieldType's options in a container

### DIFF
--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/macros/data-field-type.html.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/macros/data-field-type.html.twig
@@ -350,9 +350,13 @@
 
     <div class="row">
         {% for child in dataField.getChildren|filter(c => false == c.fieldType.deleted) %}
-            <div class="{% if child.fieldType.displayOptions.class is defined and child.fieldType.displayOptions.class  %}{{ child.fieldType.displayOptions.class }}{%else%}col-md-12{% endif %}">
+            {% if child.fieldType.type in ['EMS\\CoreBundle\\Form\\DataField\\FormFieldType'] %}
                 {{ _self.renderDataFieldBlock(child, source, compare, compareRawData, '', path, locale) }}
-            </div>
+            {% else %}
+                <div class="{% if child.fieldType.displayOptions.class is defined and child.fieldType.displayOptions.class  %}{{ child.fieldType.displayOptions.class }}{%else%}col-md-12{% endif %}">
+                    {{ _self.renderDataFieldBlock(child, source, compare, compareRawData, '', path, locale) }}
+                </div>
+            {% endif %}
             {% if child.fieldType.displayOptions.lastOfRow is defined and child.fieldType.displayOptions.lastOfRow %}
                 <div class="clearfix"></div>
             {% endif %}

--- a/EMS/core-bundle/src/Resources/views/macros/data-field-type.html.twig
+++ b/EMS/core-bundle/src/Resources/views/macros/data-field-type.html.twig
@@ -350,9 +350,13 @@
 
 	<div class="row">
 		{% for child in dataField.getChildren|filter(c => false == c.fieldType.deleted) %}
-			<div class="{% if child.fieldType.displayOptions.class is defined and child.fieldType.displayOptions.class  %}{{ child.fieldType.displayOptions.class }}{%else%}col-md-12{% endif %}">
-				{{ _self.renderDataFieldBlock(child, source, compare, compareRawData, '', path, locale) }}
-			</div>
+            {% if child.fieldType.type in ['EMS\\CoreBundle\\Form\\DataField\\FormFieldType'] %}
+                {{ _self.renderDataFieldBlock(child, source, compare, compareRawData, '', path, locale) }}
+            {% else %}
+                <div class="{% if child.fieldType.displayOptions.class is defined and child.fieldType.displayOptions.class  %}{{ child.fieldType.displayOptions.class }}{%else%}col-md-12{% endif %}">
+                    {{ _self.renderDataFieldBlock(child, source, compare, compareRawData, '', path, locale) }}
+                </div>
+            {% endif %}
 			{% if child.fieldType.displayOptions.lastOfRow is defined and child.fieldType.displayOptions.lastOfRow %}
                 <div class="clearfix"></div>
 			{% endif %}


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? |  n |
| Documentation? | n  |

fixes #964
