### PR TITLE
fix(admin/command): emsco:contenttype:switch-default-env already switched return success

### DIFF
--- a/EMS/core-bundle/src/Command/ContentType/SwitchDefaultCommand.php
+++ b/EMS/core-bundle/src/Command/ContentType/SwitchDefaultCommand.php
@@ -48,7 +48,7 @@ class SwitchDefaultCommand extends AbstractCommand
         if ($this->target === $this->contentType->giveEnvironment()) {
             $this->io->warning('The target environment is already the default environment');
 
-            return self::EXECUTE_ERROR;
+            return self::EXECUTE_SUCCESS;
         }
         if (!$this->target->getManaged()) {
             $this->io->warning('The target environment is a managed environment');

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,6 @@ demo: ## make new demo
 	@$(RUN_ADMIN) ems:managed-alias:add-environment ma_preview default
 	@$(RUN_ADMIN) ems:managed-alias:add-environment ma_live live
 	@$(RUN_ADMIN) ems:managed-alias:add-environment ma_live default
-	@$(RUN_ADMIN) emsco:contenttype:switch-default-env media_file default
 	@$(RUN_ADMIN) emsch:local:login demo demo
 	@$(RUN_ADMIN) emsch:local:push --force
 	@$(RUN_ADMIN) emsch:local:upload --filename=./demo/skeleton/template/asset_hash.twig

--- a/composer.json
+++ b/composer.json
@@ -203,7 +203,7 @@
     "phpcs": "php-cs-fixer fix",
     "phpstan": "phpstan analyse --memory-limit 1G",
     "phpunit": "phpunit",
-    "phpall": "phpunit && phpstan analyse --memory-limit 1G && php-cs-fixer fix"
+    "phpall": ["@phpunit", "@phpstan", "@phpcs"]
   },
   "extra": {
     "symfony": {


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Issue ```make demo``` broken because the switch was not needed anymore and was returning error.
If the target is already the default environment we should return success and not error.

Also updated the composer.json (improved scripts)
