### PR TITLE
feat(web/azure): add service token functionality 

### DIFF
--- a/EMS/client-helper-bundle/src/Security/Sso/OAuth2/OAuth2Authenticator.php
+++ b/EMS/client-helper-bundle/src/Security/Sso/OAuth2/OAuth2Authenticator.php
@@ -72,6 +72,6 @@ class OAuth2Authenticator extends AbstractAuthenticator
         /** @var AccessTokenInterface $accessToken */
         $accessToken = $passport->getAttribute('access_token');
 
-        return new OAuth2Token($accessToken, $passport->getUser(), $firewallName, $passport->getUser()->getRoles());
+        return $this->oAuth2Service->getProvider()->createToken($accessToken, $passport, $firewallName);
     }
 }

--- a/EMS/client-helper-bundle/src/Security/Sso/OAuth2/OAuth2Service.php
+++ b/EMS/client-helper-bundle/src/Security/Sso/OAuth2/OAuth2Service.php
@@ -52,12 +52,10 @@ class OAuth2Service
         return $this->httpUtils->createRedirectResponse($request, self::ROUTE_LOGIN);
     }
 
-    public function refreshToken(OAuth2Token $oAuth2Token): TokenInterface
+    public function refreshToken(OAuth2Token $token): TokenInterface
     {
         try {
-            $freshAccessToken = $this->getProvider()->refreshToken($oAuth2Token->getAccessToken());
-
-            return OAuth2Token::refresh($freshAccessToken, $oAuth2Token);
+            return $this->getProvider()->refreshToken($token);
         } catch (\Throwable $e) {
             $this->logger->error($e->getMessage());
 

--- a/EMS/client-helper-bundle/src/Security/Sso/OAuth2/Provider/AzureOAuth2Provider.php
+++ b/EMS/client-helper-bundle/src/Security/Sso/OAuth2/Provider/AzureOAuth2Provider.php
@@ -4,14 +4,22 @@ declare(strict_types=1);
 
 namespace EMS\ClientHelperBundle\Security\Sso\OAuth2\Provider;
 
+use EMS\ClientHelperBundle\Security\Sso\OAuth2\OAuth2Token;
+use EMS\Helpers\Standard\Type;
 use League\OAuth2\Client\Provider\AbstractProvider;
 use League\OAuth2\Client\Provider\ResourceOwnerInterface;
+use League\OAuth2\Client\Token\AccessTokenInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use TheNetworg\OAuth2\Client\Provider\Azure;
 use TheNetworg\OAuth2\Client\Provider\AzureResourceOwner;
+
+use function Symfony\Component\String\u;
 
 class AzureOAuth2Provider extends AbstractOAuth2Provider
 {
     private Azure $azure;
+    /** @var array<string, string[]> */
+    private array $serviceScopes = [];
 
     public const DEFAULT_SCOPES = ['openid', 'profile', 'offline_access'];
 
@@ -26,14 +34,56 @@ class AzureOAuth2Provider extends AbstractOAuth2Provider
         ?array $scopes,
         ?string $version
     ) {
+        $scopes = $scopes ?? self::DEFAULT_SCOPES;
+        $serviceScopes = \array_filter($scopes, static fn (string $s) => u($s)->startsWith('http'));
+        $defaultScopes = \array_diff($scopes, $serviceScopes);
+
+        foreach ($serviceScopes as $serviceScope) {
+            $host = \parse_url($serviceScope)['host'] ?? null;
+            $serviceName = Type::string($host);
+            $this->serviceScopes[$serviceName][] = $serviceScope;
+        }
+
         $this->azure = new Azure([
             'tenant' => $tenant,
             'clientId' => $clientId,
             'clientSecret' => $clientSecret,
             'redirectUri' => $redirectUri,
-            'scopes' => $scopes ?? self::DEFAULT_SCOPES,
+            'scopes' => $defaultScopes,
             'defaultEndPointVersion' => $version ?? Azure::ENDPOINT_VERSION_2_0,
         ]);
+    }
+
+    public function createToken(AccessTokenInterface $accessToken, Passport $passport, string $firewallName): OAuth2Token
+    {
+        $token = new OAuth2Token($accessToken, $passport->getUser(), $firewallName, $passport->getUser()->getRoles());
+
+        foreach ($this->serviceScopes as $serviceName => $serviceScopes) {
+            $token->serviceTokens[$serviceName] = $this->azure->getAccessToken('refresh_token', [
+                'refresh_token' => $accessToken->getRefreshToken(),
+                'scope' => \implode(' ', $serviceScopes),
+            ]);
+        }
+
+        return $token;
+    }
+
+    public function refreshToken(OAuth2Token $token): OAuth2Token
+    {
+        $refreshedToken = parent::refreshToken($token);
+
+        foreach ($token->serviceTokens as $serviceName => $serviceToken) {
+            if (!$serviceToken->hasExpired()) {
+                continue;
+            }
+
+            $refreshedToken->serviceTokens[$serviceName] = $this->azure->getAccessToken('refresh_token', [
+                'refresh_token' => $serviceToken->getRefreshToken(),
+                'scope' => $this->serviceScopes[$serviceName],
+            ]);
+        }
+
+        return $refreshedToken;
     }
 
     protected function getName(): string

--- a/EMS/client-helper-bundle/src/Security/Sso/OAuth2/Provider/ProviderInterface.php
+++ b/EMS/client-helper-bundle/src/Security/Sso/OAuth2/Provider/ProviderInterface.php
@@ -4,17 +4,21 @@ declare(strict_types=1);
 
 namespace EMS\ClientHelperBundle\Security\Sso\OAuth2\Provider;
 
+use EMS\ClientHelperBundle\Security\Sso\OAuth2\OAuth2Token;
 use League\OAuth2\Client\Token\AccessTokenInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 
 interface ProviderInterface
 {
+    public function createToken(AccessTokenInterface $accessToken, Passport $passport, string $firewallName): OAuth2Token;
+
     public function redirect(Request $request): RedirectResponse;
 
     public function getAccessToken(Request $request): AccessTokenInterface;
 
-    public function refreshToken(AccessTokenInterface $token): AccessTokenInterface;
+    public function refreshToken(OAuth2Token $token): OAuth2Token;
 
     public function getUsername(AccessTokenInterface $token): string;
 }

--- a/docs/elasticms-web/security.md
+++ b/docs/elasticms-web/security.md
@@ -159,7 +159,39 @@ Important:
 - for retrieving a `refresh_token`, scope offline_access is required
 - add optional claim for `upn` (App registrations > my app > Token configuration),
   because elasticms uses the upn for the username
+- Add yammer scopes will create a new service token:
+  EMSCH_OAUTH2_SCOPES='["openid","profile","offline_access","https://api.yammer.com/user_impersonation"]'
+  
+#### Azure twig example
 
+```twig
+{% set oauth2 = app.token %}
+
+{% set me = ems_http(
+   'https://graph.microsoft.com/v1.0/me', 
+   'GET',
+   {'headers': { 'Authorization': "Bearer #{oauth2.token}" } }
+).content|ems_json_decode %}
+
+{% set events = ems_http(
+   'https://graph.microsoft.com/v1.0/me/events?$select=subject,body,bodyPreview,organizer,attendees,start,end,location',
+   'GET',
+   { 'headers': { 'Authorization': "Bearer #{oauth2.token}" } }
+).content|ems_json_decode %}
+
+{# for yammer EMSCH_OAUTH2_SCOPES needs to contain https://api.yammer.com/user_impersonation #}
+{% set yammerUser = ems_http(
+   'https://www.yammer.com/api/v1/users/current.json',
+   'GET',
+   { 'headers': { 'Authorization': "Bearer #{oauth2.token('api.yammer.com')}" } }
+).content|ems_json_decode %}
+
+{% set yammerMessages = ems_http(
+   'https://www.yammer.com/api/v1/messages.json',
+   'GET',
+   { 'headers': { 'Authorization': "Bearer #{oauth2.token('api.yammer.com')}" } }
+).content|ems_json_decode %}
+```
 
 ## SAML (Security Assertion Markup Language)
 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  n |
| New feature?   | y  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? |  n |
| Documentation? | y  |

The OAuth2Token class can now contain serviceToken, for authentication to other services using the same access token, but creating a new one.
