### PR TITLE
fix(admin/datatable): default sort job created desc

### DIFF
--- a/EMS/core-bundle/src/DataTable/Type/ContentType/ContentTypeViewDataTableType.php
+++ b/EMS/core-bundle/src/DataTable/Type/ContentType/ContentTypeViewDataTableType.php
@@ -18,6 +18,7 @@ use EMS\CoreBundle\Roles;
 use EMS\CoreBundle\Routes;
 use EMS\CoreBundle\Service\ContentTypeService;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use function Symfony\Component\Translation\t;
 
 class ContentTypeViewDataTableType extends AbstractEntityTableType
 {
@@ -32,7 +33,7 @@ class ContentTypeViewDataTableType extends AbstractEntityTableType
     public function build(EntityTable $table): void
     {
         $table->addColumn('table.index.column.loop_count', 'orderKey');
-        $table->addColumnDefinition(new TemplateBlockTableColumn('dashboard.index.column.public', 'public', "@$this->templateNamespace/view/columns.html.twig"));
+        $table->addColumnDefinition(new TemplateBlockTableColumn(t('field.public_access', [], 'emsco-core'), 'public', "@$this->templateNamespace/view/columns.html.twig"));
         $table->addColumn('view.index.column.name', 'name');
         $table->addColumn('view.index.column.label', 'label')->setItemIconCallback(fn (View $view) => $view->getIcon() ?? '');
         $table->addColumnDefinition(new TranslationTableColumn('view.index.column.type', 'type', EMSCoreBundle::TRANS_FORM_DOMAIN));

--- a/EMS/core-bundle/src/DataTable/Type/ContentType/ContentTypeViewDataTableType.php
+++ b/EMS/core-bundle/src/DataTable/Type/ContentType/ContentTypeViewDataTableType.php
@@ -18,6 +18,7 @@ use EMS\CoreBundle\Roles;
 use EMS\CoreBundle\Routes;
 use EMS\CoreBundle\Service\ContentTypeService;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+
 use function Symfony\Component\Translation\t;
 
 class ContentTypeViewDataTableType extends AbstractEntityTableType

--- a/EMS/core-bundle/src/DataTable/Type/Job/JobDataTableType.php
+++ b/EMS/core-bundle/src/DataTable/Type/Job/JobDataTableType.php
@@ -28,7 +28,9 @@ class JobDataTableType extends AbstractEntityTableType
 
     public function build(EntityTable $table): void
     {
-        $table->setLabelAttribute('id');
+        $table
+            ->setDefaultOrder('created', 'desc')
+            ->setLabelAttribute('id');
 
         $table->addColumnDefinition(new DatetimeTableColumn(
             titleKey: t('field.date_created', [], 'emsco-core'),


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  |  n |
| Fixed tickets? | n  |
| Documentation? | n  |

And correct translation public on contentType view datatable.

Dashboard key was removed in previous pr