### PR TITLE
fix(admin/job): escape job commands trigger from UI

### DIFF
--- a/EMS/core-bundle/src/Service/JobService.php
+++ b/EMS/core-bundle/src/Service/JobService.php
@@ -20,6 +20,8 @@ use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
+use function Symfony\Component\String\u;
+
 class JobService implements EntityServiceInterface
 {
     private ObjectManager $em;
@@ -141,7 +143,9 @@ class JobService implements EntityServiceInterface
             $application->setAutoExit(false);
 
             $command = ($job->getCommand() ?? 'list');
-            $input = new StringInput($command);
+            $escapedCommand = u($command)->replace('\\', '\\\\')->toString();
+
+            $input = new StringInput($escapedCommand);
 
             $application->run($input, $output);
         } catch (\Exception $e) {


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? |  n |
| Documentation? | n  |

Global search with quote search value "demo". The symfony StringInput will remove the correctly escaped search value.

```bash
emsco:contenttype:export template_ems json '{"query":{"bool":{"must":[{"query_string":{"query":"\"demo\"","default_operator":"AND","boost":"1.0"}}]}},"sort":null}' --withBusinessId --environment=preview --baseUrl=//localhost:8881
```

```bash
Job ready to be launch

* Duration: 0 s
* Memory: 14 MB


In Json.php line 39:

Invalid json Syntax error


emsco:contenttype:export [--environment ENVIRONMENT] [--withBusinessId] [--scrollSize SCROLLSIZE] [--scrollTimeout SCROLLTIMEOUT] [--baseUrl BASEURL] [--] <contentTypeName> [<format> [<query> [<outputFile>]]]
````
