### PR TITLE
fix(cli/media-sync): add filesize limit and fix memory leak extraction

### DIFF
--- a/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySync.php
+++ b/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySync.php
@@ -227,6 +227,12 @@ final class MediaLibrarySync
             return $assetArray;
         }
 
+        if ($file->getSize() > $this->options->maxFileSizeExtract) {
+            $this->io->note(\sprintf('File "%s" to big for extraction (%d bytes)', $file->getFilename(), $file->getSize()));
+
+            return $assetArray;
+        }
+
         if ($this->io->isVerbose()) {
             $this->io->note('Tika extracting');
         }

--- a/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySync.php
+++ b/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySync.php
@@ -204,7 +204,11 @@ final class MediaLibrarySync
             }
         }
 
-        if (null !== $mediaFile && $mediaFile[EmsFields::CONTENT_FILE_HASH_FIELD] === $hash && !empty($mediaFile[EmsFields::CONTENT_FILE_CONTENT])) {
+        if (!$this->options->forceExtract
+            && null !== $mediaFile
+            && $mediaFile[EmsFields::CONTENT_FILE_HASH_FIELD] === $hash
+            && !empty($mediaFile[EmsFields::CONTENT_FILE_CONTENT])
+        ) {
             return $mediaFile;
         }
 

--- a/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySync.php
+++ b/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySync.php
@@ -144,7 +144,7 @@ final class MediaLibrarySync
 
         if (null !== $file) {
             if ($this->io->isVerbose()) {
-                $this->io->note(sprintf('Upload media "%s" (%s)', $file->getFilename(), $file->getRealPath()));
+                $this->io->note(\sprintf('Upload media "%s" (%s)', $file->getFilename(), $file->getRealPath()));
             }
 
             $mediaFile = $document ? $document->getSource()[$this->options->fileField] ?? null : null;

--- a/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySync.php
+++ b/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySync.php
@@ -216,7 +216,7 @@ final class MediaLibrarySync
             EmsFields::CONTENT_FILE_HASH_FIELD => $hash,
             EmsFields::CONTENT_FILE_NAME_FIELD => $filename,
             EmsFields::CONTENT_MIME_TYPE_FIELD => $mimeType,
-            EmsFields::CONTENT_FILE_SIZE_FIELD => $file->getSize() ? $file->getSize() : null,
+            EmsFields::CONTENT_FILE_SIZE_FIELD => $file->getSize() ?: null,
         ];
         if (null === $this->tikaHelper) {
             return $assetArray;
@@ -230,7 +230,7 @@ final class MediaLibrarySync
             $assetArray[EmsFields::CONTENT_FILE_CONTENT] = \mb_substr($promise->getText(), 0, $this->options->maxContentSize, 'UTF-8');
             $meta = $promise->getMeta();
             $createdDate = $meta->getCreated();
-            $assetArray[EmsFields::CONTENT_FILE_DATE] = null !== $createdDate ? $createdDate->format(\DATE_ATOM) : null;
+            $assetArray[EmsFields::CONTENT_FILE_DATE] = $createdDate?->format(\DATE_ATOM);
             $assetArray[EmsFields::CONTENT_FILE_AUTHOR] = $meta->getCreator();
             $assetArray[EmsFields::CONTENT_FILE_TITLE] = $meta->getTitle();
             $assetArray[EmsFields::CONTENT_FILE_LANGUAGE] = $meta->getLocale();

--- a/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySync.php
+++ b/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySync.php
@@ -227,7 +227,10 @@ final class MediaLibrarySync
         $promise->startText();
         $promise->startMeta();
         try {
-            $assetArray[EmsFields::CONTENT_FILE_CONTENT] = \mb_substr($promise->getText(), 0, $this->options->maxContentSize, 'UTF-8');
+            $extractedContent = \mb_substr($promise->getText(), 0, $this->options->maxContentSize, 'UTF-8');
+            $extractedContent = Text::superTrim($extractedContent);
+
+            $assetArray[EmsFields::CONTENT_FILE_CONTENT] = $extractedContent;
             $meta = $promise->getMeta();
             $createdDate = $meta->getCreated();
             $assetArray[EmsFields::CONTENT_FILE_DATE] = $createdDate?->format(\DATE_ATOM);

--- a/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySyncOptions.php
+++ b/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySyncOptions.php
@@ -20,6 +20,7 @@ final class MediaLibrarySyncOptions
         public readonly bool $onlyMetadataFile,
         public readonly bool $hashFolder,
         public readonly bool $hashMetaDataFile,
+        public readonly bool $forceExtract = false,
         public readonly int $maxContentSize = 5120,
     ) {
         if (!\str_starts_with($targetFolder, '/')) {

--- a/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySyncOptions.php
+++ b/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySyncOptions.php
@@ -22,6 +22,7 @@ final class MediaLibrarySyncOptions
         public readonly bool $hashMetaDataFile,
         public readonly bool $forceExtract = false,
         public readonly int $maxContentSize = 5120,
+        public readonly int $maxFileSizeExtract = (64 * 1024 * 1024)
     ) {
         if (!\str_starts_with($targetFolder, '/')) {
             throw new \RuntimeException('The target-folder options must start with a /');

--- a/elasticms-cli/src/Command/MediaLibrary/MediaLibrarySyncCommand.php
+++ b/elasticms-cli/src/Command/MediaLibrary/MediaLibrarySyncCommand.php
@@ -39,6 +39,7 @@ final class MediaLibrarySyncCommand extends AbstractCommand
     private const OPTION_HASH_METADATA_FILE = 'hash-metadata-file';
     private const OPTION_TARGET_FOLDER = 'target-folder';
     private const OPTION_FORCE_EXTRACT = 'force-extract';
+    private const OPTION_EXTRACT_SIZE = 'max-extract-size';
 
     private bool $tika;
     private ?string $tikaBaseUrl;
@@ -76,6 +77,7 @@ final class MediaLibrarySyncCommand extends AbstractCommand
             ->addOption(self::OPTION_HASH_METADATA_FILE, null, InputOption::VALUE_NONE, 'Provide a hash for option metadata file (CSV or Excel)')
             ->addOption(self::OPTION_TARGET_FOLDER, null, InputOption::VALUE_OPTIONAL, 'Base path to sync in the media library. Must start by a / and should ends also with a /', '/')
             ->addOption(self::OPTION_FORCE_EXTRACT, null, InputOption::VALUE_NONE, 'Force tika extraction')
+            ->addOption(self::OPTION_EXTRACT_SIZE, null, InputOption::VALUE_OPTIONAL, 'Max file size for extraction', 64 * 1024 * 1024)
         ;
     }
 
@@ -99,6 +101,7 @@ final class MediaLibrarySyncCommand extends AbstractCommand
             hashMetaDataFile: $this->getOptionBool(self::OPTION_HASH_METADATA_FILE),
             forceExtract: $this->getOptionBool(self::OPTION_FORCE_EXTRACT),
             maxContentSize: $this->getOptionInt(self::OPTION_MAX_CONTENT_SIZE),
+            maxFileSizeExtract: $this->getOptionInt(self::OPTION_EXTRACT_SIZE),
         );
 
         $this->tika = $this->getOptionBool(self::OPTION_TIKA);

--- a/elasticms-cli/src/Command/MediaLibrary/MediaLibrarySyncCommand.php
+++ b/elasticms-cli/src/Command/MediaLibrary/MediaLibrarySyncCommand.php
@@ -38,6 +38,7 @@ final class MediaLibrarySyncCommand extends AbstractCommand
     private const OPTION_HASH_FOLDER = 'hash-folder';
     private const OPTION_HASH_METADATA_FILE = 'hash-metadata-file';
     private const OPTION_TARGET_FOLDER = 'target-folder';
+    private const OPTION_FORCE_EXTRACT = 'force-extract';
 
     private bool $tika;
     private ?string $tikaBaseUrl;
@@ -74,6 +75,7 @@ final class MediaLibrarySyncCommand extends AbstractCommand
             ->addOption(self::OPTION_HASH_FOLDER, null, InputOption::VALUE_NONE, 'Provide a hash for folder argument (zip file)')
             ->addOption(self::OPTION_HASH_METADATA_FILE, null, InputOption::VALUE_NONE, 'Provide a hash for option metadata file (CSV or Excel)')
             ->addOption(self::OPTION_TARGET_FOLDER, null, InputOption::VALUE_OPTIONAL, 'Base path to sync in the media library. Must start by a / and should ends also with a /', '/')
+            ->addOption(self::OPTION_FORCE_EXTRACT, null, InputOption::VALUE_NONE, 'Force tika extraction')
         ;
     }
 
@@ -82,20 +84,21 @@ final class MediaLibrarySyncCommand extends AbstractCommand
         parent::initialize($input, $output);
 
         $this->options = new MediaLibrarySyncOptions(
-            $this->getArgumentString(self::ARGUMENT_FOLDER),
-            $this->getOptionString(self::OPTION_CONTENT_TYPE),
-            $this->getOptionString(self::OPTION_FOLDER_FIELD),
-            $this->getOptionString(self::OPTION_PATH_FIELD),
-            $this->getOptionString(self::OPTION_FILE_FIELD),
-            $this->getOptionStringNull(self::OPTION_METADATA_FILE),
-            $this->getOptionString(self::OPTION_LOCATE_ROW_EXPRESSION),
-            $this->getOptionString(self::OPTION_TARGET_FOLDER),
-            $this->getOptionBool(self::OPTION_DRY_RUN),
-            $this->getOptionBool(self::OPTION_ONLY_MISSING),
-            $this->getOptionBool(self::OPTION_ONLY_METADATA_FILE),
-            $this->getOptionBool(self::OPTION_HASH_FOLDER),
-            $this->getOptionBool(self::OPTION_HASH_METADATA_FILE),
-            $this->getOptionInt(self::OPTION_MAX_CONTENT_SIZE),
+            folder: $this->getArgumentString(self::ARGUMENT_FOLDER),
+            contentType: $this->getOptionString(self::OPTION_CONTENT_TYPE),
+            folderField: $this->getOptionString(self::OPTION_FOLDER_FIELD),
+            pathField: $this->getOptionString(self::OPTION_PATH_FIELD),
+            fileField: $this->getOptionString(self::OPTION_FILE_FIELD),
+            metaDataFile: $this->getOptionStringNull(self::OPTION_METADATA_FILE),
+            locateRowExpression: $this->getOptionString(self::OPTION_LOCATE_ROW_EXPRESSION),
+            targetFolder: $this->getOptionString(self::OPTION_TARGET_FOLDER),
+            dryRun: $this->getOptionBool(self::OPTION_DRY_RUN),
+            onlyMissingFile: $this->getOptionBool(self::OPTION_ONLY_MISSING),
+            onlyMetadataFile: $this->getOptionBool(self::OPTION_ONLY_METADATA_FILE),
+            hashFolder: $this->getOptionBool(self::OPTION_HASH_FOLDER),
+            hashMetaDataFile: $this->getOptionBool(self::OPTION_HASH_METADATA_FILE),
+            forceExtract: $this->getOptionBool(self::OPTION_FORCE_EXTRACT),
+            maxContentSize: $this->getOptionInt(self::OPTION_MAX_CONTENT_SIZE),
         );
 
         $this->tika = $this->getOptionBool(self::OPTION_TIKA);

--- a/elasticms-cli/src/Helper/Tika/TikaWrapper.php
+++ b/elasticms-cli/src/Helper/Tika/TikaWrapper.php
@@ -13,15 +13,15 @@ class TikaWrapper extends ProcessWrapper
     private const EMSCLI_TIKA_PATH = 'EMSCLI_TIKA_PATH';
     private readonly string $tikaJar;
 
-    private function __construct(StreamInterface $stream, string $option, private readonly bool $trimWhiteSpaces = false, float $timeout = 3 * 60.0)
+    private function __construct(StreamInterface $stream, string $option, float $timeout = 3 * 60.0)
     {
         $this->tikaJar = \getenv(self::EMSCLI_TIKA_PATH) ?: '/opt/bin/tika-app.jar';
         parent::__construct(['java', '-Djava.awt.headless=true', '-jar', $this->tikaJar, $option], $stream, $timeout);
     }
 
-    public static function getLanguage(StreamInterface $stream, bool $trimWhiteSpaces = true): TikaWrapper
+    public static function getLanguage(StreamInterface $stream): TikaWrapper
     {
-        return new self($stream, '--language', $trimWhiteSpaces);
+        return new self($stream, '--language');
     }
 
     public static function getHtml(StreamInterface $stream): TikaWrapper
@@ -29,19 +29,19 @@ class TikaWrapper extends ProcessWrapper
         return new self($stream, '--html');
     }
 
-    public static function getText(StreamInterface $stream, bool $trimWhiteSpaces = true): TikaWrapper
+    public static function getText(StreamInterface $stream): TikaWrapper
     {
-        return new self($stream, '--text', $trimWhiteSpaces);
+        return new self($stream, '--text');
     }
 
-    public static function getTextMain(StreamInterface $stream, bool $trimWhiteSpaces = true): TikaWrapper
+    public static function getTextMain(StreamInterface $stream): TikaWrapper
     {
-        return new self($stream, '--text-main', $trimWhiteSpaces);
+        return new self($stream, '--text-main');
     }
 
-    public static function getMetadata(StreamInterface $stream, bool $trimWhiteSpaces = true): TikaWrapper
+    public static function getMetadata(StreamInterface $stream): TikaWrapper
     {
-        return new self($stream, '--metadata', $trimWhiteSpaces);
+        return new self($stream, '--metadata');
     }
 
     public static function getJsonMetadata(StreamInterface $stream): TikaWrapper
@@ -51,16 +51,7 @@ class TikaWrapper extends ProcessWrapper
 
     public static function getDocumentType(StreamInterface $stream): TikaWrapper
     {
-        return new self($stream, '--detect', true);
-    }
-
-    public function getOutput(): string
-    {
-        if ($this->trimWhiteSpaces) {
-            return Text::superTrim(parent::getOutput());
-        }
-
-        return parent::getOutput();
+        return new self($stream, '--detect');
     }
 
     protected function initialize(): void

--- a/elasticms-cli/src/Helper/Tika/TikaWrapper.php
+++ b/elasticms-cli/src/Helper/Tika/TikaWrapper.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\CLI\Helper\Tika;
 
 use App\CLI\Helper\ProcessWrapper;
-use EMS\Helpers\Standard\Text;
 use Psr\Http\Message\StreamInterface;
 
 class TikaWrapper extends ProcessWrapper


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

We are calling trim on the full extracted content, and  afterwards doing a mb_substr.
The fix is first substring then trim.

Plus by default we do not call tika extract for files bigger then 64mb

Added extra output for verbose mode
Added new option --force-extract
