### PR TITLE
fix(common/storage): allow config or cache files to not be saved in any storage 

### DIFF
--- a/EMS/common-bundle/src/Storage/StorageManager.php
+++ b/EMS/common-bundle/src/Storage/StorageManager.php
@@ -141,6 +141,10 @@ class StorageManager
         $count = 0;
         foreach ($this->adapters as $adapter) {
             try {
+                if ($count > 0 && $usageType < StorageInterface::STORAGE_USAGE_ASSET) {
+                    break;
+                }
+
                 if (!$this->isUsageSupported($adapter, $usageType)) {
                     continue;
                 }

--- a/EMS/common-bundle/src/Storage/StorageManager.php
+++ b/EMS/common-bundle/src/Storage/StorageManager.php
@@ -139,34 +139,40 @@ class StorageManager
     {
         $hash = $this->computeStringHash($contents);
         $count = 0;
-
         foreach ($this->adapters as $adapter) {
-            if (!$this->isUsageSupported($adapter, $usageType)) {
-                continue;
-            }
+            try {
+                if (!$this->isUsageSupported($adapter, $usageType)) {
+                    continue;
+                }
 
-            if ($adapter->head($hash)) {
-                ++$count;
-                continue;
-            }
+                if ($adapter->head($hash)) {
+                    ++$count;
+                    continue;
+                }
 
-            if (!$adapter->initUpload($hash, \strlen($contents), $filename, $mimetype)) {
-                continue;
-            }
+                if (!$adapter->initUpload($hash, \strlen($contents), $filename, $mimetype)) {
+                    continue;
+                }
 
-            if (!$adapter->addChunk($hash, $contents)) {
-                continue;
-            }
+                if (!$adapter->addChunk($hash, $contents)) {
+                    continue;
+                }
 
-            $adapter->initFinalize($hash);
+                $adapter->initFinalize($hash);
 
-            if ($adapter->finalizeUpload($hash)) {
-                ++$count;
+                if ($adapter->finalizeUpload($hash)) {
+                    ++$count;
+                }
+            } catch (\Throwable $e) {
+                $this->logger->error(\sprintf('Not able to save %s in %s with message: %s', $hash, $adapter->__toString(), $e->getMessage()));
             }
         }
 
         if (0 === $count) {
-            throw new NotSavedException($hash);
+            $this->logger->error(\sprintf('The config %s was not able to be saved', $hash));
+            if ($usageType >= StorageInterface::STORAGE_USAGE_ASSET) {
+                throw new NotSavedException($hash);
+            }
         }
 
         return $hash;

--- a/EMS/common-bundle/tests/Unit/Storage/StorageManagerTest.php
+++ b/EMS/common-bundle/tests/Unit/Storage/StorageManagerTest.php
@@ -114,7 +114,7 @@ class StorageManagerTest extends WebTestCase
 
         $configHash = $this->storageManager->saveConfig($data);
         $this->assertEquals(\sha1(\json_encode($data)), $configHash);
-        $this->assertEquals(2, \count($this->storageManager->headIn($configHash)));
+        $this->assertEquals(1, \count($this->storageManager->headIn($configHash)));
         $this->assertEquals(3, $this->storageManager->remove($configHash));
     }
 


### PR DESCRIPTION

| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? |  n |
| Documentation? | n  |

to ensure a least that the html page will load... without asset
