### PR TITLE
fix(common/api): api with large docs use EMSCO_LOCK_TIME

### DIFF
--- a/EMS/core-bundle/src/Service/DataService.php
+++ b/EMS/core-bundle/src/Service/DataService.php
@@ -429,10 +429,10 @@ class DataService
      *
      * @throws \Exception
      */
-    public function createData(?string $ouuid, array $rawdata, ContentType $contentType, bool $byARealUser = true): Revision
+    public function createData(?string $ouuid, array $rawdata, ContentType $contentType): Revision
     {
         $now = new \DateTime();
-        $until = $now->add(new \DateInterval($byARealUser ? 'PT5M' : 'PT1M')); // +5 minutes
+        $until = $now->add(new \DateInterval('PT5M')); // +5 minutes
         $newRevision = new Revision();
         $newRevision->setContentType($contentType);
         if (null !== $ouuid) {
@@ -442,8 +442,7 @@ class DataService
         $newRevision->setEndTime(null);
         $newRevision->setDeleted(false);
         $newRevision->setDraft(true);
-
-        $lockBy = $byARealUser ? $this->userService->getCurrentUser()->getUserIdentifier() : 'DATA_SERVICE';
+        $lockBy = $this->userService->getCurrentUser()->getUserIdentifier();
         $newRevision->setLockBy($lockBy);
 
         $newRevision->setLockUntil($until);

--- a/EMS/core-bundle/src/Service/DataService.php
+++ b/EMS/core-bundle/src/Service/DataService.php
@@ -179,7 +179,7 @@ class DataService
 
         $revision->setLockBy($lockerUsername);
 
-        $lockTime ??= $username ? new \DateTime('+30 seconds') : new \DateTime($this->lockTime);
+        $lockTime ??= new \DateTime($this->lockTime);
         $revision->setLockUntil($lockTime);
 
         $em->flush();
@@ -432,7 +432,7 @@ class DataService
     public function createData(?string $ouuid, array $rawdata, ContentType $contentType): Revision
     {
         $now = new \DateTime();
-        $until = $now->add(new \DateInterval('PT5M')); // +5 minutes
+        $until = new \DateTime($this->lockTime);
         $newRevision = new Revision();
         $newRevision->setContentType($contentType);
         if (null !== $ouuid) {
@@ -1474,7 +1474,7 @@ class DataService
     public function getEmptyRevision(ContentType $contentType, ?string $user = null): Revision
     {
         $now = new \DateTime();
-        $until = $now->add(new \DateInterval('PT5M')); // +5 minutes
+        $until = new \DateTime($this->lockTime);
         $newRevision = new Revision();
         $newRevision->setContentType($contentType);
         $newRevision->addEnvironment($contentType->giveEnvironment());


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   |  n |
| BC breaks?     |  n |
| Deprecations?  |  n |
| Fixed tickets? |  n |
| Documentation? | n  |

Sometimes the lock time is to short if the document uploaded via the API is too big. Even with the API we should rely on the EMSCO_LOCK_TIME envvar
