### PR TITLE
fix(admin/release): improve labels and environment selects

### DIFF
--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/release/form.html.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/release/form.html.twig
@@ -9,12 +9,12 @@
 			{{ form_start(form_release) }}
 				<div class="box-body">
 					<div class="row">
-						{{ form_row(form_release.name) }}
-						<div class="clearfix"></div>
-						{{ form_row(form_release.execution_date) }}
-						<div class="clearfix"></div>
-						{{ form_row(form_release.environmentSource) }}
-						{{ form_row(form_release.environmentTarget) }}
+						<div class="col-md-2">
+							{{ form_row(form_release.name) }}
+							{{ form_row(form_release.environmentTarget) }}
+							{{ form_row(form_release.execution_date) }}
+							{{ form_row(form_release.environmentSource) }}
+						</div>
 					</div>
 				</div>
 				<div class="box-footer">

--- a/EMS/core-bundle/src/Controller/ContentManagement/ReleaseController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/ReleaseController.php
@@ -57,10 +57,11 @@ final class ReleaseController extends AbstractController
 
     public function add(Request $request): Response
     {
-        $form = $this->createForm(ReleaseType::class, new Release(), ['add' => true]);
+        $release = new Release();
+        $form = $this->createForm(ReleaseType::class, $release, ['add' => true]);
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {
-            $release = $this->releaseService->add($form->getViewData());
+            $release = $this->releaseService->add($release);
 
             return $this->redirectToRoute(Routes::RELEASE_EDIT, ['release' => $release->getId()]);
         }

--- a/EMS/core-bundle/src/DataTable/Type/Release/ReleaseOverviewDataTableType.php
+++ b/EMS/core-bundle/src/DataTable/Type/Release/ReleaseOverviewDataTableType.php
@@ -15,6 +15,7 @@ use EMS\CoreBundle\Form\Data\TemplateBlockTableColumn;
 use EMS\CoreBundle\Roles;
 use EMS\CoreBundle\Routes;
 use EMS\CoreBundle\Service\ReleaseService;
+
 use function Symfony\Component\Translation\t;
 
 class ReleaseOverviewDataTableType extends AbstractEntityTableType
@@ -48,7 +49,7 @@ class ReleaseOverviewDataTableType extends AbstractEntityTableType
             template: "@$this->templateNamespace/release/columns/revisions.html.twig")
         );
         $table->addColumnDefinition(new TemplateBlockTableColumn(
-                label: t('field.release_environment_target', [], 'emsco-core'),
+            label: t('field.release_environment_target', [], 'emsco-core'),
             blockName: 'environmentTarget',
             template: "@$this->templateNamespace/release/columns/revisions.html.twig")
         );

--- a/EMS/core-bundle/src/DataTable/Type/Release/ReleaseOverviewDataTableType.php
+++ b/EMS/core-bundle/src/DataTable/Type/Release/ReleaseOverviewDataTableType.php
@@ -15,6 +15,7 @@ use EMS\CoreBundle\Form\Data\TemplateBlockTableColumn;
 use EMS\CoreBundle\Roles;
 use EMS\CoreBundle\Routes;
 use EMS\CoreBundle\Service\ReleaseService;
+use function Symfony\Component\Translation\t;
 
 class ReleaseOverviewDataTableType extends AbstractEntityTableType
 {
@@ -26,13 +27,31 @@ class ReleaseOverviewDataTableType extends AbstractEntityTableType
     public function build(EntityTable $table): void
     {
         $table->setDefaultOrder('executionDate', 'desc');
-        $table->addColumn('release.index.column.name', 'name');
-        $table->addColumnDefinition(new DatetimeTableColumn('release.index.column.execution_date', 'executionDate'));
-        $table->addColumnDefinition(new TemplateBlockTableColumn('release.index.column.status', 'status', "@$this->templateNamespace/release/columns/revisions.html.twig"));
+        $table->addColumn(
+            titleKey: t('field.name', [], 'emsco-core'),
+            attribute: 'name'
+        );
+        $table->addColumnDefinition(new DatetimeTableColumn(
+            titleKey: t('field.date_execution', [], 'emsco-core'),
+            attribute: 'executionDate'
+        ));
+        $table->addColumnDefinition(new TemplateBlockTableColumn(
+            label: t('field.status', [], 'emsco-core'),
+            blockName: 'status',
+            template: "@$this->templateNamespace/release/columns/revisions.html.twig")
+        );
         $table->addColumnDefinition(new TemplateBlockTableColumn('release.index.column.docs_count', 'docs_count', "@$this->templateNamespace/release/columns/revisions.html.twig"))->setCellClass('text-right');
 
-        $table->addColumnDefinition(new TemplateBlockTableColumn('release.index.column.env_source', 'environmentSource', "@$this->templateNamespace/release/columns/revisions.html.twig"));
-        $table->addColumnDefinition(new TemplateBlockTableColumn('release.index.column.env_target', 'environmentTarget', "@$this->templateNamespace/release/columns/revisions.html.twig"));
+        $table->addColumnDefinition(new TemplateBlockTableColumn(
+            label: t('field.release_environment_source', [], 'emsco-core'),
+            blockName: 'environmentSource',
+            template: "@$this->templateNamespace/release/columns/revisions.html.twig")
+        );
+        $table->addColumnDefinition(new TemplateBlockTableColumn(
+                label: t('field.release_environment_target', [], 'emsco-core'),
+            blockName: 'environmentTarget',
+            template: "@$this->templateNamespace/release/columns/revisions.html.twig")
+        );
         $table->addItemGetAction(Routes::RELEASE_VIEW, 'release.actions.show', 'eye')
             ->addCondition(new Terms('status', [Release::APPLIED_STATUS, Release::SCHEDULED_STATUS, Release::READY_STATUS]));
         $table->addItemGetAction(Routes::RELEASE_EDIT, 'release.actions.edit', 'pencil')

--- a/EMS/core-bundle/src/DataTable/Type/Release/ReleasePickDataTableType.php
+++ b/EMS/core-bundle/src/DataTable/Type/Release/ReleasePickDataTableType.php
@@ -14,6 +14,7 @@ use EMS\CoreBundle\Routes;
 use EMS\CoreBundle\Service\ReleaseService;
 use EMS\CoreBundle\Service\Revision\RevisionService;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+
 use function Symfony\Component\Translation\t;
 
 class ReleasePickDataTableType extends AbstractEntityTableType

--- a/EMS/core-bundle/src/DataTable/Type/Release/ReleasePickDataTableType.php
+++ b/EMS/core-bundle/src/DataTable/Type/Release/ReleasePickDataTableType.php
@@ -14,6 +14,7 @@ use EMS\CoreBundle\Routes;
 use EMS\CoreBundle\Service\ReleaseService;
 use EMS\CoreBundle\Service\Revision\RevisionService;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use function Symfony\Component\Translation\t;
 
 class ReleasePickDataTableType extends AbstractEntityTableType
 {
@@ -31,9 +32,19 @@ class ReleasePickDataTableType extends AbstractEntityTableType
         $revision = $table->getContext();
 
         $table->setDefaultOrder('executionDate', 'desc');
-        $table->addColumn('release.index.column.name', 'name');
-        $table->addColumnDefinition(new DatetimeTableColumn('release.index.column.execution_date', 'executionDate'));
-        $table->addColumnDefinition(new TemplateBlockTableColumn('release.index.column.status', 'status', "@$this->templateNamespace/release/columns/revisions.html.twig"));
+        $table->addColumn(
+            titleKey: t('field.name', [], 'emsco-core'),
+            attribute: 'name'
+        );
+        $table->addColumnDefinition(new DatetimeTableColumn(
+            titleKey: t('field.date_execution', [], 'emsco-core'),
+            attribute: 'executionDate')
+        );
+        $table->addColumnDefinition(new TemplateBlockTableColumn(
+            label: t('field.status', [], 'emsco-core'),
+            blockName: 'status',
+            template: "@$this->templateNamespace/release/columns/revisions.html.twig")
+        );
         $table->addColumnDefinition(new TemplateBlockTableColumn('release.index.column.docs_count', 'docs_count', "@$this->templateNamespace/release/columns/revisions.html.twig"))->setCellClass('text-right');
 
         $table->addItemPostAction(Routes::DATA_ADD_REVISION_TO_RELEASE, 'data.actions.add_to_release_publish', 'plus', 'data.actions.add_to_release_confirm', ['revision' => $revision->getId(), 'type' => 'publish'])->setButtonType('primary');

--- a/EMS/core-bundle/src/Form/Field/EnvironmentPickerType.php
+++ b/EMS/core-bundle/src/Form/Field/EnvironmentPickerType.php
@@ -39,7 +39,7 @@ class EnvironmentPickerType extends ChoiceType
 
         foreach ($environments as $env) {
             if (($env->getManaged() || !$options['managedOnly']) && !\in_array($env->getName(), $options['ignore'])) {
-                $keys[] = $env->getName();
+                $keys[$env->getName()] = $env;
                 $this->choices[$env->getName()] = $env;
             }
         }

--- a/EMS/core-bundle/src/Form/Form/ReleaseType.php
+++ b/EMS/core-bundle/src/Form/Form/ReleaseType.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace EMS\CoreBundle\Form\Form;
 
-use EMS\CoreBundle\EMSCoreBundle;
 use EMS\CoreBundle\Entity\Release;
 use EMS\CoreBundle\Form\Field\EnvironmentPickerType;
 use EMS\CoreBundle\Form\Field\SubmitEmsType;
@@ -13,6 +12,7 @@ use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+
 use function Symfony\Component\Translation\t;
 
 final class ReleaseType extends AbstractType
@@ -30,12 +30,12 @@ final class ReleaseType extends AbstractType
             ->add('name', TextType::class, [
                 'required' => true,
                 'empty_data' => '',
-                'label' => t('field.name', [], 'emsco-core')
+                'label' => t('field.name', [], 'emsco-core'),
             ])
             ->add('environmentTarget', EnvironmentPickerType::class, [
                 'userPublishEnvironments' => true,
                 'managedOnly' => true,
-                'label' => t('field.release_environment_target', [], 'emsco-core')
+                'label' => t('field.release_environment_target', [], 'emsco-core'),
             ])
             ->add('execution_date', DateTimeType::class, [
                 'required' => false,
@@ -52,7 +52,7 @@ final class ReleaseType extends AbstractType
             ->add('environmentSource', EnvironmentPickerType::class, [
                 'userPublishEnvironments' => true,
                 'managedOnly' => true,
-                'label' => t('field.release_environment_source', [], 'emsco-core')
+                'label' => t('field.release_environment_source', [], 'emsco-core'),
             ])
         ;
 

--- a/EMS/core-bundle/src/Form/Form/ReleaseType.php
+++ b/EMS/core-bundle/src/Form/Form/ReleaseType.php
@@ -13,6 +13,7 @@ use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use function Symfony\Component\Translation\t;
 
 final class ReleaseType extends AbstractType
 {
@@ -29,15 +30,18 @@ final class ReleaseType extends AbstractType
             ->add('name', TextType::class, [
                 'required' => true,
                 'empty_data' => '',
+                'label' => t('field.name', [], 'emsco-core')
             ])
             ->add('environmentTarget', EnvironmentPickerType::class, [
                 'userPublishEnvironments' => true,
                 'managedOnly' => true,
+                'label' => t('field.release_environment_target', [], 'emsco-core')
             ])
             ->add('execution_date', DateTimeType::class, [
                 'required' => false,
                 'date_widget' => 'single_text',
                 'input' => 'datetime',
+                'label' => t('field.date_execution', [], 'emsco-core'),
                 'attr' => [
                     'class' => 'datetime-picker',
                     'data-date-format' => 'D/MM/YYYY HH:mm:ss',
@@ -48,6 +52,7 @@ final class ReleaseType extends AbstractType
             ->add('environmentSource', EnvironmentPickerType::class, [
                 'userPublishEnvironments' => true,
                 'managedOnly' => true,
+                'label' => t('field.release_environment_source', [], 'emsco-core')
             ])
         ;
 
@@ -55,18 +60,18 @@ final class ReleaseType extends AbstractType
             $builder->add('create', SubmitEmsType::class, [
                 'attr' => ['class' => 'btn btn-primary btn-sm'],
                 'icon' => 'fa fa-plus',
-                'label' => 'release.add.save',
+                'label' => t('action.create', [], 'emsco-core'),
             ]);
         } else {
             $builder->add(self::BTN_SAVE, SubmitEmsType::class, [
                 'attr' => ['class' => 'btn btn-default btn-sm'],
                 'icon' => 'fa fa-save',
-                'label' => 'release.edit.save',
+                'label' => t('action.save', [], 'emsco-core'),
             ])
             ->add(self::BTN_SAVE_CLOSE, SubmitEmsType::class, [
                 'attr' => ['class' => 'btn btn-default btn-sm'],
                 'icon' => 'fa fa-save',
-                'label' => 'release.edit.saveAndClose',
+                'label' => t('action.save_close', [], 'emsco-core'),
             ]);
         }
     }
@@ -75,7 +80,6 @@ final class ReleaseType extends AbstractType
     {
         $resolver->setDefaults([
             'data_class' => Release::class,
-            'translation_domain' => EMSCoreBundle::TRANS_DOMAIN,
             'add' => false,
         ]);
     }

--- a/EMS/core-bundle/src/Form/Form/ReleaseType.php
+++ b/EMS/core-bundle/src/Form/Form/ReleaseType.php
@@ -29,7 +29,10 @@ final class ReleaseType extends AbstractType
             ->add('name', TextType::class, [
                 'required' => true,
                 'empty_data' => '',
-                'row_attr' => ['class' => 'col-md-3'],
+            ])
+            ->add('environmentTarget', EnvironmentPickerType::class, [
+                'userPublishEnvironments' => true,
+                'managedOnly' => true,
             ])
             ->add('execution_date', DateTimeType::class, [
                 'required' => false,
@@ -41,15 +44,8 @@ final class ReleaseType extends AbstractType
                     'data-date-days-of-week-disabled' => '',
                     'data-date-disabled-hours' => '',
                 ],
-                'row_attr' => ['class' => 'col-md-6'],
             ])
             ->add('environmentSource', EnvironmentPickerType::class, [
-                'row_attr' => ['class' => 'col-md-3'],
-                'userPublishEnvironments' => true,
-                'managedOnly' => true,
-            ])
-            ->add('environmentTarget', EnvironmentPickerType::class, [
-                'row_attr' => ['class' => 'col-md-3'],
                 'userPublishEnvironments' => true,
                 'managedOnly' => true,
             ])

--- a/EMS/core-bundle/src/Form/Form/ReleaseType.php
+++ b/EMS/core-bundle/src/Form/Form/ReleaseType.php
@@ -5,12 +5,10 @@ declare(strict_types=1);
 namespace EMS\CoreBundle\Form\Form;
 
 use EMS\CoreBundle\EMSCoreBundle;
-use EMS\CoreBundle\Entity\Environment;
 use EMS\CoreBundle\Entity\Release;
+use EMS\CoreBundle\Form\Field\EnvironmentPickerType;
 use EMS\CoreBundle\Form\Field\SubmitEmsType;
-use EMS\CoreBundle\Service\EnvironmentService;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -20,10 +18,6 @@ final class ReleaseType extends AbstractType
 {
     public const BTN_SAVE = 'save';
     public const BTN_SAVE_CLOSE = 'saveAndClose';
-
-    public function __construct(private readonly EnvironmentService $environmentService)
-    {
-    }
 
     /**
      * @param FormBuilderInterface<FormBuilderInterface> $builder
@@ -49,22 +43,17 @@ final class ReleaseType extends AbstractType
                 ],
                 'row_attr' => ['class' => 'col-md-6'],
             ])
-            ->add('environmentSource', ChoiceType::class, [
-                'attr' => ['class' => 'select2'],
-                'choices' => $this->environmentService->getEnvironments(),
-                'required' => true,
-                'choice_label' => fn (Environment $value) => '<i class="fa fa-square text-'.$value->getColor().'"></i>&nbsp;&nbsp;'.$value->getLabel(),
+            ->add('environmentSource', EnvironmentPickerType::class, [
                 'row_attr' => ['class' => 'col-md-3'],
-                'choice_value' => static fn (?Environment $value) => $value?->getId(),
+                'userPublishEnvironments' => true,
+                'managedOnly' => true,
             ])
-            ->add('environmentTarget', ChoiceType::class, [
-                'attr' => ['class' => 'select2'],
-                'choices' => $this->environmentService->getEnvironments(),
-                'required' => true,
-                'choice_label' => fn (Environment $value) => '<i class="fa fa-square text-'.$value->getColor().'"></i>&nbsp;&nbsp;'.$value->getLabel(),
+            ->add('environmentTarget', EnvironmentPickerType::class, [
                 'row_attr' => ['class' => 'col-md-3'],
-                'choice_value' => static fn (?Environment $value) => $value?->getId(),
-            ]);
+                'userPublishEnvironments' => true,
+                'managedOnly' => true,
+            ])
+        ;
 
         if ($options['add'] ?? false) {
             $builder->add('create', SubmitEmsType::class, [

--- a/EMS/core-bundle/src/Resources/config/form.xml
+++ b/EMS/core-bundle/src/Resources/config/form.xml
@@ -436,10 +436,6 @@
             <argument type="service" id="ems.service.user" />
             <tag name="form.type"/>
         </service>
-        <service id="ems.form.form.releasetype" class="EMS\CoreBundle\Form\Form\ReleaseType">
-            <argument type="service" id="ems.service.environment" />
-            <tag name="form.type"/>
-        </service>
         <service id="emsco.form.revision.task.filters" class="EMS\CoreBundle\Form\Revision\Task\RevisionTaskFiltersType">
             <tag name="form.type"/>
         </service>

--- a/EMS/core-bundle/src/Resources/translations/EMSCoreBundle.en.yml
+++ b/EMS/core-bundle/src/Resources/translations/EMSCoreBundle.en.yml
@@ -347,11 +347,6 @@ form:
             environments: Environments
             label: Label
             name: Name
-        release:
-            environmentSource: 'Environment source'
-            environmentTarget: 'Environment target'
-            execution_date: 'Execution date'
-            name: Name
         revision-type:
             copy-label: Copy
             paste-label: Paste
@@ -514,19 +509,11 @@ release:
         set_status_wip: 'Rework release'
         show: View
     add:
-        save: Create
         title: 'Add a Release'
     edit:
-        save: Save
-        saveAndClose: 'Save and Close'
         title: 'Edit a Release'
     index:
         column:
-            env_source: 'Environment source'
-            env_target: 'Environment target'
-            execution_date: 'Execution date'
-            name: Name
-            status: Status
             docs_count: '# Documents'
         title: 'List of Releases'
     menu: Releases

--- a/EMS/core-bundle/src/Resources/translations/emsco-core+intl-icu.en.yml
+++ b/EMS/core-bundle/src/Resources/translations/emsco-core+intl-icu.en.yml
@@ -7,6 +7,7 @@ action:
     attach: Attach
     close: Close
     confirmation: 'Do you confirm?'
+    create: Create
     deactivate: Deactivate
     define: Define
     delete: Delete
@@ -19,6 +20,8 @@ action:
     export: Export
     rebuild: Rebuild
     reorder: Reorder
+    save: Save
+    save_close: 'Save and Close'
     select_all: 'Select all'
     status: Status
     toggle_visibility: 'Toggle visibility'
@@ -88,6 +91,7 @@ field:
     cron: Cron
     date_build: 'Date build'
     date_created: 'Date creation'
+    date_execution: 'Execution date'
     date_modified: 'Date modified'
     date_run_next: 'Date next run'
     date_run_previous: 'Date previous run'
@@ -113,6 +117,8 @@ field:
     name: Name
     plural: Plural
     public_access: 'Public Access'
+    release_environment_source: 'Source environment for publication'
+    release_environment_target: 'Environment for publication or unpublish'
     severity: Severity
     singular: Singular
     status: Status

--- a/EMS/core-bundle/src/Resources/views/release/form.html.twig
+++ b/EMS/core-bundle/src/Resources/views/release/form.html.twig
@@ -9,12 +9,12 @@
 			{{ form_start(form_release) }}
 				<div class="box-body">
 					<div class="row">
-						{{ form_row(form_release.name) }}
-						<div class="clearfix"></div>
-						{{ form_row(form_release.execution_date) }}
-						<div class="clearfix"></div>
-						{{ form_row(form_release.environmentSource) }}
-						{{ form_row(form_release.environmentTarget) }}
+						<div class="col-md-2">
+							{{ form_row(form_release.name) }}
+							{{ form_row(form_release.environmentTarget) }}
+							{{ form_row(form_release.execution_date) }}
+							{{ form_row(form_release.environmentSource) }}
+						</div>
 					</div>
 				</div>
 				<div class="box-footer">


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

- Using environmentPickerType: this way we only show environments that can be used inside a release. If a environment (default) has a publish role `not defined`, it means nobody can be publish or unpublished from this environment.
- Target environment field under name field
- Update labels for target & source environment.
- Use ems-core-intl-icu domain and remove old keys form deprecate EMSCoreBundle domain
