### PR TITLE
fix(admin/release): layout issue, update labels and filter environments (default)

### DIFF
--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/release/form.html.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/release/form.html.twig
@@ -9,7 +9,7 @@
 			{{ form_start(form_release) }}
 				<div class="box-body">
 					<div class="row">
-						<div class="col-md-2">
+						<div class="col-md-6 col-lg-4">
 							{{ form_row(form_release.name) }}
 							{{ form_row(form_release.environmentTarget) }}
 							{{ form_row(form_release.execution_date) }}

--- a/EMS/core-bundle/src/Form/Form/ReleaseType.php
+++ b/EMS/core-bundle/src/Form/Form/ReleaseType.php
@@ -34,6 +34,7 @@ final class ReleaseType extends AbstractType
             ])
             ->add('environmentTarget', EnvironmentPickerType::class, [
                 'userPublishEnvironments' => true,
+                'defaultEnvironment' => false,
                 'managedOnly' => true,
                 'label' => t('field.release_environment_target', [], 'emsco-core'),
             ])
@@ -51,6 +52,7 @@ final class ReleaseType extends AbstractType
             ])
             ->add('environmentSource', EnvironmentPickerType::class, [
                 'userPublishEnvironments' => true,
+                'defaultEnvironment' => true,
                 'managedOnly' => true,
                 'label' => t('field.release_environment_source', [], 'emsco-core'),
             ])

--- a/EMS/core-bundle/src/Repository/EnvironmentRepository.php
+++ b/EMS/core-bundle/src/Repository/EnvironmentRepository.php
@@ -170,6 +170,19 @@ class EnvironmentRepository extends EntityRepository
         return new ArrayCollection($qb->getQuery()->getResult());
     }
 
+    /**
+     * @return ArrayCollection<int, int>
+     */
+    public function findDefaultEnvironmentIds(): ArrayCollection
+    {
+        $qb = $this->createQueryBuilder('e');
+        $qb
+            ->select('DISTINCT e.id')
+            ->join('e.contentTypesHavingThisAsDefault', 'c');
+
+        return new ArrayCollection($qb->getQuery()->getSingleColumnResult());
+    }
+
     public function save(Environment $environment): void
     {
         $this->_em->persist($environment);

--- a/EMS/core-bundle/src/Resources/translations/emsco-core+intl-icu.en.yml
+++ b/EMS/core-bundle/src/Resources/translations/emsco-core+intl-icu.en.yml
@@ -117,8 +117,8 @@ field:
     name: Name
     plural: Plural
     public_access: 'Public Access'
-    release_environment_source: 'Source environment for publication'
-    release_environment_target: 'Environment for publication or unpublish'
+    release_environment_source: 'Source Environment for publication'
+    release_environment_target: 'Environment for (un)publication'
     severity: Severity
     singular: Singular
     status: Status

--- a/EMS/core-bundle/src/Resources/views/release/form.html.twig
+++ b/EMS/core-bundle/src/Resources/views/release/form.html.twig
@@ -9,7 +9,7 @@
 			{{ form_start(form_release) }}
 				<div class="box-body">
 					<div class="row">
-						<div class="col-md-2">
+						<div class="col-md-6 col-lg-4">
 							{{ form_row(form_release.name) }}
 							{{ form_row(form_release.environmentTarget) }}
 							{{ form_row(form_release.execution_date) }}

--- a/EMS/core-bundle/src/Service/EnvironmentService.php
+++ b/EMS/core-bundle/src/Service/EnvironmentService.php
@@ -139,6 +139,14 @@ class EnvironmentService implements EntityServiceInterface
     }
 
     /**
+     * @return ArrayCollection<int, int>
+     */
+    public function getDefaultEnvironmentIds(): ArrayCollection
+    {
+        return $this->environmentRepository->findDefaultEnvironmentIds();
+    }
+
+    /**
      * @deprecated  https://github.com/ems-project/EMSCoreBundle/issues/281
      *
      * @return array<string, Environment>
@@ -279,9 +287,7 @@ class EnvironmentService implements EntityServiceInterface
             });
         }
 
-        $userPublishEnvironments = new ArrayCollection($circleEnvironments);
-
-        return $userPublishEnvironments->filter(function (Environment $e) {
+        return (new ArrayCollection($circleEnvironments))->filter(function (Environment $e) {
             $role = $e->getRolePublish();
 
             return null === $role || $this->authorizationChecker->isGranted($role);


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Source environment: only show environments that are used has default environments
Target environment: only show environment that are not used as default environments

But in both cases if the result is empty we display all environments. For example a content type with a default environment live. Means we can not filter target or source environment because 'preview' and 'live' can be source or target.
