### PR TITLE
fix(admin/media-lib): fix invalid documents

### DIFF
--- a/EMS/core-bundle/src/Core/Component/MediaLibrary/MediaLibraryService.php
+++ b/EMS/core-bundle/src/Core/Component/MediaLibrary/MediaLibraryService.php
@@ -140,7 +140,13 @@ class MediaLibraryService
     public function getFolders(): MediaLibraryFolders
     {
         $query = $this->elasticaService->getBoolQuery();
-        $query->addMustNot((new NestedQuery())->setPath($this->getConfig()->fieldFile)->setQuery(new Exists($this->getConfig()->fieldFile)));
+        $query->addMustNot(
+            (new NestedQuery())
+                ->setPath($this->getConfig()->fieldFile)
+                ->setQuery(new Exists($this->getConfig()->fieldFile))
+        );
+        $query->addMust(new Exists($this->getConfig()->fieldPath));
+        $query->addMust(new Exists($this->getConfig()->fieldFolder));
 
         $folders = new MediaLibraryFolders($this->getConfig());
         $scroll = $this->elasticaService->scroll($this->buildSearch($query));

--- a/demo/skeleton/template_ems/view/overview_media_library.twig
+++ b/demo/skeleton/template_ems/view/overview_media_library.twig
@@ -5,7 +5,7 @@
 
     {% set columns = [
         { "label": "Path", "template": (block('columnMediaPath')),  "orderField": "media_path"},
-        { "label": "Folder", "template": "{{ data.source.media_folder }}",  "orderField": "media_folder"},
+        { "label": "Folder", "template": "{{ data.source.media_folder|default('???') }}",  "orderField": "media_folder"},
         { "label": "Last Update", "template": (block('columnLastUpdate')), "orderField": "_finalization_datetime"},
     ] %}
 
@@ -104,7 +104,7 @@
 
 {% block columnMediaPath %}
 {% verbatim %}
-<a href="{{ path('data.revisions', {ouuid: data.id, type: data.contentType} ) }}">{{ data.source.media_path }}</a>
+<a href="{{ path('data.revisions', {ouuid: data.id, type: data.contentType} ) }}">{{ data.source.media_path|default('???') }}</a>
 {% endverbatim %}
 {% endblock %}
 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? |  n |

If for some reason their is a invalid media lib document created (without a folder or path): 
- media library folders not showing (ajax 500 error).
- datatable overview in demo also not working.
