### PR TITLE
fix(admin/environment): picker default name value

### DIFF
--- a/EMS/core-bundle/src/Form/Form/ReleaseType.php
+++ b/EMS/core-bundle/src/Form/Form/ReleaseType.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EMS\CoreBundle\Form\Form;
 
+use EMS\CoreBundle\Entity\Environment;
 use EMS\CoreBundle\Entity\Release;
 use EMS\CoreBundle\Form\Field\EnvironmentPickerType;
 use EMS\CoreBundle\Form\Field\SubmitEmsType;
@@ -37,6 +38,7 @@ final class ReleaseType extends AbstractType
                 'defaultEnvironment' => false,
                 'managedOnly' => true,
                 'label' => t('field.release_environment_target', [], 'emsco-core'),
+                'choice_callback' => fn (Environment $environment) => $environment,
             ])
             ->add('execution_date', DateTimeType::class, [
                 'required' => false,
@@ -55,6 +57,7 @@ final class ReleaseType extends AbstractType
                 'defaultEnvironment' => true,
                 'managedOnly' => true,
                 'label' => t('field.release_environment_source', [], 'emsco-core'),
+                'choice_callback' => fn (Environment $environment) => $environment,
             ])
         ;
 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   |  n |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | #1015  |
| Documentation? | n  |

Broken in https://github.com/ems-project/elasticms/pull/1001/files#diff-f5be6b0768804b00eb0fb6fc0b946d7fcd256b271d51bb1965c7a4d011a193c9L42 -> version 5.21

On release creation/update we want the environmentPickerType to return the entity values. On contentType defninitions we just want the 'name' value of an environment. 


