### PR TITLE
feat(admin/tasks): rename task manager to task admin

### DIFF
--- a/EMS/core-bundle/src/Command/Revision/Task/TaskNotificationMailCommand.php
+++ b/EMS/core-bundle/src/Command/Revision/Task/TaskNotificationMailCommand.php
@@ -42,7 +42,7 @@ final class TaskNotificationMailCommand extends AbstractCommand
             ->addOption(self::OPTION_SUBJECT, null, InputOption::VALUE_REQUIRED, 'Set mail subject', 'notification tasks')
             ->addOption(self::OPTION_DEADLINE_START, null, InputOption::VALUE_REQUIRED, 'Start deadline from now "-1 days"')
             ->addOption(self::OPTION_DEADLINE_END, null, InputOption::VALUE_REQUIRED, 'End deadline from now "+1 days"')
-            ->addOption(self::OPTION_INCLUDE_TASK_MANAGERS, null, InputOption::VALUE_NONE, 'Include task managers')
+            ->addOption(self::OPTION_INCLUDE_TASK_MANAGERS, null, InputOption::VALUE_NONE, 'Include task admins/managers')
             ->addOption(self::OPTION_LIMIT, null, InputOption::VALUE_REQUIRED, 'limit the results inside mail', 10)
         ;
     }

--- a/EMS/core-bundle/src/Core/Revision/Task/TaskMailer.php
+++ b/EMS/core-bundle/src/Core/Revision/Task/TaskMailer.php
@@ -118,7 +118,7 @@ class TaskMailer
         return match (true) {
             ($sender->getUsername() === $task->getAssignee()) => 'assignee',
             ($sender->getUsername() === $task->getCreatedBy()) => 'creator',
-            $this->taskManager->isTaskManager($sender) => 'task manager',
+            $this->taskManager->isTaskManager($sender) => 'task admin',
             default => null,
         };
     }

--- a/EMS/core-bundle/src/Resources/translations/EMSCoreBundle.en.yml
+++ b/EMS/core-bundle/src/Resources/translations/EMSCoreBundle.en.yml
@@ -394,7 +394,7 @@ ROLE_SUPER_AUTHOR: 'Super Author'
 ROLE_SUPER_PUBLISHER: 'Super Publisher'
 ROLE_SUPER_USER: 'Super User'
 ROLE_SUPER_WEBMASTER: 'Super Webmaster'
-ROLE_TASK_MANAGER: 'Task Manager'
+ROLE_TASK_MANAGER: 'Task admin'
 ROLE_TRADUCTOR: Traductor
 ROLE_COPYWRITER: Copywriter
 ROLE_AUDITOR: Auditor

--- a/EMS/core-bundle/src/Resources/translations/emsco-forms.en.yml
+++ b/EMS/core-bundle/src/Resources/translations/emsco-forms.en.yml
@@ -101,7 +101,7 @@ ROLE_SUPER_AUTHOR: 'Super Author'
 ROLE_SUPER_PUBLISHER: 'Super Publisher'
 ROLE_SUPER_USER: 'Super User'
 ROLE_SUPER_WEBMASTER: 'Super Webmaster'
-ROLE_TASK_MANAGER: 'Task Manager'
+ROLE_TASK_MANAGER: 'Task admin'
 ROLE_COPYWRITER: Copywriter
 ROLE_TRADUCTOR: Traductor
 ROLE_USER: User

--- a/docs/elasticms-admin/commands/commands.md
+++ b/docs/elasticms-admin/commands/commands.md
@@ -327,7 +327,7 @@ Options:
       --subject=SUBJECT                Set mail subject [default: "notification tasks"]
       --deadline-start=DEADLINE-START  Start deadline from now "-1 days"
       --deadline-end=DEADLINE-END      End deadline from now "+1 days"
-      --include-task-managers          Include task managers
+      --include-task-managers          Include task admins/managers
       --limit=LIMIT                    limit the results inside mail [default: 10]
 ```
 

--- a/docs/elasticms-admin/contentType/contentType.md
+++ b/docs/elasticms-admin/contentType/contentType.md
@@ -116,13 +116,13 @@ When tasks are enabled, every user can create, handle, validate tasks inside a r
 
 If a user completes a task, he can **only** validate the task if he is the requester.
 
-Only the requester and task managers can delete the tasks
+Only the requester and task admins can delete the tasks
 
 On all tasks steps the assignee and/or requester will receive **emails**.
 
 Users who have the role `TASK_MANAGER` can see all current tasks in their dashboard overview.
 
-Task manager can also delete tasks, but the requester will receive an email.
+Task admins can also delete tasks, but the requester will receive an email.
 
 ## Roles
 

--- a/docs/elasticms-web/security.md
+++ b/docs/elasticms-web/security.md
@@ -69,7 +69,7 @@ On submit the application will preform a coreApi login to the environment api.
      <li>{{ app.user.displayName }}</li>
      <li>{{ app.user.circles|join(' | ') }}</li>
      <li>{{ app.user.roles|join(' | ') }}</li>
-     {% if is_granted('ROLE_TASK_MANAGER') %}<li>Task manager</li>{% endif %}
+     {% if is_granted('ROLE_TASK_MANAGER') %}<li>Task admin</li>{% endif %}
    </ul>
    <a href="{{ path("emsch_logout") }}">Logout</a>
 {% endif %}


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | n  |
| New feature?   | y  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Rename the label `Task manager` to `Task admin`.
For not creating BC breaks the `ROLE_TASK_MANAGER` is not changing to ROLE_TASK_ADMIN.
