### PR TITLE
fix(admin/datatable): revert remove table-responsive

### DIFF
--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/datatable/dom.html.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/datatable/dom.html.twig
@@ -1,50 +1,51 @@
 {%- use '@EMSAdminUI/bootstrap5/form/forms.html.twig' -%}
 {% trans_default_domain 'EMSCoreBundle' %}
 
-<table id="{{ datatable.id }}" class="table table-condensed table-striped" data-datatable="{{ datatable.frontendOptions|json_encode|e('html_attr') }}">
-    <thead>
-    <tr role="row">
-        {% if datatable.supportsTableActions %}
-            <th class="fit" data-orderable="false" data-name="_checkbox">
-                <input type="checkbox" value="" data-grouped-checkbox-target=".{{ (datatable.id ~ '-select')|e('html_attr') }}-to-select">
-            </th>
-        {% endif %}
-        {% for column in datatable.columns %}
-            <th class="nowrap" data-orderable="{{ column.orderable ? 'true' : 'false' }}" data-name="{{  column.attribute }}">
-                {% if column.iconClass %}
-                    <i class="{{ column.iconClass }}" aria-hidden="true" title="{{ column.titleKey|trans|e('html_attr') }}"></i>
-                    <span class="sr-only">{{ column.titleKey|trans }}</span>
-                {% else %}
-                    {{ column.titleKey|trans }}
-                {% endif %}
-            </th>
-        {% endfor %}
-        {% if datatable.itemActions|length > 0 %}
-            <th class="nowrap" data-orderable="false">{{ 'key.actions'|trans({}, 'emsco-core') }}</th>
-        {% endif %}
-    </tr>
-    </thead>
-    <tbody>
-    {% for line in datatable %}
-        <tr>
+<div class="table-responsive">
+    <table id="{{ datatable.id }}" class="table table-condensed table-striped" data-datatable="{{ datatable.frontendOptions|json_encode|e('html_attr') }}">
+        <thead>
+        <tr role="row">
             {% if datatable.supportsTableActions %}
-                <td class="{{ datatable.attributeName|e('html_attr') }}-to-select">
-                    {{ block('emsco_form_table_column_action_checkbox') }}
-                </td>
+                <th class="fit" data-orderable="false" data-name="_checkbox">
+                    <input type="checkbox" value="" data-grouped-checkbox-target=".{{ (datatable.id ~ '-select')|e('html_attr') }}-to-select">
+                </th>
             {% endif %}
             {% for column in datatable.columns %}
-                {{ block(column.tableDataBlock()) }}
+                <th class="nowrap" data-orderable="{{ column.orderable ? 'true' : 'false' }}" data-name="{{  column.attribute }}">
+                    {% if column.iconClass %}
+                        <i class="{{ column.iconClass }}" aria-hidden="true" title="{{ column.titleKey|trans|e('html_attr') }}"></i>
+                        <span class="sr-only">{{ column.titleKey|trans }}</span>
+                    {% else %}
+                        {{ column.titleKey|trans }}
+                    {% endif %}
+                </th>
             {% endfor %}
             {% if datatable.itemActions|length > 0 %}
-                <td data-search="">
-                    {{ block('emsco_form_table_column_row_actions') }}
-                </td>
+                <th class="nowrap" data-orderable="false">{{ 'key.actions'|trans({}, 'emsco-core') }}</th>
             {% endif %}
         </tr>
-    {%  endfor %}
-    </tbody>
-</table>
-
+        </thead>
+        <tbody>
+        {% for line in datatable %}
+            <tr>
+                {% if datatable.supportsTableActions %}
+                    <td class="{{ datatable.attributeName|e('html_attr') }}-to-select">
+                        {{ block('emsco_form_table_column_action_checkbox') }}
+                    </td>
+                {% endif %}
+                {% for column in datatable.columns %}
+                    {{ block(column.tableDataBlock()) }}
+                {% endfor %}
+                {% if datatable.itemActions|length > 0 %}
+                    <td data-search="">
+                        {{ block('emsco_form_table_column_row_actions') }}
+                    </td>
+                {% endif %}
+            </tr>
+        {%  endfor %}
+        </tbody>
+    </table>
+</div>
 {% if datatable.supportsTableActions and datatable.tableMassActions|length > 0%}
     <div class="btn-group">
         {% for action in datatable.tableMassActions %}

--- a/EMS/core-bundle/src/Resources/views/datatable/dom.html.twig
+++ b/EMS/core-bundle/src/Resources/views/datatable/dom.html.twig
@@ -1,49 +1,51 @@
 {%- use '@EMSCore/form/forms.html.twig' -%}
 {% trans_default_domain 'EMSCoreBundle' %}
 
-<table id="{{ datatable.id }}" class="table table-condensed table-striped" data-datatable="{{ datatable.frontendOptions|json_encode|e('html_attr') }}">
-    <thead>
-    <tr role="row">
-        {% if datatable.supportsTableActions %}
-            <th class="fit" data-orderable="false" data-name="_checkbox">
-                <input type="checkbox" value="" data-grouped-checkbox-target=".{{ (datatable.id ~ '-select')|e('html_attr') }}-to-select">
-            </th>
-        {% endif %}
-        {% for column in datatable.columns %}
-            <th class="nowrap" data-orderable="{{ column.orderable ? 'true' : 'false' }}" data-name="{{  column.attribute }}">
-                {% if column.iconClass %}
-                    <i class="{{ column.iconClass }}" aria-hidden="true" title="{{ column.titleKey|trans|e('html_attr') }}"></i>
-                    <span class="sr-only">{{ column.titleKey|trans }}</span>
-                {% else %}
-                    {{ column.titleKey|trans }}
-                {% endif %}
-            </th>
-        {% endfor %}
-        {% if datatable.itemActions|length > 0 %}
-            <th class="nowrap" data-orderable="false">{{ 'key.actions'|trans({}, 'emsco-core') }}</th>
-        {% endif %}
-    </tr>
-    </thead>
-    <tbody>
-    {% for line in datatable %}
-        <tr>
+<div class="table-responsive">
+    <table id="{{ datatable.id }}" class="table table-condensed table-striped" data-datatable="{{ datatable.frontendOptions|json_encode|e('html_attr') }}">
+        <thead>
+        <tr role="row">
             {% if datatable.supportsTableActions %}
-                <td class="{{ datatable.attributeName|e('html_attr') }}-to-select">
-                    {{ block('emsco_form_table_column_action_checkbox') }}
-                </td>
+                <th class="fit" data-orderable="false" data-name="_checkbox">
+                    <input type="checkbox" value="" data-grouped-checkbox-target=".{{ (datatable.id ~ '-select')|e('html_attr') }}-to-select">
+                </th>
             {% endif %}
             {% for column in datatable.columns %}
-                {{ block(column.tableDataBlock()) }}
+                <th class="nowrap" data-orderable="{{ column.orderable ? 'true' : 'false' }}" data-name="{{  column.attribute }}">
+                    {% if column.iconClass %}
+                        <i class="{{ column.iconClass }}" aria-hidden="true" title="{{ column.titleKey|trans|e('html_attr') }}"></i>
+                        <span class="sr-only">{{ column.titleKey|trans }}</span>
+                    {% else %}
+                        {{ column.titleKey|trans }}
+                    {% endif %}
+                </th>
             {% endfor %}
             {% if datatable.itemActions|length > 0 %}
-                <td data-search="">
-                    {{ block('emsco_form_table_column_row_actions') }}
-                </td>
+                <th class="nowrap" data-orderable="false">{{ 'key.actions'|trans({}, 'emsco-core') }}</th>
             {% endif %}
         </tr>
-    {%  endfor %}
-    </tbody>
-</table>
+        </thead>
+        <tbody>
+        {% for line in datatable %}
+            <tr>
+                {% if datatable.supportsTableActions %}
+                    <td class="{{ datatable.attributeName|e('html_attr') }}-to-select">
+                        {{ block('emsco_form_table_column_action_checkbox') }}
+                    </td>
+                {% endif %}
+                {% for column in datatable.columns %}
+                    {{ block(column.tableDataBlock()) }}
+                {% endfor %}
+                {% if datatable.itemActions|length > 0 %}
+                    <td data-search="">
+                        {{ block('emsco_form_table_column_row_actions') }}
+                    </td>
+                {% endif %}
+            </tr>
+        {%  endfor %}
+        </tbody>
+    </table>
+</div>
 
 {% if datatable.supportsTableActions and datatable.tableMassActions|length > 0%}
     <div class="btn-group">


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

In previous pr #1000  the div.table-responsive was removed. This creates a breaking change on smaller windows
