### PR TITLE
feat(admin/wysiwyg): add data attributes in iframe preview

### DIFF
--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/macros/data-field-type.html.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/macros/data-field-type.html.twig
@@ -732,7 +732,9 @@
                     {% set displayOptions = dataField.fieldType.displayOptions %}
                     {% set iframeUrl = path('emsco_wysiwyg_styleset_iframe', {
                         'name': displayOptions.styles_set|default('default'),
-                        'language': displayOptions.language|default('en'),
+                        'language': dataField.formOptions.locale|default('en'),
+                        'emsLink': dataField.formOptions.referredEmsId|default(null),
+                        'field': dataField.fieldType.name
                     }) %}
                     <iframe src="{{ iframeUrl }}" class="styleset-preview panel-body" data-iframe-body="{{ panelBody|e('html_attr') }}"></iframe>
                 {% else %}

--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/macros/data-field-type.html.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/macros/data-field-type.html.twig
@@ -734,7 +734,8 @@
                         'name': displayOptions.styles_set|default('default'),
                         'language': dataField.formOptions.locale|default('en'),
                         'emsLink': dataField.formOptions.referredEmsId|default(null),
-                        'field': dataField.fieldType.name
+                        'field': dataField.fieldType.name,
+                        'fieldPath': dataField.fieldType.path
                     }) %}
                     <iframe src="{{ iframeUrl }}" class="styleset-preview panel-body" data-iframe-body="{{ panelBody|e('html_attr') }}"></iframe>
                 {% else %}

--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/wysiwyg_styles_set/iframe.html.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/wysiwyg_styles_set/iframe.html.twig
@@ -15,6 +15,7 @@
 </head>
 <body class="wysiwyg-preview"
       data-field="{{ field }}"
+      data-field-path="{{ fieldPath|e('html_attr') }}"
       {% if emsLink %}data-document-url="{{ path('emsco_interface_document_get', { interface: 'json', name: emsLink.contentType, ouuid: emsLink.ouuid }) }}"{% endif %} >
 {% if null != styleSet.contentJs %}
     <script src="{{ asset(styleSet.contentJs, styleSet.saveDir == null ? 'emsch' : null) }}"></script>

--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/wysiwyg_styles_set/iframe.html.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/wysiwyg_styles_set/iframe.html.twig
@@ -13,7 +13,9 @@
         {% endif %}
     {% endapply %}
 </head>
-<body class="wysiwyg-preview">
+<body class="wysiwyg-preview"
+      data-field="{{ field }}"
+      {% if emsLink %}data-document-url="{{ path('emsco_interface_document_get', { interface: 'json', name: emsLink.contentType, ouuid: emsLink.ouuid }) }}"{% endif %} >
 {% if null != styleSet.contentJs %}
     <script src="{{ asset(styleSet.contentJs, styleSet.saveDir == null ? 'emsch' : null) }}"></script>
 {% endif %}

--- a/EMS/core-bundle/src/Controller/Wysiwyg/StylesetController.php
+++ b/EMS/core-bundle/src/Controller/Wysiwyg/StylesetController.php
@@ -4,23 +4,29 @@ declare(strict_types=1);
 
 namespace EMS\CoreBundle\Controller\Wysiwyg;
 
+use EMS\CommonBundle\Common\EMSLink;
 use EMS\CoreBundle\Service\WysiwygStylesSetService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class StylesetController extends AbstractController
 {
-    public function __construct(private readonly WysiwygStylesSetService $wysiwygStylesSetService, private readonly string $templateNamespace)
-    {
+    public function __construct(
+        private readonly WysiwygStylesSetService $wysiwygStylesSetService,
+        private readonly string $templateNamespace
+    ) {
     }
 
-    public function iframe(string $name, string $language): Response
+    public function iframe(Request $request, string $name, string $language): Response
     {
-        $splitLanguage = \explode('_', $language);
+        $emsLink = $request->get('emsLink');
 
         return $this->render("@$this->templateNamespace/wysiwyg_styles_set/iframe.html.twig", [
             'styleSet' => $this->wysiwygStylesSetService->getByName($name),
-            'language' => \array_shift($splitLanguage),
+            'language' => $language,
+            'field' => $request->get('field'),
+            'emsLink' => $emsLink ? EMSLink::fromText($emsLink) : null,
         ]);
     }
 }

--- a/EMS/core-bundle/src/Controller/Wysiwyg/StylesetController.php
+++ b/EMS/core-bundle/src/Controller/Wysiwyg/StylesetController.php
@@ -26,6 +26,7 @@ class StylesetController extends AbstractController
             'styleSet' => $this->wysiwygStylesSetService->getByName($name),
             'language' => $language,
             'field' => $request->get('field'),
+            'fieldPath' => $request->get('fieldPath'),
             'emsLink' => $emsLink ? EMSLink::fromText($emsLink) : null,
         ]);
     }

--- a/EMS/core-bundle/src/Core/ContentType/DataFieldFormOptions.php
+++ b/EMS/core-bundle/src/Core/ContentType/DataFieldFormOptions.php
@@ -7,7 +7,7 @@ namespace EMS\CoreBundle\Core\ContentType;
 class DataFieldFormOptions
 {
     public function __construct(
-        public readonly string $locale,
+        public readonly ?string $locale = 'en',
         public readonly ?string $referredEmsId = null,
     ) {
     }

--- a/EMS/core-bundle/src/Core/ContentType/DataFieldFormOptions.php
+++ b/EMS/core-bundle/src/Core/ContentType/DataFieldFormOptions.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\Core\ContentType;
+
+class DataFieldFormOptions
+{
+    public function __construct(
+        public readonly string $locale,
+        public readonly ?string $referredEmsId = null,
+    ) {
+    }
+}

--- a/EMS/core-bundle/src/Entity/DataField.php
+++ b/EMS/core-bundle/src/Entity/DataField.php
@@ -4,6 +4,7 @@ namespace EMS\CoreBundle\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use EMS\CoreBundle\Core\ContentType\DataFieldFormOptions;
 use EMS\CoreBundle\Exception\DataFormatException;
 use EMS\CoreBundle\Form\DataField\CollectionFieldType;
 use EMS\CoreBundle\Form\DataField\OuuidFieldType;
@@ -43,6 +44,8 @@ class DataField implements \ArrayAccess, \IteratorAggregate, \Stringable
     private array $messages = [];
 
     private bool $marked = false;
+
+    private ?DataFieldFormOptions $formOptions = null;
 
     public function setChildrenFieldType(FieldType $fieldType): void
     {
@@ -586,10 +589,7 @@ class DataField implements \ArrayAccess, \IteratorAggregate, \Stringable
         return $this->orderKey;
     }
 
-    /**
-     * @return DataField
-     */
-    public function setFieldType(FieldType $fieldType = null)
+    public function setFieldType(FieldType $fieldType = null): self
     {
         $this->fieldType = $fieldType;
 
@@ -672,10 +672,8 @@ class DataField implements \ArrayAccess, \IteratorAggregate, \Stringable
      * Set rawData.
      *
      * @param array<mixed>|string|int|float|bool|null $rawData
-     *
-     * @return DataField
      */
-    public function setRawData($rawData)
+    public function setRawData($rawData): self
     {
         $this->rawData = $rawData;
 
@@ -710,5 +708,15 @@ class DataField implements \ArrayAccess, \IteratorAggregate, \Stringable
     public function getInputValue()
     {
         return $this->inputValue;
+    }
+
+    public function getFormOptions(): ?DataFieldFormOptions
+    {
+        return $this->formOptions;
+    }
+
+    public function setFormOptions(?DataFieldFormOptions $formOptions): void
+    {
+        $this->formOptions = $formOptions;
     }
 }

--- a/EMS/core-bundle/src/Entity/User.php
+++ b/EMS/core-bundle/src/Entity/User.php
@@ -9,6 +9,7 @@ use EMS\CommonBundle\Entity\CreatedModifiedTrait;
 use EMS\CoreBundle\Core\User\UserOptions;
 use EMS\CoreBundle\Roles;
 use EMS\Helpers\Standard\DateTime;
+use EMS\Helpers\Standard\Locale;
 use EMS\Helpers\Standard\Type;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 
@@ -185,9 +186,7 @@ class User implements UserInterface, EntityInterface, PasswordAuthenticatedUserI
     public function getLanguage(): string
     {
         if ($this->localePreferred) {
-            $preferredLanguage = \strstr($this->localePreferred, '_', true);
-
-            return $preferredLanguage ?: self::DEFAULT_LOCALE;
+            return Locale::short($this->localePreferred, self::DEFAULT_LOCALE);
         }
 
         return $this->getLocale();

--- a/EMS/core-bundle/src/Entity/User.php
+++ b/EMS/core-bundle/src/Entity/User.php
@@ -186,7 +186,7 @@ class User implements UserInterface, EntityInterface, PasswordAuthenticatedUserI
     public function getLanguage(): string
     {
         if ($this->localePreferred) {
-            return Locale::short($this->localePreferred, self::DEFAULT_LOCALE);
+            return Locale::getLanguage($this->localePreferred, self::DEFAULT_LOCALE);
         }
 
         return $this->getLocale();

--- a/EMS/core-bundle/src/Form/DataField/ContainerFieldType.php
+++ b/EMS/core-bundle/src/Form/DataField/ContainerFieldType.php
@@ -7,9 +7,11 @@ namespace EMS\CoreBundle\Form\DataField;
 use EMS\CoreBundle\Entity\DataField;
 use EMS\CoreBundle\Entity\FieldType;
 use EMS\CoreBundle\Form\Field\IconPickerType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\Intl\Locales;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ContainerFieldType extends DataFieldType
@@ -79,6 +81,7 @@ class ContainerFieldType extends DataFieldType
     {
         parent::configureOptions($resolver);
         $resolver->setDefault('icon', null);
+        $resolver->setDefault('language', null);
     }
 
     /**
@@ -107,9 +110,14 @@ class ContainerFieldType extends DataFieldType
         $optionsForm->remove('migrationOptions');
         $optionsForm->get('restrictionOptions')->remove('mandatory');
         $optionsForm->get('restrictionOptions')->remove('mandatory_if');
-        $optionsForm->get('displayOptions')->add('icon', IconPickerType::class, [
+        $optionsForm->get('displayOptions')
+            ->add('icon', IconPickerType::class, ['required' => false])
+            ->add('language', ChoiceType::class, [
                 'required' => false,
-        ]);
+                'choices' => \array_flip(Locales::getNames()),
+                'choice_translation_domain' => false,
+            ])
+        ;
     }
 
     /**

--- a/EMS/core-bundle/src/Form/DataField/WysiwygFieldType.php
+++ b/EMS/core-bundle/src/Form/DataField/WysiwygFieldType.php
@@ -11,6 +11,7 @@ use EMS\CoreBundle\Form\Field\WysiwygStylesSetPickerType;
 use EMS\CoreBundle\Routes;
 use EMS\CoreBundle\Service\ElasticsearchService;
 use EMS\CoreBundle\Service\WysiwygStylesSetService;
+use EMS\Helpers\Standard\Locale;
 use EMS\Helpers\Standard\Type;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -83,8 +84,7 @@ class WysiwygFieldType extends DataFieldType
         }
 
         if (isset($options['language'])) {
-            $splitLanguage = \explode('_', \strval($options['language']));
-            $attr['data-lang'] = \array_shift($splitLanguage);
+            $attr['data-lang'] = Locale::short($options['language']);
         }
 
         $attr['data-referrer-ems-id'] = $options['referrer-ems-id'] ?? false;

--- a/EMS/core-bundle/src/Form/DataField/WysiwygFieldType.php
+++ b/EMS/core-bundle/src/Form/DataField/WysiwygFieldType.php
@@ -84,7 +84,7 @@ class WysiwygFieldType extends DataFieldType
         }
 
         if (isset($options['language'])) {
-            $attr['data-lang'] = Locale::short($options['language']);
+            $attr['data-lang'] = Locale::getLanguage($options['language']);
         }
 
         $attr['data-referrer-ems-id'] = $options['referrer-ems-id'] ?? false;

--- a/EMS/core-bundle/src/Form/DataTransformer/DataFieldModelTransformer.php
+++ b/EMS/core-bundle/src/Form/DataTransformer/DataFieldModelTransformer.php
@@ -2,6 +2,7 @@
 
 namespace EMS\CoreBundle\Form\DataTransformer;
 
+use EMS\CoreBundle\Core\ContentType\DataFieldFormOptions;
 use EMS\CoreBundle\Entity\DataField;
 use EMS\CoreBundle\Entity\FieldType;
 use EMS\CoreBundle\Form\DataField\DataFieldType;
@@ -13,8 +14,18 @@ use Symfony\Component\Form\FormRegistryInterface;
  */
 class DataFieldModelTransformer implements DataTransformerInterface
 {
+    private ?DataFieldFormOptions $formOptions = null;
+
     public function __construct(private readonly FieldType $fieldType, private readonly FormRegistryInterface $formRegistry)
     {
+    }
+
+    public static function withFormOptions(FieldType $fieldType, FormRegistryInterface $formRegistry, DataFieldFormOptions $viewOptions): self
+    {
+        $transformer = new self($fieldType, $formRegistry);
+        $transformer->formOptions = $viewOptions;
+
+        return $transformer;
     }
 
     /**
@@ -26,6 +37,7 @@ class DataFieldModelTransformer implements DataTransformerInterface
     {
         /** @var DataFieldType $dataFieldType */
         $dataFieldType = $this->formRegistry->getType($this->fieldType->getType())->getInnerType();
+        $dataFieldType->setFormOptions($this->formOptions);
 
         return $dataFieldType->modelTransform($data, $this->fieldType);
     }
@@ -41,6 +53,7 @@ class DataFieldModelTransformer implements DataTransformerInterface
     {
         /** @var DataFieldType $dataFieldType */
         $dataFieldType = $this->formRegistry->getType($this->fieldType->getType())->getInnerType();
+        $dataFieldType->setFormOptions($this->formOptions);
 
         return $dataFieldType->reverseModelTransform($data);
     }

--- a/EMS/core-bundle/src/Form/Extension/LocaleFormExtension.php
+++ b/EMS/core-bundle/src/Form/Extension/LocaleFormExtension.php
@@ -21,7 +21,7 @@ class LocaleFormExtension extends AbstractTypeExtension
             ->setNormalizer('locale', function (Options $options, ?string $value) {
                 $language = $options['language'] ?? null;
 
-                return ($language) ? Locale::short($language) : $value;
+                return ($language) ? Locale::getLanguage($language) : $value;
             });
     }
 

--- a/EMS/core-bundle/src/Form/Extension/LocaleFormExtension.php
+++ b/EMS/core-bundle/src/Form/Extension/LocaleFormExtension.php
@@ -4,17 +4,25 @@ declare(strict_types=1);
 
 namespace EMS\CoreBundle\Form\Extension;
 
+use EMS\Helpers\Standard\Locale;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class LocaleFormExtension extends AbstractTypeExtension
 {
     public function configureOptions(OptionsResolver $resolver): void
     {
-        $resolver->setDefaults(['locale' => null]);
+        $resolver
+            ->setDefaults(['locale' => 'en'])
+            ->setNormalizer('locale', function (Options $options, ?string $value) {
+                $language = $options['language'] ?? null;
+
+                return ($language) ? Locale::short($language) : $value;
+            });
     }
 
     public function buildView(FormView $view, FormInterface $form, array $options): void

--- a/EMS/core-bundle/src/Resources/views/macros/data-field-type.html.twig
+++ b/EMS/core-bundle/src/Resources/views/macros/data-field-type.html.twig
@@ -734,7 +734,8 @@
 						'name': displayOptions.styles_set|default('default'),
 						'language': dataField.formOptions.locale|default('en'),
 						'emsLink': dataField.formOptions.referredEmsId|default(null),
-						'field': dataField.fieldType.name
+						'field': dataField.fieldType.name,
+						'fieldPath': dataField.fieldType.path
 					}) %}
 					<iframe src="{{ iframeUrl }}" class="styleset-preview panel-body" data-iframe-body="{{ panelBody|e('html_attr') }}"></iframe>
 				{% else %}

--- a/EMS/core-bundle/src/Resources/views/macros/data-field-type.html.twig
+++ b/EMS/core-bundle/src/Resources/views/macros/data-field-type.html.twig
@@ -732,7 +732,9 @@
 					{% set displayOptions = dataField.fieldType.displayOptions %}
 					{% set iframeUrl = path('emsco_wysiwyg_styleset_iframe', {
 						'name': displayOptions.styles_set|default('default'),
-						'language': displayOptions.language|default('en'),
+						'language': dataField.formOptions.locale|default('en'),
+						'emsLink': dataField.formOptions.referredEmsId|default(null),
+						'field': dataField.fieldType.name
 					}) %}
 					<iframe src="{{ iframeUrl }}" class="styleset-preview panel-body" data-iframe-body="{{ panelBody|e('html_attr') }}"></iframe>
 				{% else %}

--- a/EMS/core-bundle/src/Resources/views/wysiwyg_styles_set/iframe.html.twig
+++ b/EMS/core-bundle/src/Resources/views/wysiwyg_styles_set/iframe.html.twig
@@ -15,6 +15,7 @@
 </head>
 <body class="wysiwyg-preview"
       data-field="{{ field }}"
+      data-field-path="{{ fieldPath|e('html_attr') }}"
       {% if emsLink %}data-document-url="{{ path('emsco_interface_document_get', { interface: 'json', name: emsLink.contentType, ouuid: emsLink.ouuid }) }}"{% endif %} >
 {% if null != styleSet.contentJs %}
     <script src="{{ asset(styleSet.contentJs, styleSet.saveDir == null ? 'emsch' : null) }}"></script>

--- a/EMS/core-bundle/src/Resources/views/wysiwyg_styles_set/iframe.html.twig
+++ b/EMS/core-bundle/src/Resources/views/wysiwyg_styles_set/iframe.html.twig
@@ -15,7 +15,7 @@
 </head>
 <body class="wysiwyg-preview"
       data-field="{{ field }}"
-      {% if emsLink %}data-url="{{ path('emsco_interface_document_get', { interface: 'json', name: emsLink.contentType, ouuid: emsLink.ouuid }) }}"{% endif %} >
+      {% if emsLink %}data-document-url="{{ path('emsco_interface_document_get', { interface: 'json', name: emsLink.contentType, ouuid: emsLink.ouuid }) }}"{% endif %} >
 {% if null != styleSet.contentJs %}
     <script src="{{ asset(styleSet.contentJs, styleSet.saveDir == null ? 'emsch' : null) }}"></script>
 {% endif %}

--- a/EMS/core-bundle/src/Resources/views/wysiwyg_styles_set/iframe.html.twig
+++ b/EMS/core-bundle/src/Resources/views/wysiwyg_styles_set/iframe.html.twig
@@ -13,7 +13,9 @@
         {% endif %}
     {% endapply %}
 </head>
-<body class="wysiwyg-preview">
+<body class="wysiwyg-preview"
+      data-field="{{ field }}"
+      {% if emsLink %}data-url="{{ path('emsco_interface_document_get', { interface: 'json', name: emsLink.contentType, ouuid: emsLink.ouuid }) }}"{% endif %} >
 {% if null != styleSet.contentJs %}
     <script src="{{ asset(styleSet.contentJs, styleSet.saveDir == null ? 'emsch' : null) }}"></script>
 {% endif %}

--- a/EMS/helpers/src/Standard/Locale.php
+++ b/EMS/helpers/src/Standard/Locale.php
@@ -6,7 +6,7 @@ namespace EMS\Helpers\Standard;
 
 class Locale
 {
-    public static function short(?string $locale = null, ?string $default = 'en'): string
+    public static function getLanguage(?string $locale = null, ?string $default = 'en'): string
     {
         $default ??= 'en';
         $result = null !== $locale ? \strtolower($locale) : $default;

--- a/EMS/helpers/src/Standard/Locale.php
+++ b/EMS/helpers/src/Standard/Locale.php
@@ -14,6 +14,10 @@ class Locale
 
         $result = \array_shift($explode);
 
-        return 2 === \strlen($result) ? $result : $default;
+        if (2 !== \strlen($result)) {
+            throw new \RuntimeException(\sprintf('Invalid locale passed "%s"', $result));
+        }
+
+        return $result;
     }
 }

--- a/EMS/helpers/src/Standard/Locale.php
+++ b/EMS/helpers/src/Standard/Locale.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\Helpers\Standard;
+
+class Locale
+{
+    public static function short(?string $locale = null, ?string $default = 'en'): string
+    {
+        $default ??= 'en';
+        $result = null !== $locale ? \strtolower($locale) : $default;
+        $explode = \explode('_', $result);
+
+        $result = \array_shift($explode);
+
+        return 2 === \strlen($result) ? $result : $default;
+    }
+}

--- a/EMS/helpers/tests/Unit/Standard/LocaleTest.php
+++ b/EMS/helpers/tests/Unit/Standard/LocaleTest.php
@@ -15,6 +15,12 @@ class LocaleTest extends TestCase
     public function testShortLocale(?string $input, ?string $default, string $expected): void
     {
         $this->assertEquals($expected, Locale::short($input, $default));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Invalid locale passed "toto"');
+
+        Locale::short('toto', 'tada');
+        Locale::short(null, 'toto');
     }
 
     /**
@@ -28,7 +34,6 @@ class LocaleTest extends TestCase
             ['FR', 'en', 'fr'],
             ['nl_BE', null, 'nl'],
             ['FR_BE', null, 'fr'],
-            ['french', 'en', 'en'],
             [null, 'en', 'en'],
             [null, null, 'en'],
         ];

--- a/EMS/helpers/tests/Unit/Standard/LocaleTest.php
+++ b/EMS/helpers/tests/Unit/Standard/LocaleTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\Helpers\Tests\Unit\Standard;
+
+use EMS\Helpers\Standard\Locale;
+use PHPUnit\Framework\TestCase;
+
+class LocaleTest extends TestCase
+{
+    /**
+     * @dataProvider provideLocaleInput
+     */
+    public function testShortLocale(?string $input, ?string $default, string $expected): void
+    {
+        $this->assertEquals($expected, Locale::short($input, $default));
+    }
+
+    /**
+     * @return array<int, array<int, string|null>>
+     */
+    public function provideLocaleInput(): array
+    {
+        return [
+            ['fr', 'en', 'fr'],
+            ['fr', null, 'fr'],
+            ['FR', 'en', 'fr'],
+            ['nl_BE', null, 'nl'],
+            ['FR_BE', null, 'fr'],
+            ['french', 'en', 'en'],
+            [null, 'en', 'en'],
+            [null, null, 'en'],
+        ];
+    }
+}

--- a/EMS/helpers/tests/Unit/Standard/LocaleTest.php
+++ b/EMS/helpers/tests/Unit/Standard/LocaleTest.php
@@ -12,15 +12,15 @@ class LocaleTest extends TestCase
     /**
      * @dataProvider provideLocaleInput
      */
-    public function testShortLocale(?string $input, ?string $default, string $expected): void
+    public function testLanguage(?string $input, ?string $default, string $expected): void
     {
-        $this->assertEquals($expected, Locale::short($input, $default));
+        $this->assertEquals($expected, Locale::getLanguage($input, $default));
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Invalid locale passed "toto"');
 
-        Locale::short('toto', 'tada');
-        Locale::short(null, 'toto');
+        Locale::getLanguage('toto', 'tada');
+        Locale::getLanguage(null, 'toto');
     }
 
     /**

--- a/docs/elasticms-admin/wysiwyg/wysiwyg.md
+++ b/docs/elasticms-admin/wysiwyg/wysiwyg.md
@@ -93,7 +93,7 @@ Using the style on a **WysiwygFieldType** you can enable `Styles set preview`.
 It will load the CSS and JS files when using the WYSIWYG field.
 In revision detail the text content will be rendered inside an iframe including the CSS and JS files.
 
-Since version 5.22.0 the iframe body tag contains data attributes `field` and `document-url`.
+Since version 5.22.0 the iframe body tag contains data attributes `field`, `field-path`, and `document-url`.
 Needed if we want to enable javascript code based on other document fields.
 
 Example generate table of content in preview

--- a/docs/elasticms-admin/wysiwyg/wysiwyg.md
+++ b/docs/elasticms-admin/wysiwyg/wysiwyg.md
@@ -89,11 +89,40 @@ Can be used to overwrite CKEditor settings and user profiles.
 
 ### Styles set preview
 
-Using the style on a **WysiwygFieldType** you can enable `Styles set preview`. 
-
-It will load the CSS and JS files when using the WYSIWYG field. 
-
+Using the style on a **WysiwygFieldType** you can enable `Styles set preview`.
+It will load the CSS and JS files when using the WYSIWYG field.
 In revision detail the text content will be rendered inside an iframe including the CSS and JS files.
+
+Since version 5.22.0 the iframe body tag contains data attributes `field` and `document-url`.
+Needed if we want to enable javascript code based on other document fields.
+
+Example generate table of content in preview
+
+```javascript
+window.addEventListener("load", () => {
+  const lang = document.documentElement.lang
+  const { documentUrl: url, field } = document.body.dataset
+
+  if (!url || !lang || !['content_fr', 'content_nl'].includes(field)) return
+
+  async function getDocument(url) {
+    const response = await fetch(url)
+    return response.ok ? response.json() : null
+  }
+
+  getDocument(url).then((json) => {
+    const { success, revision } = json
+    if (!success || !revision) return
+
+    const generateToc = revision[`generate_toc_${lang}`]
+    if (!generateToc) return
+
+    createToc(document.body, options);
+    window.parent.postMessage("resize"); // resize the iframe because createToc() will inject new html tags 
+    
+  }).catch((error) => console.error('Error fetching document:', error));
+});
+```
 
 > **TIP** 
 > 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   |  y |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | y |

- Add a new Locale standard for calculating the short (2 digits) version of a locale
- Container field add display option 'language' (passed to all children like multiplex)
- Form option locale use language option if defined (language option can be passed by parent (container or multiplex)
- Add data-field and data-document-url on body tag inside iframe preview
- Add example of javascript in documentation
- Update the admin UI template

