### PR TITLE
fix(admin/revision): trash view only working for super user (sorting)

### DIFF
--- a/EMS/core-bundle/src/DataTable/Type/Revision/RevisionTrashDataTableType.php
+++ b/EMS/core-bundle/src/DataTable/Type/Revision/RevisionTrashDataTableType.php
@@ -45,7 +45,6 @@ class RevisionTrashDataTableType extends AbstractTableType implements QueryServi
         $table
             ->setIdField('ouuid')
             ->setLabelAttribute('label')
-            ->setExtraFrontendOption(['order' => [$this->userService->isSuper() ? 3 : 4, 'desc']])
             ->setDefaultOrder('modified', 'desc');
 
         $table->addColumn(t('field.label', [], 'emsco-core'), 'label');


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | #1030   |
| Documentation? |  n |

Bug: trash view only working for user with the role 'super user'. 

Fix: remove setExtraFrontendOption, the Table parent class calculate the order based on the order field.

```php
/**
     * @return array<string, mixed>
     */
    public function getFrontendOptions(): array
    {
        $columnIndex = 0;
        if ($this->supportsTableActions()) {
            $columnIndex = 1;
        }
        if (!$this->isSortable() && null !== $this->orderField) {
            $counter = $columnIndex;
            foreach ($this->getColumns() as $column) {
                if ($this->orderField === $column->getAttribute()) {
                    $columnIndex = $counter;
                    break;
                }
                ++$counter;
            }
        }
        $options = [];

        if (null !== $columnIndex) {
            $options['order'] = [[$columnIndex, $this->orderDirection]];
        }
```
