### PR TITLE
fix(admin/cli): reindex skip lock and with_warnings false

### DIFF
--- a/EMS/core-bundle/src/Command/ReindexCommand.php
+++ b/EMS/core-bundle/src/Command/ReindexCommand.php
@@ -153,6 +153,11 @@ class ReindexCommand extends AbstractCommand
             do {
                 /** @var Revision $revision */
                 foreach ($paginator as $revision) {
+                    if ($revision->isLocked()) {
+                        $progress->advance();
+                        continue;
+                    }
+
                     if ($revision->getDeleted()) {
                         ++$this->deleted;
                         $this->logger->warning('log.reindex.revision.deleted_but_referenced', [

--- a/EMS/core-bundle/src/Service/DataService.php
+++ b/EMS/core-bundle/src/Service/DataService.php
@@ -1413,7 +1413,10 @@ class DataService
             $finalizationDate = $objectArray[Mapping::FINALIZATION_DATETIME_FIELD];
         }
 
-        $builder = $this->formFactory->createBuilder(RevisionType::class, $reloadRevision, ['raw_data' => $reloadRevision->getRawData()]);
+        $builder = $this->formFactory->createBuilder(RevisionType::class, $reloadRevision, [
+            'raw_data' => $reloadRevision->getRawData(),
+            'with_warning' => false,
+        ]);
         $form = $builder->getForm();
 
         $objectArray = $reloadRevision->getRawData();


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? |  n |
| Documentation? | n  |

- Reindex should skip locked revisions
- Reindex reload data -> with_warning false (convert text to dataLink post processing)
