### PR TITLE
fix(admin/wysiwyg): emsch_assets_version default null for saveDir

### DIFF
--- a/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/wysiwyg_styles_set/iframe.html.twig
+++ b/EMS/admin-ui-bundle/src/Resources/views/bootstrap5/wysiwyg_styles_set/iframe.html.twig
@@ -6,7 +6,7 @@
     <style>body {overflow: hidden;}</style>
     {% apply spaceless %}
         {% if styleSet.assets.sha1|default %}
-            {% do emsch_assets_version(styleSet.assets.sha1) %}
+            {% do emsch_assets_version(styleSet.assets.sha1, null) %}
         {% endif %}
         {% if null != styleSet.contentCss %}
             <link rel="stylesheet" href="{{ asset(styleSet.contentCss, styleSet.saveDir == null ? 'emsch' : null) }}">

--- a/EMS/client-helper-bundle/src/Helper/Asset/AssetHelperRuntime.php
+++ b/EMS/client-helper-bundle/src/Helper/Asset/AssetHelperRuntime.php
@@ -20,8 +20,11 @@ final class AssetHelperRuntime implements RuntimeExtensionInterface
 
     public function __construct(
         private readonly StorageManager $storageManager,
-        private readonly ClientRequestManager $manager, private readonly AssetRuntime $commonAssetRuntime, string $projectDir, private readonly ?string $localFolder)
-    {
+        private readonly ClientRequestManager $manager,
+        private readonly AssetRuntime $commonAssetRuntime,
+        string $projectDir,
+        private readonly ?string $localFolder
+    ) {
         $this->publicDir = $projectDir.'/public';
 
         $this->filesystem = new Filesystem();

--- a/EMS/client-helper-bundle/src/Helper/Asset/AssetHelperRuntime.php
+++ b/EMS/client-helper-bundle/src/Helper/Asset/AssetHelperRuntime.php
@@ -18,19 +18,14 @@ final class AssetHelperRuntime implements RuntimeExtensionInterface
     private ?string $versionHash = null;
     private ?string $versionSaveDir = null;
 
-    public function __construct(
-        private readonly StorageManager $storageManager,
-        private readonly ClientRequestManager $manager,
-        private readonly AssetRuntime $commonAssetRuntime,
-        string $projectDir,
-        private readonly ?string $localFolder
-    ) {
+    public function __construct(private readonly StorageManager $storageManager, private readonly ClientRequestManager $manager, private readonly AssetRuntime $commonAssetRuntime, string $projectDir, private readonly ?string $localFolder)
+    {
         $this->publicDir = $projectDir.'/public';
 
         $this->filesystem = new Filesystem();
     }
 
-    public function setVersion(string $hash, ?string $saveDir = null): ?string
+    public function setVersion(string $hash, ?string $saveDir = 'bundles'): ?string
     {
         if (null !== $this->versionHash && $this->versionHash !== $hash) {
             throw new \RuntimeException('Another hash version has been already defined');

--- a/EMS/client-helper-bundle/src/Helper/Asset/AssetHelperRuntime.php
+++ b/EMS/client-helper-bundle/src/Helper/Asset/AssetHelperRuntime.php
@@ -18,14 +18,16 @@ final class AssetHelperRuntime implements RuntimeExtensionInterface
     private ?string $versionHash = null;
     private ?string $versionSaveDir = null;
 
-    public function __construct(private readonly StorageManager $storageManager, private readonly ClientRequestManager $manager, private readonly AssetRuntime $commonAssetRuntime, string $projectDir, private readonly ?string $localFolder)
+    public function __construct(
+        private readonly StorageManager $storageManager,
+        private readonly ClientRequestManager $manager, private readonly AssetRuntime $commonAssetRuntime, string $projectDir, private readonly ?string $localFolder)
     {
         $this->publicDir = $projectDir.'/public';
 
         $this->filesystem = new Filesystem();
     }
 
-    public function setVersion(string $hash, ?string $saveDir = 'bundles'): ?string
+    public function setVersion(string $hash, ?string $saveDir = null): ?string
     {
         if (null !== $this->versionHash && $this->versionHash !== $hash) {
             throw new \RuntimeException('Another hash version has been already defined');

--- a/EMS/core-bundle/src/Resources/views/wysiwyg_styles_set/iframe.html.twig
+++ b/EMS/core-bundle/src/Resources/views/wysiwyg_styles_set/iframe.html.twig
@@ -6,7 +6,7 @@
     <style>body {overflow: hidden;}</style>
     {% apply spaceless %}
         {% if styleSet.assets.sha1|default %}
-            {% do emsch_assets_version(styleSet.assets.sha1) %}
+            {% do emsch_assets_version(styleSet.assets.sha1, null) %}
         {% endif %}
         {% if null != styleSet.contentCss %}
             <link rel="stylesheet" href="{{ asset(styleSet.contentCss, styleSet.saveDir == null ? 'emsch' : null) }}">


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? |  n |
| Documentation? | n  |

We need to pass null for not extracting the assets inside the bundle dir

