### PR TITLE
feat(common/cli): file structure api or storage manager

### DIFF
--- a/EMS/common-bundle/src/Command/FileStructure/FileStructurePublishCommand.php
+++ b/EMS/common-bundle/src/Command/FileStructure/FileStructurePublishCommand.php
@@ -36,8 +36,7 @@ class FileStructurePublishCommand extends AbstractCommand
     public function __construct(
         private readonly AdminHelper $adminHelper,
         private readonly StorageManager $storageManager
-    )
-    {
+    ) {
         parent::__construct();
     }
 

--- a/EMS/common-bundle/src/Command/FileStructure/FileStructurePublishCommand.php
+++ b/EMS/common-bundle/src/Command/FileStructure/FileStructurePublishCommand.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace EMS\CommonBundle\Command\FileStructure;
 
 use EMS\CommonBundle\Commands;
+use EMS\CommonBundle\Common\Admin\AdminHelper;
 use EMS\CommonBundle\Common\Command\AbstractCommand;
 use EMS\CommonBundle\Common\File\FileStructure\FileStructureClientInterface;
 use EMS\CommonBundle\Common\File\FileStructure\S3Client;
+use EMS\CommonBundle\Contracts\File\FileManagerInterface;
 use EMS\CommonBundle\Exception\FileStructureNotSyncException;
 use EMS\CommonBundle\Storage\Archive;
 use EMS\CommonBundle\Storage\StorageManager;
@@ -24,12 +26,17 @@ class FileStructurePublishCommand extends AbstractCommand
     public const ARGUMENT_TARGET = 'target';
     public const OPTION_S3_CREDENTIAL = 's3-credential';
     public const OPTION_FORCE = 'force';
+    public const OPTION_ADMIN = 'admin';
     private string $target;
     private ?string $s3Credential;
     private string $archiveHash;
     private bool $force;
+    private FileManagerInterface $fileManager;
 
-    public function __construct(private readonly StorageManager $storageManager)
+    public function __construct(
+        private readonly AdminHelper $adminHelper,
+        private readonly StorageManager $storageManager
+    )
     {
         parent::__construct();
     }
@@ -37,11 +44,14 @@ class FileStructurePublishCommand extends AbstractCommand
     protected function configure(): void
     {
         parent::configure();
-        $this->setDescription('Publish the file structure of an ElasticMS archive into a S3 bucket');
-        $this->addArgument(self::ARGUMENT_ARCHIVE_HASH, InputArgument::REQUIRED, 'Elasticsearch index');
-        $this->addArgument(self::ARGUMENT_TARGET, InputArgument::REQUIRED, 'Target (S3 bucket)');
-        $this->addOption(self::OPTION_S3_CREDENTIAL, null, InputOption::VALUE_OPTIONAL, 'S3 credential in a JSON format');
-        $this->addOption(self::OPTION_FORCE, null, InputOption::VALUE_NONE, 'The target is synchronize even if the target looks already synchronized or if the target looks out of sync');
+        $this
+            ->setDescription('Publish the file structure of an ElasticMS archive into a S3 bucket')
+            ->addArgument(self::ARGUMENT_ARCHIVE_HASH, InputArgument::REQUIRED, 'Elasticsearch index')
+            ->addArgument(self::ARGUMENT_TARGET, InputArgument::REQUIRED, 'Target (S3 bucket)')
+            ->addOption(self::OPTION_S3_CREDENTIAL, null, InputOption::VALUE_OPTIONAL, 'S3 credential in a JSON format')
+            ->addOption(self::OPTION_FORCE, null, InputOption::VALUE_NONE, 'The target is synchronize even if the target looks already synchronized or if the target looks out of sync')
+            ->addOption(self::OPTION_ADMIN, null, InputOption::VALUE_NONE, 'Use admin api')
+        ;
     }
 
     protected function initialize(InputInterface $input, OutputInterface $output): void
@@ -51,14 +61,19 @@ class FileStructurePublishCommand extends AbstractCommand
         $this->target = $this->getArgumentString(self::ARGUMENT_TARGET);
         $this->s3Credential = $this->getOptionStringNull(self::OPTION_S3_CREDENTIAL);
         $this->force = $this->getOptionBool(self::OPTION_FORCE);
+
+        $this->fileManager = match ($this->getOptionBool(self::OPTION_ADMIN)) {
+            true => $this->adminHelper->getCoreApi()->file(),
+            false => $this->storageManager,
+        };
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->io->title('File Structure - Publish');
+        $this->io->title('EMS - File structure - Publish');
 
-        $algo = $this->storageManager->getHashAlgo();
-        $archive = Archive::fromStructure($this->storageManager->getContents($this->archiveHash), $algo);
+        $algo = $this->fileManager->getHashAlgo();
+        $archive = Archive::fromStructure($this->fileManager->getContents($this->archiveHash), $algo);
 
         $client = $this->getClient();
         $client->initSync($this->archiveHash);
@@ -76,7 +91,7 @@ class FileStructurePublishCommand extends AbstractCommand
 
         $this->io->progressStart($archive->getCount());
         foreach ($archive->iterator() as $item) {
-            $stream = $this->storageManager->getStream($item->hash);
+            $stream = $this->fileManager->getStream($item->hash);
             $client->createFile($item->filename, $stream, $item->type);
             $this->io->progressAdvance();
         }
@@ -91,8 +106,7 @@ class FileStructurePublishCommand extends AbstractCommand
         if (null === $this->s3Credential) {
             throw new \RuntimeException('Only S3 is currently implemented, --s3-credential must be defined');
         }
-        $s3Client = new S3Client(Json::decode($this->s3Credential), $this->target);
 
-        return $s3Client;
+        return new S3Client(Json::decode($this->s3Credential), $this->target);
     }
 }

--- a/EMS/common-bundle/src/Command/FileStructure/FileStructurePullCommand.php
+++ b/EMS/common-bundle/src/Command/FileStructure/FileStructurePullCommand.php
@@ -7,11 +7,13 @@ namespace EMS\CommonBundle\Command\FileStructure;
 use EMS\CommonBundle\Commands;
 use EMS\CommonBundle\Common\Admin\AdminHelper;
 use EMS\CommonBundle\Common\Command\AbstractCommand;
-use EMS\CommonBundle\Contracts\CoreApi\CoreApiInterface;
+use EMS\CommonBundle\Contracts\File\FileManagerInterface;
 use EMS\CommonBundle\Storage\Archive;
+use EMS\CommonBundle\Storage\StorageManager;
 use EMS\Helpers\Standard\Type;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
@@ -21,21 +23,28 @@ class FileStructurePullCommand extends AbstractCommand
     protected static $defaultName = Commands::FILE_STRUCTURE_PULL;
     private const ARGUMENT_ARCHIVE_HASH = 'hash';
     private const ARGUMENT_FOLDER = 'folder';
-    private string $folderPath;
-    private CoreApiInterface $coreApi;
-    private string $archiveHash;
+    private const OPTION_ADMIN = 'admin';
 
-    public function __construct(private readonly AdminHelper $adminHelper)
-    {
+    private string $folderPath;
+    private string $archiveHash;
+    private FileManagerInterface $fileManager;
+
+    public function __construct(
+        private readonly AdminHelper $adminHelper,
+        private readonly StorageManager $storageManager,
+    ) {
         parent::__construct();
     }
 
     protected function configure(): void
     {
         parent::configure();
-        $this->setDescription('Pull an EMS archive into a local folder (and overwrite it)');
-        $this->addArgument(self::ARGUMENT_ARCHIVE_HASH, InputArgument::REQUIRED, 'Hash of the ElasticMS Archive');
-        $this->addArgument(self::ARGUMENT_FOLDER, InputArgument::REQUIRED, 'Target folder');
+        $this
+            ->setDescription('Pull an EMS archive into a local folder (and overwrite it)')
+            ->addArgument(self::ARGUMENT_ARCHIVE_HASH, InputArgument::REQUIRED, 'Hash of the ElasticMS Archive')
+            ->addArgument(self::ARGUMENT_FOLDER, InputArgument::REQUIRED, 'Target folder')
+            ->addOption(self::OPTION_ADMIN, null, InputOption::VALUE_NONE, 'Pull from admin')
+        ;
     }
 
     protected function initialize(InputInterface $input, OutputInterface $output): void
@@ -43,13 +52,16 @@ class FileStructurePullCommand extends AbstractCommand
         parent::initialize($input, $output);
         $this->archiveHash = $this->getArgumentString(self::ARGUMENT_ARCHIVE_HASH);
         $this->folderPath = $this->getArgumentString(self::ARGUMENT_FOLDER);
-        $this->coreApi = $this->adminHelper->getCoreApi();
+        $this->fileManager = match ($this->getOptionBool(self::OPTION_ADMIN)) {
+            true => $this->adminHelper->getCoreApi()->file(),
+            false => $this->storageManager,
+        };
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $algo = $this->coreApi->file()->getHashAlgo();
-        $archiveFile = $this->coreApi->file()->downloadFile($this->archiveHash);
+        $algo = $this->fileManager->getHashAlgo();
+        $archiveFile = $this->fileManager->downloadFile($this->archiveHash);
         $archive = Archive::fromStructure(Type::string(\file_get_contents($archiveFile)), $algo);
 
         $done = [];
@@ -73,7 +85,7 @@ class FileStructurePullCommand extends AbstractCommand
                 $progressBar->advance();
                 continue;
             }
-            $tempFile = $this->coreApi->file()->downloadFile($item->hash);
+            $tempFile = $this->fileManager->downloadFile($item->hash);
             $explodedPath = \explode(\DIRECTORY_SEPARATOR, $this->folderPath.\DIRECTORY_SEPARATOR.$item->filename);
             \array_pop($explodedPath);
             $filesystem->mkdir(\implode(\DIRECTORY_SEPARATOR, $explodedPath));

--- a/EMS/common-bundle/src/Command/FileStructure/FileStructurePullCommand.php
+++ b/EMS/common-bundle/src/Command/FileStructure/FileStructurePullCommand.php
@@ -60,6 +60,8 @@ class FileStructurePullCommand extends AbstractCommand
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $this->io->title('EMS - File structure - Pull');
+
         $algo = $this->fileManager->getHashAlgo();
         $archiveFile = $this->fileManager->downloadFile($this->archiveHash);
         $archive = Archive::fromStructure(Type::string(\file_get_contents($archiveFile)), $algo);

--- a/EMS/common-bundle/src/Command/FileStructure/FileStructurePushCommand.php
+++ b/EMS/common-bundle/src/Command/FileStructure/FileStructurePushCommand.php
@@ -7,55 +7,66 @@ namespace EMS\CommonBundle\Command\FileStructure;
 use EMS\CommonBundle\Commands;
 use EMS\CommonBundle\Common\Admin\AdminHelper;
 use EMS\CommonBundle\Common\Command\AbstractCommand;
-use EMS\CommonBundle\Contracts\CoreApi\CoreApiInterface;
+use EMS\CommonBundle\Contracts\File\FileManagerInterface;
 use EMS\CommonBundle\Storage\Archive;
+use EMS\CommonBundle\Storage\StorageManager;
 use EMS\Helpers\Html\MimeTypes;
 use EMS\Helpers\Standard\Json;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class FileStructurePushCommand extends AbstractCommand
 {
     protected static $defaultName = Commands::FILE_STRUCTURE_PUSH;
     private const ARGUMENT_FOLDER = 'folder';
+    private const OPTION_ADMIN = 'admin';
     private string $folderPath;
-    private CoreApiInterface $coreApi;
+    private FileManagerInterface $fileManager;
 
-    public function __construct(private readonly AdminHelper $adminHelper)
-    {
+    public function __construct(
+        private readonly AdminHelper $adminHelper,
+        private readonly StorageManager $storageManager,
+    ) {
         parent::__construct();
     }
 
     protected function configure(): void
     {
         parent::configure();
-        $this->setDescription('Push an EMS Archive file structure into a EMS Admin storage services (via the API)');
-        $this->addArgument(self::ARGUMENT_FOLDER, InputArgument::REQUIRED, 'Source folder');
+        $this
+            ->setDescription('Push an EMS Archive file structure into a EMS Admin storage services (via the API)')
+            ->addArgument(self::ARGUMENT_FOLDER, InputArgument::REQUIRED, 'Source folder')
+            ->addOption(self::OPTION_ADMIN, null, InputOption::VALUE_NONE, 'Push to admin')
+        ;
     }
 
     protected function initialize(InputInterface $input, OutputInterface $output): void
     {
         parent::initialize($input, $output);
         $this->folderPath = $this->getArgumentString(self::ARGUMENT_FOLDER);
-        $this->coreApi = $this->adminHelper->getCoreApi();
+        $this->fileManager = match ($this->getOptionBool(self::OPTION_ADMIN)) {
+            true => $this->adminHelper->getCoreApi()->file(),
+            false => $this->storageManager,
+        };
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $algo = $this->coreApi->file()->getHashAlgo();
+        $algo = $this->fileManager->getHashAlgo();
         $archive = Archive::fromDirectory($this->folderPath, $algo);
         $progressBar = $this->io->createProgressBar($archive->getCount());
-        foreach ($this->coreApi->file()->heads(...$archive->getHashes()) as $hash) {
+        foreach ($this->fileManager->heads(...$archive->getHashes()) as $hash) {
             $file = $archive->getFirstFileByHash($hash);
-            $uploadHash = $this->coreApi->file()->uploadFile($this->folderPath.DIRECTORY_SEPARATOR.$file->filename);
+            $uploadHash = $this->fileManager->uploadFile($this->folderPath.DIRECTORY_SEPARATOR.$file->filename);
             if ($uploadHash !== $hash) {
                 throw new \RuntimeException(\sprintf('Mismatched between the computed hash (%s) and the hash of the uploaded file (%s) for the file %s', $hash, $uploadHash, $file->filename));
             }
             $progressBar->advance();
         }
         $progressBar->finish();
-        $hash = $this->coreApi->file()->uploadContents(Json::encode($archive), 'archive.json', MimeTypes::APPLICATION_JSON->value);
+        $hash = $this->fileManager->uploadContents(Json::encode($archive), 'archive.json', MimeTypes::APPLICATION_JSON->value);
         $this->io->newLine();
         $this->io->success(\sprintf('Archive %s have been uploaded with the directory content of %s', $hash, $this->folderPath));
 

--- a/EMS/common-bundle/src/Command/FileStructure/FileStructurePushCommand.php
+++ b/EMS/common-bundle/src/Command/FileStructure/FileStructurePushCommand.php
@@ -54,8 +54,13 @@ class FileStructurePushCommand extends AbstractCommand
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $this->io->title('EMS - File structure - Push');
         $algo = $this->fileManager->getHashAlgo();
+
+        $this->io->section('Building archive');
         $archive = Archive::fromDirectory($this->folderPath, $algo);
+
+        $this->io->section('Pushing archive');
         $progressBar = $this->io->createProgressBar($archive->getCount());
         foreach ($this->fileManager->heads(...$archive->getHashes()) as $hash) {
             $file = $archive->getFirstFileByHash($hash);

--- a/EMS/common-bundle/src/Common/CoreApi/Endpoint/File/File.php
+++ b/EMS/common-bundle/src/Common/CoreApi/Endpoint/File/File.php
@@ -112,9 +112,8 @@ final class File implements FileInterface
             throw new \RuntimeException(\sprintf('Could not download file with hash %s', $hash));
         }
         $stream = $this->client->download($this->downloadLink($hash));
-        $storageFile = new StorageFile($stream);
 
-        return $storageFile->getFilename();
+        return (new StorageFile($stream))->getFilename();
     }
 
     public function downloadLink(string $hash): string
@@ -181,5 +180,15 @@ final class File implements FileInterface
                 yield $hash;
             }
         }
+    }
+
+    public function getContents(string $hash): string
+    {
+        return $this->getStream($hash)->getContents();
+    }
+
+    public function getStream(string $hash): StreamInterface
+    {
+        return $this->client->download($this->downloadLink($hash));
     }
 }

--- a/EMS/common-bundle/src/Common/CoreApi/Endpoint/File/File.php
+++ b/EMS/common-bundle/src/Common/CoreApi/Endpoint/File/File.php
@@ -14,8 +14,6 @@ use Psr\Http\Message\StreamInterface;
 
 final class File implements FileInterface
 {
-    private const HEADS_CHUNK_SIZE = 1000;
-
     public function __construct(private readonly Client $client, private readonly StorageManager $storageManager)
     {
     }
@@ -174,10 +172,7 @@ final class File implements FileInterface
         }
     }
 
-    /**
-     * @return iterable<string>
-     */
-    public function heads(string ...$fileHashes): iterable
+    public function heads(string ...$fileHashes): \Traversable
     {
         $pagedHashes = \array_chunk($fileHashes, self::HEADS_CHUNK_SIZE, true);
         foreach ($pagedHashes as $hashes) {

--- a/EMS/common-bundle/src/Common/CoreApi/Endpoint/File/File.php
+++ b/EMS/common-bundle/src/Common/CoreApi/Endpoint/File/File.php
@@ -174,7 +174,8 @@ final class File implements FileInterface
 
     public function heads(string ...$fileHashes): \Traversable
     {
-        $pagedHashes = \array_chunk($fileHashes, self::HEADS_CHUNK_SIZE, true);
+        $uniqueFileHashes = \array_unique($fileHashes);
+        $pagedHashes = \array_chunk($uniqueFileHashes, self::HEADS_CHUNK_SIZE, true);
         foreach ($pagedHashes as $hashes) {
             foreach ($this->client->post('/api/file/heads', $hashes)->getData() as $hash) {
                 yield $hash;

--- a/EMS/common-bundle/src/Contracts/CoreApi/Endpoint/File/FileInterface.php
+++ b/EMS/common-bundle/src/Contracts/CoreApi/Endpoint/File/FileInterface.php
@@ -4,32 +4,20 @@ declare(strict_types=1);
 
 namespace EMS\CommonBundle\Contracts\CoreApi\Endpoint\File;
 
+use EMS\CommonBundle\Contracts\File\FileManagerInterface;
 use Psr\Http\Message\StreamInterface;
 
-interface FileInterface
+interface FileInterface extends FileManagerInterface
 {
-    public function downloadFile(string $hash): string;
-
-    public function getHashAlgo(): string;
-
     public function downloadLink(string $hash): string;
 
     public function hashFile(string $filename): string;
 
     public function hashStream(StreamInterface $stream): string;
 
-    /**
-     * @return iterable<string>
-     */
-    public function heads(string ...$fileHashes): iterable;
-
     public function initUpload(string $hash, int $size, string $filename, string $mimetype): int;
 
     public function addChunk(string $hash, string $chunk): int;
-
-    public function uploadContents(string $contents, string $filename, string $mimeType): string;
-
-    public function uploadFile(string $realPath, ?string $mimeType = null, ?string $filename = null, ?callable $callback = null): string;
 
     public function uploadStream(StreamInterface $stream, string $filename, string $mimeType, bool $head = true): string;
 

--- a/EMS/common-bundle/src/Contracts/File/FileManagerInterface.php
+++ b/EMS/common-bundle/src/Contracts/File/FileManagerInterface.php
@@ -6,14 +6,16 @@ namespace EMS\CommonBundle\Contracts\File;
 
 interface FileManagerInterface
 {
+    public const HEADS_CHUNK_SIZE = 1000;
+
     public function downloadFile(string $hash): string;
 
     public function getHashAlgo(): string;
 
     /**
-     * @return iterable<string>
+     * @return \Traversable<int, string>
      */
-    public function heads(string ...$fileHashes): iterable;
+    public function heads(string ...$fileHashes): \Traversable;
 
     public function uploadContents(string $contents, string $filename, string $mimeType): string;
 

--- a/EMS/common-bundle/src/Contracts/File/FileManagerInterface.php
+++ b/EMS/common-bundle/src/Contracts/File/FileManagerInterface.php
@@ -4,13 +4,19 @@ declare(strict_types=1);
 
 namespace EMS\CommonBundle\Contracts\File;
 
+use Psr\Http\Message\StreamInterface;
+
 interface FileManagerInterface
 {
     public const HEADS_CHUNK_SIZE = 1000;
 
     public function downloadFile(string $hash): string;
 
+    public function getContents(string $hash): string;
+
     public function getHashAlgo(): string;
+
+    public function getStream(string $hash): StreamInterface;
 
     /**
      * @return \Traversable<int, string>

--- a/EMS/common-bundle/src/Contracts/File/FileManagerInterface.php
+++ b/EMS/common-bundle/src/Contracts/File/FileManagerInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CommonBundle\Contracts\File;
+
+interface FileManagerInterface
+{
+    public function downloadFile(string $hash): string;
+
+    public function getHashAlgo(): string;
+
+    /**
+     * @return iterable<string>
+     */
+    public function heads(string ...$fileHashes): iterable;
+
+    public function uploadContents(string $contents, string $filename, string $mimeType): string;
+
+    public function uploadFile(string $realPath, ?string $mimeType = null, ?string $filename = null, ?callable $callback = null): string;
+}

--- a/EMS/common-bundle/src/Resources/config/commands.xml
+++ b/EMS/common-bundle/src/Resources/config/commands.xml
@@ -91,15 +91,17 @@
             <tag name="console.command" command="ems:version"/>
         </service>
         <service id="ems.command.file_structure.publish" class="EMS\CommonBundle\Command\FileStructure\FileStructurePublishCommand">
-            <argument type="service" id="EMS\CommonBundle\Storage\StorageManager"/>
+            <argument type="service" id="ems_common.storage.manager"/>
             <tag name="console.command" />
         </service>
         <service id="ems.command.file_structure.pull" class="EMS\CommonBundle\Command\FileStructure\FileStructurePullCommand">
             <argument type="service" id="ems.helper.admin_api"/>
+            <argument type="service" id="ems_common.storage.manager"/>
             <tag name="console.command" />
         </service>
         <service id="ems.command.file_structure.push" class="EMS\CommonBundle\Command\FileStructure\FileStructurePushCommand">
             <argument type="service" id="ems.helper.admin_api"/>
+            <argument type="service" id="ems_common.storage.manager"/>
             <tag name="console.command" />
         </service>
         <service id="ems.command.storage.clear_cache" class="EMS\CommonBundle\Command\Storage\ClearCacheCommand">

--- a/EMS/common-bundle/src/Resources/config/commands.xml
+++ b/EMS/common-bundle/src/Resources/config/commands.xml
@@ -91,6 +91,7 @@
             <tag name="console.command" command="ems:version"/>
         </service>
         <service id="ems.command.file_structure.publish" class="EMS\CommonBundle\Command\FileStructure\FileStructurePublishCommand">
+            <argument type="service" id="ems.helper.admin_api"/>
             <argument type="service" id="ems_common.storage.manager"/>
             <tag name="console.command" />
         </service>

--- a/EMS/common-bundle/src/Storage/Service/S3Storage.php
+++ b/EMS/common-bundle/src/Storage/Service/S3Storage.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EMS\CommonBundle\Storage\Service;
 
+use Aws\Exception\AwsException;
 use Aws\S3\S3Client;
 use EMS\CommonBundle\Common\Cache\Cache;
 use EMS\CommonBundle\Storage\File\FileInterface;
@@ -11,6 +12,7 @@ use EMS\CommonBundle\Storage\Processor\Config;
 use EMS\CommonBundle\Storage\StreamWrapper;
 use EMS\Helpers\Html\MimeTypes;
 use EMS\Helpers\Standard\Base64;
+use GuzzleHttp\Promise\Each;
 use Psr\Http\Message\StreamInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Finder\SplFileInfo;
@@ -352,16 +354,24 @@ class S3Storage extends AbstractUrlStorage
     public function heads(string ...$hashes): array
     {
         $client = $this->getS3Client();
-        $result = [];
+        $notFound = [];
 
-        foreach ($hashes as $hash) {
-            $key = \implode('/', [\substr($hash, 0, 3), $hash]);
-
-            if (!$client->doesObjectExist($this->bucket, $key)) {
-                $result[] = $hash;
+        $promiseGenerator = function () use ($hashes, $client, &$notFound) {
+            foreach ($hashes as $hash) {
+                yield $client->headObjectAsync([
+                    'Bucket' => $this->bucket,
+                    'Key' => \implode('/', [\substr($hash, 0, 3), $hash]),
+                ])->then(onRejected: function (AwsException $exception) use (&$notFound, $hash) {
+                    if ('NotFound' === $exception->getAwsErrorCode()) {
+                        $notFound[] = $hash;
+                    }
+                });
             }
-        }
+        };
 
-        return $result;
+        $promise = Each::ofLimit(iterable: $promiseGenerator(), concurrency: 10);
+        $promise->wait();
+
+        return $notFound;
     }
 }

--- a/EMS/common-bundle/src/Storage/Service/S3Storage.php
+++ b/EMS/common-bundle/src/Storage/Service/S3Storage.php
@@ -369,7 +369,7 @@ class S3Storage extends AbstractUrlStorage
             }
         };
 
-        $promise = Each::ofLimit(iterable: $promiseGenerator(), concurrency: 10);
+        $promise = Each::ofLimit(iterable: $promiseGenerator(), concurrency: 500);
         $promise->wait();
 
         return $notFound;

--- a/EMS/common-bundle/src/Storage/StorageManager.php
+++ b/EMS/common-bundle/src/Storage/StorageManager.php
@@ -89,18 +89,15 @@ class StorageManager implements FileManagerInterface
         return false;
     }
 
-    /**
-     * @return string[]
-     */
-    public function heads(string ...$hashes): array
+    public function heads(string ...$fileHashes): \Traversable
     {
-        $heads = $hashes;
+        $pagedHashes = \array_chunk($fileHashes, self::HEADS_CHUNK_SIZE, true);
 
-        foreach ($this->adapters as $adapter) {
-            $heads = $adapter->heads(...$heads);
+        foreach ($pagedHashes as $hashes) {
+            foreach ($this->adapters as $adapter) {
+                yield from $adapter->heads(...$hashes);
+            }
         }
-
-        return $heads;
     }
 
     /**

--- a/EMS/common-bundle/src/Storage/StorageManager.php
+++ b/EMS/common-bundle/src/Storage/StorageManager.php
@@ -538,7 +538,7 @@ class StorageManager implements FileManagerInterface
         $mimeType = MimeTypeHelper::getInstance()->guessMimeType($archiveFile->path);
 
         return match ($mimeType) {
-            MimeTypes::APPLICATION_ZIP->value => $this->getStreamFromZipArchive($hash, $path, $archiveFile),
+            MimeTypes::APPLICATION_ZIP->value, MimeTypes::APPLICATION_GZIP->value => $this->getStreamFromZipArchive($hash, $path, $archiveFile),
             MimeTypes::APPLICATION_JSON->value => $this->getStreamFromJsonArchive($hash, $path, $archiveFile),
             default => throw new \RuntimeException(\sprintf('Archive format %s not supported', $mimeType)),
         };
@@ -550,6 +550,7 @@ class StorageManager implements FileManagerInterface
         $type = MimeTypeHelper::getInstance()->guessMimeType($archiveFile->path);
         switch ($type) {
             case MimeTypes::APPLICATION_ZIP->value:
+            case MimeTypes::APPLICATION_GZIP->value:
                 $tempDir = TempDirectory::createFromZipArchive($archiveFile->path);
                 break;
             case MimeTypes::APPLICATION_JSON->value:

--- a/EMS/common-bundle/src/Storage/StorageManager.php
+++ b/EMS/common-bundle/src/Storage/StorageManager.php
@@ -91,7 +91,8 @@ class StorageManager implements FileManagerInterface
 
     public function heads(string ...$fileHashes): \Traversable
     {
-        $pagedHashes = \array_chunk($fileHashes, self::HEADS_CHUNK_SIZE, true);
+        $uniqueFileHashes = \array_unique($fileHashes);
+        $pagedHashes = \array_chunk($uniqueFileHashes, self::HEADS_CHUNK_SIZE, true);
 
         foreach ($pagedHashes as $hashes) {
             foreach ($this->adapters as $adapter) {

--- a/EMS/core-bundle/src/Controller/ContentManagement/FileController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/FileController.php
@@ -43,7 +43,9 @@ class FileController extends AbstractController
     {
         $hashes = Json::decode($request->getContent());
 
-        return new JsonResponse($this->fileService->heads(...$hashes));
+        $heads = \iterator_to_array($this->fileService->heads(...$hashes));
+
+        return new JsonResponse($heads);
     }
 
     public function viewFileAction(string $sha1, Request $request): Response

--- a/EMS/core-bundle/src/Service/FileService.php
+++ b/EMS/core-bundle/src/Service/FileService.php
@@ -158,9 +158,9 @@ class FileService implements EntityServiceInterface
     }
 
     /**
-     * @return string[]
+     * @return \Traversable<int, string>
      */
-    public function heads(string ...$hashes): array
+    public function heads(string ...$hashes): \Traversable
     {
         return $this->storageManager->heads(...$hashes);
     }

--- a/EMS/helpers/src/Html/MimeTypes.php
+++ b/EMS/helpers/src/Html/MimeTypes.php
@@ -7,6 +7,7 @@ namespace EMS\Helpers\Html;
 enum MimeTypes: string
 {
     case APPLICATION_ZIP = 'application/zip';
+    case APPLICATION_GZIP = 'application/x-gzip-compressed';
     case APPLICATION_XML = 'application/xml';
     case APPLICATION_JSON = 'application/json';
     case APPLICATION_OCTET_STREAM = 'application/octet-stream';

--- a/docs/recipes/websites/file-structure.md
+++ b/docs/recipes/websites/file-structure.md
@@ -1,21 +1,28 @@
 # File structure
 
-## Push a local folder to ElasticMS
+## Push a local folder to ElasticMS or Storage
 
-The following command is available in all ElacticMS applications (Admin, Web and CLI) but required that your are logged in first (`ems:admin:login`).
+The following commands is available in all ElacticMS applications (Admin, Web and CLI).
+
 
 ```shell
-php bin/console ems:file-structure:push ../../demo
+php bin/console ems:file-structure:push ../../demo --admin
 ```
 This command will upload all files present in the ../../demo folder an give you an hash as output.
 That hash identify an ElasticMS Archive, it's a JSON containing the all files structure (with hash, filename, size and mimetype of all files).
 
+The admin option requires api authentication, first run `ems:admin:login`.
+Without the admin option, it will use the application storages defined in `EMS_STORAGES`.
+
 ## Update a local folder from ElasticMS
 
 ```shell
-php bin/console ems:file-structure:pull d3bb0298fd9a69743333fb25dbe6cdefdc834ff2 ../../demo
+php bin/console ems:file-structure:pull d3bb0298fd9a69743333fb25dbe6cdefdc834ff2 ../../demo --admin
 ```
 Update the folder ../../demo by the content of the ElasticMS archive identified by the hash `d3bb0298fd9a69743333fb25dbe6cdefdc834ff2`.
+
+The admin option requires api authentication, first run `ems:admin:login`.
+Without the admin option, it will use the application storages defined in `EMS_STORAGES`.
 
 ## Publish a file structure to a S3 bucket
 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  n |
| New feature?   | y  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | y |

The 2 file structure commands can now work with the api or directly with the storage manager.
Switch is done by the new added option ```--admin```.

