### PR TITLE
fix(admin/contentType): locale default null not 'en'

### DIFF
--- a/EMS/core-bundle/src/Form/Extension/LocaleFormExtension.php
+++ b/EMS/core-bundle/src/Form/Extension/LocaleFormExtension.php
@@ -17,7 +17,7 @@ class LocaleFormExtension extends AbstractTypeExtension
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
-            ->setDefaults(['locale' => 'en'])
+            ->setDefaults(['locale' => null])
             ->setNormalizer('locale', function (Options $options, ?string $value) {
                 try {
                     $language = $options['language'] ?? null;


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

bug was introduced in #1029 and released in 5.22.0. Setting the locale to default 'en' has a side effect on multiplex with 'en' value.
In edit mode the tabs are differently sorted, keep like it was locale default null.
