### PR TITLE
fix(admin/security): give public access to route prefixed with /bundle

### DIFF
--- a/elasticms-admin/config/packages/security.yaml
+++ b/elasticms-admin/config/packages/security.yaml
@@ -58,6 +58,7 @@ security:
     access_control:
         - { path: ^/$, role: PUBLIC_ACCESS }
         - { path: ^/metrics$, role: PUBLIC_ACCESS }
+        - { path: ^/bundle, role: PUBLIC_ACCESS }
         - { path: ^/favicon.ico$, role: PUBLIC_ACCESS }
         - { path: ^/apple\-touch\-icon\.png$, role: PUBLIC_ACCESS }
         - { path: ^/favicon\-(16|32|48|64|128|256)x(16|32|48|64|128|256)\.png$, role: PUBLIC_ACCESS }


### PR DESCRIPTION


| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

- /bundle without trailing s for now
- It's about anonymous access to channels (it's better to have js, css, ....)
