### PR TITLE
fix(admin/dataTable): ajaxData is in export format (links are just text)

### DIFF
--- a/EMS/core-bundle/src/Core/DataTable/TableExporter.php
+++ b/EMS/core-bundle/src/Core/DataTable/TableExporter.php
@@ -27,7 +27,7 @@ final class TableExporter
     private function buildSpreadsheet(TableInterface $table, string $spreadsheetWriter): Response
     {
         $headers = $this->tableRenderer->buildHeaders($table);
-        $rows = $this->tableRenderer->buildAllRows($table);
+        $rows = $this->tableRenderer->buildAllRows(table: $table, export: true);
 
         return $this->spreadsheetGenerator->generateSpreadsheet([
             SpreadsheetGeneratorServiceInterface::SHEETS => [[

--- a/EMS/core-bundle/src/Core/DataTable/TableRenderer.php
+++ b/EMS/core-bundle/src/Core/DataTable/TableRenderer.php
@@ -39,17 +39,17 @@ final class TableRenderer
     /**
      * @return array<mixed>
      */
-    public function buildAllRows(TableInterface $table): array
+    public function buildAllRows(TableInterface $table, bool $export = false): array
     {
         if ($table instanceof ElasticaTable) {
-            return $this->buildAllRowsElastica($table);
+            return $this->buildAllRowsElastica($table, $export);
         }
 
         $rows = [];
         $table->setSize(0);
 
         while ($table->next()) {
-            $rows = [...$rows, ...$this->buildRows($table)];
+            $rows = [...$rows, ...$this->buildRows($table, $export)];
         }
 
         return $rows;
@@ -58,13 +58,13 @@ final class TableRenderer
     /**
      * @return array<mixed>
      */
-    public function buildRows(TableInterface $table): array
+    public function buildRows(TableInterface $table, bool $export = false): array
     {
         $rows = [];
         $template = $this->twig->createTemplate($table->getRowTemplate());
 
         foreach ($table as $line) {
-            $rows[] = $this->lineToRow($template, $table, $line);
+            $rows[] = $this->lineToRow($template, $table, $line, $export);
         }
 
         return $rows;
@@ -73,7 +73,7 @@ final class TableRenderer
     /**
      * @return array<mixed>
      */
-    private function buildAllRowsElastica(ElasticaTable $table): array
+    private function buildAllRowsElastica(ElasticaTable $table, bool $export = false): array
     {
         $this->elasticaLogger->disable();
 
@@ -81,7 +81,7 @@ final class TableRenderer
         $template = $this->twig->createTemplate($table->getRowTemplate());
 
         foreach ($table->scroll() as $line) {
-            $rows[] = $this->lineToRow($template, $table, $line);
+            $rows[] = $this->lineToRow($template, $table, $line, $export);
         }
 
         $this->elasticaLogger->enable();
@@ -92,12 +92,12 @@ final class TableRenderer
     /**
      * @return array<mixed>
      */
-    private function lineToRow(TemplateWrapper $template, TableInterface $table, TableRowInterface $line): array
+    private function lineToRow(TemplateWrapper $template, TableInterface $table, TableRowInterface $line, bool $export = false): array
     {
         return Json::decode($template->render([
             'table' => $table,
             'line' => $line,
-            'export' => true,
+            'export' => $export,
         ]));
     }
 }


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

This pr https://github.com/ems-project/elasticms/pull/1052 -> removed ajax.html.twig and used the TableRenderer for returning ajax table data.

But the renderer was only used in exports, and only returning export data (links are not links but just text)
