### PR TITLE
fix(admin/contentType): locale option array on dateRange

### DIFF
--- a/EMS/core-bundle/src/Core/ContentType/DataFieldFormOptions.php
+++ b/EMS/core-bundle/src/Core/ContentType/DataFieldFormOptions.php
@@ -7,7 +7,7 @@ namespace EMS\CoreBundle\Core\ContentType;
 class DataFieldFormOptions
 {
     public function __construct(
-        public readonly ?string $locale = 'en',
+        public readonly mixed $locale = 'en',
         public readonly ?string $referredEmsId = null,
     ) {
     }

--- a/EMS/core-bundle/src/Form/Extension/LocaleFormExtension.php
+++ b/EMS/core-bundle/src/Form/Extension/LocaleFormExtension.php
@@ -18,7 +18,7 @@ class LocaleFormExtension extends AbstractTypeExtension
     {
         $resolver
             ->setDefaults(['locale' => null])
-            ->setNormalizer('locale', function (Options $options, ?string $value) {
+            ->setNormalizer('locale', function (Options $options, null|string|array $value) {
                 try {
                     $language = $options['language'] ?? null;
 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

They formType 'DateRange' is using the 'locale' for defining a sub options:

```php
$out['displayOptions']['locale'] = [
        'format' => 'DD/MM/YYYY HH:mm',
        'firstDay' => 1,
];
```
