### PR TITLE
fix(cli/command): file import config normal merge (for overwritting)

### DIFF
--- a/elasticms-cli/src/Command/FileReader/FileReaderImportCommand.php
+++ b/elasticms-cli/src/Command/FileReader/FileReaderImportCommand.php
@@ -99,6 +99,7 @@ final class FileReaderImportCommand extends AbstractCommand
             $ouuids = $config->deleteMissingDocuments ? $this->searchExistingOuuids() : [];
 
             $progressBar = $this->io->createProgressBar();
+            $count = 0;
             $queue = $coreApi->queue($this->flushSize)->addFlushCallback(fn () => $progressBar->advance());
 
             foreach ($cells as $syncMetaData) {
@@ -114,6 +115,8 @@ final class FileReaderImportCommand extends AbstractCommand
                 if (!$this->dryRun) {
                     $queue->add($contentTypeApi->indexAsync(ouuid: $ouuid, rawData: $rawData, merge: $this->merge));
                 }
+
+                ++$count;
             }
 
             $queue->flush();
@@ -130,7 +133,7 @@ final class FileReaderImportCommand extends AbstractCommand
             }
 
             $this->io->definitionList('Summary',
-                ['Index' => \count($queue)],
+                ['Index' => $count],
                 ['Delete' => \count($ouuids)]
             );
 

--- a/elasticms-cli/src/Command/FileReader/FileReaderImportCommand.php
+++ b/elasticms-cli/src/Command/FileReader/FileReaderImportCommand.php
@@ -150,7 +150,7 @@ final class FileReaderImportCommand extends AbstractCommand
         }, $inputs);
 
         return FileReaderImportConfig::createFromArray(
-            config: \array_merge_recursive(...$configs)
+            config: \array_merge(...$configs)
         );
     }
 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Array merge recursive of two string will create an array of 2 string (delimter for example).
The last config definition of delimiter should be the delimiter we want to use.
