### PR TITLE
feat(helper/uuid): generate uuid from value

### DIFF
--- a/EMS/common-bundle/src/Twig/CommonExtension.php
+++ b/EMS/common-bundle/src/Twig/CommonExtension.php
@@ -7,7 +7,7 @@ use EMS\CommonBundle\Common\EMSLink;
 use EMS\CommonBundle\Common\Standard\Base64;
 use EMS\CommonBundle\Helper\Text\Encoder;
 use EMS\Helpers\Standard\Color;
-use Ramsey\Uuid\Uuid;
+use EMS\Helpers\Standard\UuidGenerator;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
@@ -27,7 +27,7 @@ class CommonExtension extends AbstractExtension
             new TwigFunction('ems_analyze', [SearchRuntime::class, 'analyze']),
             new TwigFunction('ems_image_info', [AssetRuntime::class, 'imageInfo']),
             new TwigFunction('ems_version', [InfoRuntime::class, 'version']),
-            new TwigFunction('ems_uuid', [Uuid::class, 'uuid4']),
+            new TwigFunction('ems_uuid', [UuidGenerator::class, 'random']),
             new TwigFunction('ems_store_read', [StoreDataRuntime::class, 'read']),
             new TwigFunction('ems_store_save', [StoreDataRuntime::class, 'save']),
             new TwigFunction('ems_store_delete', [StoreDataRuntime::class, 'delete']),
@@ -67,6 +67,7 @@ class CommonExtension extends AbstractExtension
             new TwigFilter('ems_color', fn ($color) => new Color($color)),
             new TwigFilter('ems_link', fn ($emsLink) => EMSLink::fromText($emsLink)),
             new TwigFilter('ems_valid_mail', [TextRuntime::class, 'isValidEmail']),
+            new TwigFilter('ems_uuid', [UuidGenerator::class, 'fromValue']),
         ];
     }
 

--- a/EMS/helpers/src/Standard/UuidGenerator.php
+++ b/EMS/helpers/src/Standard/UuidGenerator.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\Helpers\Standard;
+
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
+
+class UuidGenerator
+{
+    public static function random(): UuidInterface
+    {
+        return Uuid::uuid4();
+    }
+
+    public static function fromValue(string $value): UuidInterface
+    {
+        return Uuid::uuid5(Uuid::NAMESPACE_URL, $value);
+    }
+}

--- a/docs/dev/common-bundle/twig.md
+++ b/docs/dev/common-bundle/twig.md
@@ -24,6 +24,7 @@
   * [ems_file_from_archive](#ems_file_from_archive)
   * [ems_link](#ems_link)
   * [ems_valid_mail](#ems_valid_mail)
+  * [ems_uuid](#ems_uuid-1)
 <!-- TOC -->
 
 # Twig Functions
@@ -97,7 +98,7 @@ Where _'4ef5796bb14ce4b711737dc44aa20bff82193cf5'_ is the hash of a jpg
 Generate a version 4 (random) UUID. [More info](https://uuid.ramsey.dev/en/stable/rfc4122/version4.html).
 
 ````twig
-{{ ems_uuid() }} {# displays: 21.16 KB #}
+{{ ems_uuid() }}
 ````
 
 ## ems_store_read
@@ -397,4 +398,13 @@ Returns true if the input is a valid email
 ```twig
 {%- if _source.email|ems_valid_mail -%}{% endif %}
 ```
+
+## ems_uuid
+
+Generate a version 5 UUID from a value. [More info](https://uuid.ramsey.dev/en/stable/rfc4122/version5.html).
+
+```twig
+{{ 'my_unique_id_value'|ems_uuid }} 
+```
+
 

--- a/elasticms-cli/src/Client/File/FileReaderImportConfig.php
+++ b/elasticms-cli/src/Client/File/FileReaderImportConfig.php
@@ -19,6 +19,7 @@ class FileReaderImportConfig
         public ?string $encoding = null,
         public array $excludeRows = [],
         public bool $generateHash = false,
+        public bool $generateOuuid = false,
         public ?string $ouuidExpression = "row['ouuid']",
         public ?string $ouuidPrefix = null,
     ) {
@@ -38,11 +39,13 @@ class FileReaderImportConfig
                 'encoding' => null,
                 'exclude_rows' => [],
                 'generate_hash' => false,
+                'generate_ouuid' => false,
                 'ouuid_expression' => 'row[\'ouuid\']',
                 'ouuid_prefix' => null,
             ])
             ->setAllowedTypes('delete_missing_documents', 'bool')
             ->setAllowedTypes('generate_hash', 'bool')
+            ->setAllowedTypes('generate_ouuid', 'bool')
             ->setAllowedTypes('ouuid_expression', ['string', 'null'])
             ->setAllowedTypes('ouuid_prefix', ['string', 'null'])
         ;
@@ -56,6 +59,7 @@ class FileReaderImportConfig
             encoding: $options['encoding'],
             excludeRows: $options['exclude_rows'],
             generateHash: $options['generate_hash'],
+            generateOuuid: $options['generate_ouuid'],
             ouuidExpression: $options['ouuid_expression'],
             ouuidPrefix: $options['ouuid_prefix'],
         );

--- a/elasticms-cli/src/Command/FileReader/FileReaderImportCommand.php
+++ b/elasticms-cli/src/Command/FileReader/FileReaderImportCommand.php
@@ -14,6 +14,7 @@ use EMS\CommonBundle\Search\Search;
 use EMS\CommonBundle\Storage\StorageManager;
 use EMS\Helpers\Standard\Hash;
 use EMS\Helpers\Standard\Json;
+use EMS\Helpers\Standard\UuidGenerator;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -167,6 +168,7 @@ final class FileReaderImportCommand extends AbstractCommand
         $prefix = $config->ouuidPrefix;
 
         return match (true) {
+            $config->generateOuuid => (string) UuidGenerator::fromValue(($prefix ?? '').$ouuid),
             null !== $prefix => Hash::string($prefix.$ouuid),
             $config->generateHash => Hash::string(\sprintf('FileReaderImport:%s:%s', $this->contentType, $ouuid)),
             default => $ouuid


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  n |
| New feature?   | y  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? |  y  |

Generate a UUID from a given value. Added support with new common twig filter 'ems_uuid', the function already exists and still useful for generating random uuids.
