### PR TITLE
fix(admin/revision): data not consumed error on publishing new version

### DIFF
--- a/EMS/core-bundle/src/Service/DataService.php
+++ b/EMS/core-bundle/src/Service/DataService.php
@@ -1266,7 +1266,7 @@ class DataService
     /**
      * @throws \Exception
      */
-    public function updateDataStructure(FieldType $meta, DataField $dataField, int $parentKey = 0): void
+    public function updateDataStructure(FieldType $meta, DataField $dataField): void
     {
         if (null === $fieldType = $dataField->getFieldType()) {
             return;
@@ -1283,7 +1283,7 @@ class DataService
             return;
         }
 
-        foreach ($meta->getChildren() as $key => $field) {
+        foreach ($meta->getChildren() as $field) {
             if ($field->getDeleted() || null !== $dataField->__get('ems_'.$field->getName())) {
                 continue;
             }
@@ -1293,7 +1293,7 @@ class DataService
                 $formFieldType = $this->formRegistry->getType($field->getType())->getInnerType();
                 $formMeta = $formFieldType->getReferredFieldType($field);
 
-                $this->updateDataStructure($formMeta, $dataField, $key);
+                $this->updateDataStructure($formMeta, $dataField);
                 continue;
             }
 
@@ -1301,7 +1301,7 @@ class DataService
             $child->setFieldType($field);
             $child->setOrderKey($field->getOrderKey());
             $child->setParent($dataField);
-            $dataField->addChild($child, $parentKey + $key);
+            $dataField->addChild($child);
 
             if (isset($field->getDisplayOptions()['defaultValue'])) {
                 $child->setEncodedText($field->getDisplayOptions()['defaultValue']);


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

The normal finalizeDraft is ignoring the data not consumed, but on publishing a new version we see the data not consumed error. Because the form fields are overwritten with fields added after the form.

This bug was created in:
https://github.com/ems-project/elasticms/pull/608
