### PR TITLE
fix(cli/command): file reader import generate version uuid

### DIFF
--- a/docs/elasticms-cli/commands.md
+++ b/docs/elasticms-cli/commands.md
@@ -104,6 +104,8 @@ php bin/console emscli:file-reader:import pages.csv page \
 * `ouuid_expression`: ?string (default="row['ouuid']")
   * Expression language apply to excel rows in order to identify the document by its ouuid. If equal to
     null new document will be created
+* `ouuid_version_expression`: ?string (default=null)
+  * Expression language apply to excel rows for generating a version uuid saved in `_version_uuid` 
 * `ouuid_prefix`: ?string (default=null)
   * The ouuid will prefix with this value before hashing
 

--- a/elasticms-cli/src/Client/File/FileReaderImportConfig.php
+++ b/elasticms-cli/src/Client/File/FileReaderImportConfig.php
@@ -21,6 +21,7 @@ class FileReaderImportConfig
         public bool $generateHash = false,
         public bool $generateOuuid = false,
         public ?string $ouuidExpression = "row['ouuid']",
+        public ?string $ouuidVersionExpression = null,
         public ?string $ouuidPrefix = null,
     ) {
     }
@@ -41,12 +42,14 @@ class FileReaderImportConfig
                 'generate_hash' => false,
                 'generate_ouuid' => false,
                 'ouuid_expression' => 'row[\'ouuid\']',
+                'ouuid_version_expression' => null,
                 'ouuid_prefix' => null,
             ])
             ->setAllowedTypes('delete_missing_documents', 'bool')
             ->setAllowedTypes('generate_hash', 'bool')
             ->setAllowedTypes('generate_ouuid', 'bool')
             ->setAllowedTypes('ouuid_expression', ['string', 'null'])
+            ->setAllowedTypes('ouuid_version_expression', ['string', 'null'])
             ->setAllowedTypes('ouuid_prefix', ['string', 'null'])
         ;
 
@@ -61,6 +64,7 @@ class FileReaderImportConfig
             generateHash: $options['generate_hash'],
             generateOuuid: $options['generate_ouuid'],
             ouuidExpression: $options['ouuid_expression'],
+            ouuidVersionExpression: $options['ouuid_version_expression'],
             ouuidPrefix: $options['ouuid_prefix'],
         );
     }

--- a/elasticms-cli/src/Command/FileReader/FileReaderImportCommand.php
+++ b/elasticms-cli/src/Command/FileReader/FileReaderImportCommand.php
@@ -103,11 +103,17 @@ final class FileReaderImportCommand extends AbstractCommand
             $count = 0;
             $queue = $coreApi->queue($this->flushSize)->addFlushCallback(fn () => $progressBar->advance());
 
-            foreach ($cells as $syncMetaData) {
-                $ouuid = $this->createOuuid($config, $syncMetaData);
+            foreach ($cells as $row) {
+                $ouuid = $this->createOuuid($config, $row);
 
                 $rawData = $config->defaultData;
-                $rawData['_sync_metadata'] = $syncMetaData;
+                $rawData['_sync_metadata'] = $row;
+
+                if (null !== $ouuidVersionExpression = $config->ouuidVersionExpression) {
+                    $rawData['_version_uuid'] = UuidGenerator::fromValue(
+                        value: $this->expressionLanguage->evaluate($ouuidVersionExpression, ['row' => $row])
+                    );
+                }
 
                 if ($ouuid) {
                     unset($ouuids[$ouuid]);


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | n  |
| New feature?   | y  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | y  |

On import we should be able to generate a version uuid from the config, just like the ouuid generation (expression).
