### PR TITLE
fix(admin/revision): no 'data_not_consumed' warning for private fields

### DIFF
--- a/EMS/core-bundle/src/Service/DataService.php
+++ b/EMS/core-bundle/src/Service/DataService.php
@@ -1370,12 +1370,13 @@ class DataService
         $this->updateDataStructure($revision->giveContentType()->getFieldType(), $data);
         $object = $revision->getRawData();
         $this->updateDataValue($data, $object);
-        unset($object[Mapping::CONTENT_TYPE_FIELD]);
-        unset($object[Mapping::HASH_FIELD]);
-        unset($object[Mapping::FINALIZED_BY_FIELD]);
-        unset($object[Mapping::FINALIZATION_DATETIME_FIELD]);
-        unset($object[Mapping::VERSION_TAG]);
-        unset($object[Mapping::VERSION_UUID]);
+
+        foreach (\array_keys($object) as $key) {
+            if (\is_string($key) && \str_starts_with($key, '_')) {
+                unset($object[$key]);
+            }
+        }
+
         if ($ignoreNotConsumed) {
             return;
         }


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Using the cli file importer, which creates a private field `_sync_data` the warning 'data not consumed' was in the logs.
But we can just unset all private fields before checking the data not consumed
