### PR TITLE
fix(admin/cli): reindex command doctrine paginate with bulkSize

### DIFF
--- a/EMS/core-bundle/src/Command/ReindexCommand.php
+++ b/EMS/core-bundle/src/Command/ReindexCommand.php
@@ -144,7 +144,7 @@ class ReindexCommand extends AbstractCommand
             $page = 0;
             $this->bulker->setSign($signData);
             $this->bulker->setSize($bulkSize);
-            $paginator = $revRepo->getRevisionsPaginatorPerEnvironmentAndContentType($environment, $contentType, $page);
+            $paginator = $revRepo->getRevisionsPaginatorPerEnvironmentAndContentType($environment, $contentType, $page, $bulkSize);
 
             $output->writeln('');
             $output->writeln('Start reindex '.$contentType->getName());
@@ -182,7 +182,7 @@ class ReindexCommand extends AbstractCommand
                 $em->clear();
 
                 ++$page;
-                $paginator = $revRepo->getRevisionsPaginatorPerEnvironmentAndContentType($environment, $contentType, $page);
+                $paginator = $revRepo->getRevisionsPaginatorPerEnvironmentAndContentType($environment, $contentType, $page, $bulkSize);
                 $iterator = $paginator->getIterator();
             } while ($iterator instanceof \ArrayIterator && $iterator->count());
             $this->bulker->send(true);

--- a/EMS/core-bundle/src/Repository/RevisionRepository.php
+++ b/EMS/core-bundle/src/Repository/RevisionRepository.php
@@ -199,14 +199,14 @@ class RevisionRepository extends EntityRepository
     /**
      * @return Paginator<Revision>
      */
-    public function getRevisionsPaginatorPerEnvironmentAndContentType(Environment $env, ContentType $contentType, int $page = 0): Paginator
+    public function getRevisionsPaginatorPerEnvironmentAndContentType(Environment $env, ContentType $contentType, int $page = 0, int $size = 50): Paginator
     {
         $qb = $this->createQueryBuilder('r');
         $qb->join('r.environments', 'e')
         ->where('e.id = :eid')
         ->andWhere('r.contentType = :ct')
-        ->setMaxResults(50)
-        ->setFirstResult($page * 50)
+        ->setMaxResults($size)
+        ->setFirstResult($page * $size)
         ->orderBy('r.id', 'asc')
         ->setParameters(['eid' => $env->getId(), 'ct' => $contentType]);
 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | n  |
| New feature?   |  n |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

The default blukSize is defined by %ems_core.default_bulk_size%.

For better performance doctrine should also use the bulkSize for pagination.
