### PR TITLE
refactor(web): routing and templating match the content type name

### DIFF
--- a/EMS/client-helper-bundle/src/Helper/Routing/RoutingFile.php
+++ b/EMS/client-helper-bundle/src/Helper/Routing/RoutingFile.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace EMS\ClientHelperBundle\Helper\Routing;
 
 use EMS\ClientHelperBundle\Helper\Templating\TemplateFiles;
+use EMS\ClientHelperBundle\Helper\Templating\TemplateName;
 use EMS\Helpers\Standard\Json;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Yaml\Yaml;
@@ -43,7 +44,7 @@ final class RoutingFile implements \Countable
         foreach ($documents as $document) {
             $data = $document->getDataSource();
             if (isset($data['template_static'])) {
-                $templateFile = $templateFiles->find($data['template_static']);
+                $templateFile = $templateFiles->find(new TemplateName($data['template_static']));
                 $data['template_static'] = $templateFile ? $templateFile->getPathName() : $data['template_static'];
             }
 
@@ -73,7 +74,7 @@ final class RoutingFile implements \Countable
 
         foreach ($this->routes as $name => $route) {
             if (isset($route['template_static'])) {
-                $template = $this->templateFiles->find($route['template_static']);
+                $template = $this->templateFiles->find(new TemplateName($route['template_static']));
                 if ($template) {
                     $route['template_static'] = $template->getPathOuuid();
                 }
@@ -100,7 +101,7 @@ final class RoutingFile implements \Countable
 
         foreach ($this->routes as $name => $data) {
             if (isset($data['template_static'])) {
-                $template = $this->templateFiles->find($data['template_static']);
+                $template = $this->templateFiles->find(new TemplateName($data['template_static']));
                 $data['template_static'] = $template ? $template->getPathName() : $data['template_static'];
             }
 

--- a/EMS/client-helper-bundle/src/Helper/Templating/TemplateBuilder.php
+++ b/EMS/client-helper-bundle/src/Helper/Templating/TemplateBuilder.php
@@ -33,7 +33,7 @@ final class TemplateBuilder extends AbstractBuilder
     {
         $settings = $this->settings($environment);
 
-        return $environment->getLocal()->getTemplates($settings)->getByTemplateName($templateName);
+        return $environment->getLocal()->getTemplates($settings)->get($templateName);
     }
 
     public function buildFiles(Environment $environment, string $directory): TemplateFiles
@@ -64,7 +64,7 @@ final class TemplateBuilder extends AbstractBuilder
         $settings = $this->clientRequest->getSettings($environment);
 
         if ($environment->isLocalPulled()) {
-            return $environment->getLocal()->getTemplates($settings)->getByTemplateName($templateName)->isFresh($time);
+            return $environment->getLocal()->getTemplates($settings)->get($templateName)->isFresh($time);
         }
 
         $contentType = $settings->getTemplateContentType($templateName->getContentType());

--- a/EMS/client-helper-bundle/src/Helper/Templating/TemplateFiles.php
+++ b/EMS/client-helper-bundle/src/Helper/Templating/TemplateFiles.php
@@ -61,26 +61,26 @@ final class TemplateFiles implements \IteratorAggregate, \Countable
         return new \ArrayIterator($this->templateFiles);
     }
 
-    public function get(string $search): TemplateFile
+    public function get(TemplateName $templateName): TemplateFile
     {
-        if (null === $template = $this->find($search)) {
-            throw new \RuntimeException(\sprintf('Could not find template "%s"', $search));
+        if (null === $template = $this->find($templateName)) {
+            throw new \RuntimeException(\sprintf('Could not find template "%s"', $templateName->getSearchName()));
         }
 
         return $template;
     }
 
-    public function getByTemplateName(TemplateName $templateName): TemplateFile
-    {
-        return $this->get($templateName->getSearchName());
-    }
-
-    public function find(string $search): ?TemplateFile
+    public function find(TemplateName $templateName): ?TemplateFile
     {
         foreach ($this->templateFiles as $templateFile) {
-            if ($search === $templateFile->getPathOuuid() || $search === $templateFile->getPathName()) {
-                return $templateFile;
+            if ($templateFile->getContentTypeName() !== $templateName->getContentType()) {
+                continue;
             }
+            if ($templateName->getSearchName() !== $templateFile->getPathOuuid() && $templateName->getSearchName() !== $templateFile->getPathName()) {
+                continue;
+            }
+
+            return $templateFile;
         }
 
         return null;

--- a/EMS/client-helper-bundle/src/Helper/Templating/TemplateName.php
+++ b/EMS/client-helper-bundle/src/Helper/Templating/TemplateName.php
@@ -57,6 +57,9 @@ final class TemplateName
      */
     private function match(string $name): array
     {
+        if ('@' !== \substr($name, 0, 1)) {
+            $name = "@EMSCH/$name";
+        }
         \preg_match(self::REGEX_MATCH_OUUID, $name, $matchOuuid);
 
         if ($matchOuuid) {


### PR DESCRIPTION

| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  |  n |
| Fixed tickets? | n  |
| Documentation? | n  |

also match the content type name not only the template filename or ouuid
