### PR TITLE
fix(admin/cli): activate content type command fix configure

### DIFF
--- a/EMS/core-bundle/src/Command/ActivateContentTypeCommand.php
+++ b/EMS/core-bundle/src/Command/ActivateContentTypeCommand.php
@@ -35,18 +35,17 @@ class ActivateContentTypeCommand extends Command
     protected function configure(): void
     {
         parent::configure();
-        $fileNames = \implode(', ', $this->contentTypeService->getAllNames());
         $this
             ->addArgument(
                 self::ARGUMENT_CONTENTTYPES,
                 InputArgument::IS_ARRAY,
-                \sprintf('Optional array of contenttypes to create. Allowed values: [%s]', $fileNames)
+                \sprintf('Optional array of contenttypes to create')
             )
             ->addOption(
                 self::OPTION_ALL,
                 null,
                 InputOption::VALUE_NONE,
-                \sprintf('Make all contenttypes: [%s]', $fileNames)
+                \sprintf('Make all contenttypes')
             )
             ->addOption(
                 self::DEACTIVATE,


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   |  n |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Calling the contentTypeService inside the configure is not good. This means we can not run the console without a db connection. It's like calling the service directly in the constructor. The execute is already checking if the passed contentType names are valid.