### PR TITLE
fix(common/storage): If 404 the file is missing (otherwise throws an error) in HTTP storage service

### DIFF
--- a/EMS/common-bundle/src/Storage/Service/HttpStorage.php
+++ b/EMS/common-bundle/src/Storage/Service/HttpStorage.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
 use Psr\Http\Message\StreamInterface;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class HttpStorage extends AbstractUrlStorage
@@ -124,9 +125,12 @@ class HttpStorage extends AbstractUrlStorage
     public function head(string $hash): bool
     {
         try {
-            return 200 === $this->getClient()->head($this->getUrl.$hash)->getStatusCode();
-        } catch (\Throwable) {
-            throw new NotFoundHttpException($hash);
+            return Response::HTTP_OK === $this->getClient()->head($this->getUrl.$hash)->getStatusCode();
+        } catch (\Throwable $e) {
+            if (Response::HTTP_NOT_FOUND === $e->getCode()) {
+                return false;
+            }
+            throw $e;
         }
     }
 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  |  n |
| Fixed tickets? |  n |
| Documentation? | n  |
