### PR TITLE
feat(cli): enable symfony debug bundle in dev mode

### DIFF
--- a/elasticms-cli/config/bundles.php
+++ b/elasticms-cli/config/bundles.php
@@ -7,4 +7,5 @@ return [
     EMS\CommonBundle\EMSCommonBundle::class => ['all' => true],
     Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle::class => ['all' => true],
     Twig\Extra\TwigExtraBundle\TwigExtraBundle::class => ['all' => true],
+    Symfony\Bundle\DebugBundle\DebugBundle::class => ['dev' => true, 'test' => true],
 ];

--- a/elasticms-cli/config/packages/debug.yaml
+++ b/elasticms-cli/config/packages/debug.yaml
@@ -1,0 +1,5 @@
+when@dev:
+    debug:
+        # Forwards VarDumper Data clones to a centralized server allowing to inspect dumps on CLI or in your browser.
+        # See the "server:dump" command to start a new server.
+        dump_destination: "tcp://%env(VAR_DUMPER_SERVER)%"

--- a/elasticms-cli/symfony.lock
+++ b/elasticms-cli/symfony.lock
@@ -343,6 +343,9 @@
     "symfony/css-selector": {
         "version": "v5.4.3"
     },
+    "symfony/debug-bundle": {
+        "version": "v5.4.45"
+    },
     "symfony/dependency-injection": {
         "version": "v5.4.3"
     },


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  n |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Just like the web & admin, it is useful to have the var_dumper_server in cli app
