### PR TITLE
fix(common/helper): the mimetype guesser is not good at recognize text  file

### DIFF
--- a/EMS/common-bundle/src/Helper/MimeTypeHelper.php
+++ b/EMS/common-bundle/src/Helper/MimeTypeHelper.php
@@ -30,7 +30,7 @@ class MimeTypeHelper
     public function guessMimeType(string $filename): string
     {
         $mimeType = $this->mimeTypes->guessMimeType($filename);
-        if (\str_starts_with($mimeType, 'text/')) {
+        if (\str_starts_with($mimeType ?? '', 'text/')) {
             $ext = \pathinfo($filename, PATHINFO_EXTENSION);
             $mimeType = $this->mimeTypes->getMimeTypes($ext)[0] ?? $mimeType;
         }

--- a/EMS/common-bundle/src/Helper/MimeTypeHelper.php
+++ b/EMS/common-bundle/src/Helper/MimeTypeHelper.php
@@ -30,7 +30,7 @@ class MimeTypeHelper
     public function guessMimeType(string $filename): string
     {
         $mimeType = $this->mimeTypes->guessMimeType($filename);
-        if (self::TEXT_PLAIN === $mimeType) {
+        if (\str_starts_with($mimeType, 'text/')) {
             $ext = \pathinfo($filename, PATHINFO_EXTENSION);
             $mimeType = $this->mimeTypes->getMimeTypes($ext)[0] ?? $mimeType;
         }


### PR DESCRIPTION


| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? |  n |
| Documentation? | n  |

it's better to use the file extension to recognise the mime-type of a text file
