### PR TITLE
feat(admin/submission): add export command filter by expression

### DIFF
--- a/EMS/common-bundle/src/Contracts/SpreadsheetGeneratorServiceInterface.php
+++ b/EMS/common-bundle/src/Contracts/SpreadsheetGeneratorServiceInterface.php
@@ -12,6 +12,7 @@ interface SpreadsheetGeneratorServiceInterface
     public const WRITER = 'writer';
     public const XLSX_WRITER = 'xlsx';
     public const CSV_WRITER = 'csv';
+    public const FORMAT_WRITERS = [self::CSV_WRITER, self::XLSX_WRITER];
     public const CSV_SEPARATOR = 'csv_separator';
     public const SHEETS = 'sheets';
     public const CONTENT_FILENAME = 'filename';

--- a/EMS/core-bundle/src/Command/Submission/ExportCommand.php
+++ b/EMS/core-bundle/src/Command/Submission/ExportCommand.php
@@ -3,6 +3,7 @@
 namespace EMS\CoreBundle\Command\Submission;
 
 use EMS\CommonBundle\Common\Command\AbstractCommand;
+use EMS\CommonBundle\Contracts\SpreadsheetGeneratorServiceInterface;
 use EMS\CommonBundle\Service\ExpressionService;
 use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Service\Form\Submission\FormSubmissionService;
@@ -16,12 +17,17 @@ class ExportCommand extends AbstractCommand
     protected static $defaultName = Commands::SUBMISSION_EXPORT;
     public const ARG_FIELDS = 'fields';
     public const OPTIONS_FILTER = 'filter';
+    public const OPTIONS_FORMAT = 'format';
     /** @var string[] */
     private array $fields;
     private ?string $filter;
+    private string  $format;
 
-    public function __construct(private readonly FormSubmissionService $formSubmissionService, private readonly ExpressionService $expressionService)
-    {
+    public function __construct(
+        private readonly FormSubmissionService $formSubmissionService,
+        private readonly ExpressionService $expressionService,
+        private readonly SpreadsheetGeneratorServiceInterface $spreadsheetGeneratorService,
+    ) {
         parent::__construct();
     }
 
@@ -35,9 +41,15 @@ class ExportCommand extends AbstractCommand
                 'Fields to export'
             )->addOption(
                 self::OPTIONS_FILTER,
-                'f',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 'Expression to filter submissions'
+            )->addOption(
+                self::OPTIONS_FORMAT,
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'File format of the export, xlsx or csv are supported',
+                'xlsx'
             );
     }
 
@@ -46,11 +58,13 @@ class ExportCommand extends AbstractCommand
         parent::initialize($input, $output);
         $this->fields = $this->getArgumentStringArray(self::ARG_FIELDS);
         $this->filter = $this->getOptionStringNull(self::OPTIONS_FILTER);
+        $this->format = $this->getOptionString(self::OPTIONS_FORMAT);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->io->section('Export the form submissions');
+        $sheet = [[...$this->fields]];
 
         foreach ($this->formSubmissionService->getUnprocessed() as $submission) {
             $data = \array_merge([
@@ -62,10 +76,22 @@ class ExportCommand extends AbstractCommand
             if (null !== $this->filter && !$this->expressionService->evaluateToBool($this->filter, $data)) {
                 continue;
             }
+            $line = [];
             foreach ($this->fields as $field) {
-                echo $data[$field] ?? '';
+                $line[] = $data[$field] ?? '';
             }
+            $sheet[] = $line;
         }
+
+        $config = [
+            SpreadsheetGeneratorServiceInterface::SHEETS => [[
+                'rows' => $sheet,
+                'name' => 'submissions',
+            ]],
+            SpreadsheetGeneratorServiceInterface::CONTENT_FILENAME => 'submissions',
+            SpreadsheetGeneratorServiceInterface::WRITER => $this->format,
+        ];
+        $this->spreadsheetGeneratorService->generateSpreadsheetFile($config, 'submission.xlsx');
 
         return self::EXECUTE_SUCCESS;
     }

--- a/EMS/core-bundle/src/Command/Submission/ExportCommand.php
+++ b/EMS/core-bundle/src/Command/Submission/ExportCommand.php
@@ -44,7 +44,7 @@ class ExportCommand extends AbstractCommand
                 self::OPTION_FILTER,
                 null,
                 InputOption::VALUE_OPTIONAL,
-                'Expression to filter submissions, e.g. "\'true\' == (data[\'recontact-optin\'] ?? \'false\')"'
+                'Expression to filter submissions, e.g. "\'true\' == (data[\'recontact-optin\'] ?? \'false\')". The following variables are available: data (array), instance (string), name (string), locale (string), submission_date (date in the ISO 8601 format)'
             )->addOption(
                 self::OPTION_FILENAME,
                 null,

--- a/EMS/core-bundle/src/Command/Submission/ExportCommand.php
+++ b/EMS/core-bundle/src/Command/Submission/ExportCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EMS\CoreBundle\Command\Submission;
 
 use EMS\CommonBundle\Common\Command\AbstractCommand;

--- a/EMS/core-bundle/src/Command/Submission/ExportCommand.php
+++ b/EMS/core-bundle/src/Command/Submission/ExportCommand.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace EMS\CoreBundle\Command\Submission;
+
+use EMS\CommonBundle\Common\Command\AbstractCommand;
+use EMS\CommonBundle\Service\ExpressionService;
+use EMS\CoreBundle\Commands;
+use EMS\CoreBundle\Service\Form\Submission\FormSubmissionService;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ExportCommand extends AbstractCommand
+{
+    protected static $defaultName = Commands::SUBMISSION_EXPORT;
+    public const ARG_FIELDS = 'fields';
+    public const OPTIONS_FILTER = 'filter';
+    /** @var string[] */
+    private array $fields;
+    private ?string $filter;
+
+    public function __construct(private readonly FormSubmissionService $formSubmissionService, private readonly ExpressionService $expressionService)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setDescription('Extract form submissions')
+            ->addArgument(
+                self::ARG_FIELDS,
+                InputArgument::IS_ARRAY,
+                'Fields to export'
+            )->addOption(
+                self::OPTIONS_FILTER,
+                'f',
+                InputOption::VALUE_OPTIONAL,
+                'Expression to filter submissions'
+            );
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output): void
+    {
+        parent::initialize($input, $output);
+        $this->fields = $this->getArgumentStringArray(self::ARG_FIELDS);
+        $this->filter = $this->getOptionStringNull(self::OPTIONS_FILTER);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->io->section('Export the form submissions');
+
+        foreach ($this->formSubmissionService->getUnprocessed() as $submission) {
+            $data = \array_merge([
+                'instance' => $submission->getInstance(),
+                'name' => $submission->getName(),
+                'locale' => $submission->getLocale(),
+                'submission_date' => $submission->getCreated()->format('c'),
+            ], $submission->getData() ?? []);
+            if (null !== $this->filter && !$this->expressionService->evaluateToBool($this->filter, $data)) {
+                continue;
+            }
+            foreach ($this->fields as $field) {
+                echo $data[$field] ?? '';
+            }
+        }
+
+        return self::EXECUTE_SUCCESS;
+    }
+}

--- a/EMS/core-bundle/src/Command/Submission/ExportCommand.php
+++ b/EMS/core-bundle/src/Command/Submission/ExportCommand.php
@@ -16,12 +16,13 @@ class ExportCommand extends AbstractCommand
 {
     protected static $defaultName = Commands::SUBMISSION_EXPORT;
     public const ARG_FIELDS = 'fields';
-    public const OPTIONS_FILTER = 'filter';
-    public const OPTIONS_FORMAT = 'format';
+    public const OPTION_FILTER = 'filter';
+    public const OPTION_FILENAME = 'filename';
+
     /** @var string[] */
     private array $fields;
     private ?string $filter;
-    private string  $format;
+    private ?string  $filename;
 
     public function __construct(
         private readonly FormSubmissionService $formSubmissionService,
@@ -40,16 +41,15 @@ class ExportCommand extends AbstractCommand
                 InputArgument::IS_ARRAY,
                 'Fields to export'
             )->addOption(
-                self::OPTIONS_FILTER,
+                self::OPTION_FILTER,
                 null,
                 InputOption::VALUE_OPTIONAL,
                 'Expression to filter submissions'
             )->addOption(
-                self::OPTIONS_FORMAT,
+                self::OPTION_FILENAME,
                 null,
                 InputOption::VALUE_OPTIONAL,
-                'File format of the export, xlsx or csv are supported',
-                'xlsx'
+                'Export filename, xlsx or csv formats are supported',
             );
     }
 
@@ -57,14 +57,14 @@ class ExportCommand extends AbstractCommand
     {
         parent::initialize($input, $output);
         $this->fields = $this->getArgumentStringArray(self::ARG_FIELDS);
-        $this->filter = $this->getOptionStringNull(self::OPTIONS_FILTER);
-        $this->format = $this->getOptionString(self::OPTIONS_FORMAT);
+        $this->filter = $this->getOptionStringNull(self::OPTION_FILTER);
+        $this->filename = $this->getOptionStringNull(self::OPTION_FILENAME);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->io->section('Export the form submissions');
-        $sheet = [[...$this->fields]];
+        $sheet = [];
 
         foreach ($this->formSubmissionService->getUnprocessed() as $submission) {
             $data = \array_merge([
@@ -83,15 +83,27 @@ class ExportCommand extends AbstractCommand
             $sheet[] = $line;
         }
 
+        if (null === $this->filename) {
+            $this->io->table([...$this->fields], $sheet);
+
+            return self::EXECUTE_SUCCESS;
+        }
+
+        $extension = \pathinfo($this->filename)['extension'] ?? '';
+        if (!\in_array($extension, SpreadsheetGeneratorServiceInterface::FORMAT_WRITERS)) {
+            $this->io->error(\sprintf('File format %s is not supported', $extension));
+        }
+
         $config = [
             SpreadsheetGeneratorServiceInterface::SHEETS => [[
-                'rows' => $sheet,
+                'rows' => [[...$this->fields], ...$sheet],
                 'name' => 'submissions',
             ]],
             SpreadsheetGeneratorServiceInterface::CONTENT_FILENAME => 'submissions',
-            SpreadsheetGeneratorServiceInterface::WRITER => $this->format,
+            SpreadsheetGeneratorServiceInterface::WRITER => $extension,
         ];
-        $this->spreadsheetGeneratorService->generateSpreadsheetFile($config, 'submission.xlsx');
+        $this->spreadsheetGeneratorService->generateSpreadsheetFile($config, $this->filename);
+        $this->io->success(\sprintf('The file %s has been successfully generated', $this->filename));
 
         return self::EXECUTE_SUCCESS;
     }

--- a/EMS/core-bundle/src/Command/Submission/ExportCommand.php
+++ b/EMS/core-bundle/src/Command/Submission/ExportCommand.php
@@ -44,7 +44,7 @@ class ExportCommand extends AbstractCommand
                 self::OPTION_FILTER,
                 null,
                 InputOption::VALUE_OPTIONAL,
-                'Expression to filter submissions'
+                'Expression to filter submissions, e.g. "locale==\'en\'"'
             )->addOption(
                 self::OPTION_FILENAME,
                 null,

--- a/EMS/core-bundle/src/Command/Submission/ExportCommand.php
+++ b/EMS/core-bundle/src/Command/Submission/ExportCommand.php
@@ -44,7 +44,7 @@ class ExportCommand extends AbstractCommand
                 self::OPTION_FILTER,
                 null,
                 InputOption::VALUE_OPTIONAL,
-                'Expression to filter submissions, e.g. "locale==\'en\'"'
+                'Expression to filter submissions, e.g. "\'true\' == (data[\'recontact-optin\'] ?? \'false\')"'
             )->addOption(
                 self::OPTION_FILENAME,
                 null,
@@ -68,19 +68,20 @@ class ExportCommand extends AbstractCommand
 
         $this->io->progressStart($this->formSubmissionService->count());
         foreach ($this->formSubmissionService->getUnprocessed() as $submission) {
-            $data = \array_merge([
+            $data = [
                 'instance' => $submission->getInstance(),
                 'name' => $submission->getName(),
                 'locale' => $submission->getLocale(),
                 'submission_date' => $submission->getCreated()->format('c'),
-            ], $submission->getData() ?? []);
+                'data' => $submission->getData() ?? [],
+            ];
             if (null !== $this->filter && !$this->expressionService->evaluateToBool($this->filter, $data)) {
                 $this->io->progressAdvance();
                 continue;
             }
             $line = [];
             foreach ($this->fields as $field) {
-                $line[] = $data[$field] ?? '';
+                $line[] = $data['data'][$field] ?? $data[$field] ?? '';
             }
             $sheet[] = $line;
             $this->io->progressAdvance();

--- a/EMS/core-bundle/src/Command/Submission/ExportCommand.php
+++ b/EMS/core-bundle/src/Command/Submission/ExportCommand.php
@@ -66,6 +66,7 @@ class ExportCommand extends AbstractCommand
         $this->io->section('Export the form submissions');
         $sheet = [];
 
+        $this->io->progressStart($this->formSubmissionService->count());
         foreach ($this->formSubmissionService->getUnprocessed() as $submission) {
             $data = \array_merge([
                 'instance' => $submission->getInstance(),
@@ -74,6 +75,7 @@ class ExportCommand extends AbstractCommand
                 'submission_date' => $submission->getCreated()->format('c'),
             ], $submission->getData() ?? []);
             if (null !== $this->filter && !$this->expressionService->evaluateToBool($this->filter, $data)) {
+                $this->io->progressAdvance();
                 continue;
             }
             $line = [];
@@ -81,7 +83,9 @@ class ExportCommand extends AbstractCommand
                 $line[] = $data[$field] ?? '';
             }
             $sheet[] = $line;
+            $this->io->progressAdvance();
         }
+        $this->io->progressFinish();
 
         if (null === $this->filename) {
             $this->io->table([...$this->fields], $sheet);

--- a/EMS/core-bundle/src/Commands.php
+++ b/EMS/core-bundle/src/Commands.php
@@ -43,4 +43,5 @@ final class Commands
     public const MANAGED_ALIAS_ADD_ENVIRONMENT = 'emsco:managed-alias:add-environment';
     public const ASSET_REFRESH_FILE_FIELD = 'emsco:asset:refresh-file-fields';
     final public const SUBMISSION_FORWARD = 'emsco:submissions:forward';
+    final public const SUBMISSION_EXPORT = 'emsco:submissions:export';
 }

--- a/EMS/core-bundle/src/Repository/FormSubmissionRepository.php
+++ b/EMS/core-bundle/src/Repository/FormSubmissionRepository.php
@@ -57,7 +57,7 @@ class FormSubmissionRepository extends ServiceEntityRepository
             ->andWhere($qb->expr()->isNotNull('fs.data'))
             ->orderBy('fs.created', 'desc');
 
-        return $qb->getQuery()->getArrayResult();
+        return $qb->getQuery()->execute();
     }
 
     public function countAllUnprocessed(string $searchValue): int
@@ -105,7 +105,7 @@ class FormSubmissionRepository extends ServiceEntityRepository
             ->andWhere($qb->expr()->isNotNull('fs.data'))
             ->orderBy('fs.created', 'desc');
 
-        return $qb->getQuery()->getArrayResult();
+        return $qb->getQuery()->execute();
     }
 
     public function persist(FormSubmission $formSubmission): void

--- a/EMS/core-bundle/src/Resources/config/command.xml
+++ b/EMS/core-bundle/src/Resources/config/command.xml
@@ -260,6 +260,11 @@
             <argument type="service" id="ems.form_submission"/>
             <tag name="console.command"/>
         </service>
+        <service id="ems.submission.export" class="EMS\CoreBundle\Command\Submission\ExportCommand">
+            <argument type="service" id="ems.form_submission"/>
+            <argument type="service" id="ems_common.service.expression_service"/>
+            <tag name="console.command"/>
+        </service>
         <service id="ems.environment.updatemetafield" class="EMS\CoreBundle\Command\UpdateMetaFieldCommand">
             <argument type="service" id="doctrine"/>
             <argument type="service" id="logger"/>

--- a/EMS/core-bundle/src/Resources/config/command.xml
+++ b/EMS/core-bundle/src/Resources/config/command.xml
@@ -263,6 +263,7 @@
         <service id="ems.submission.export" class="EMS\CoreBundle\Command\Submission\ExportCommand">
             <argument type="service" id="ems.form_submission"/>
             <argument type="service" id="ems_common.service.expression_service"/>
+            <argument type="service" id="EMS\CommonBundle\Contracts\SpreadsheetGeneratorServiceInterface"/>
             <tag name="console.command"/>
         </service>
         <service id="ems.environment.updatemetafield" class="EMS\CoreBundle\Command\UpdateMetaFieldCommand">


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   |  y |
| BC breaks?     |  n |
| Deprecations?  |  n |
| Fixed tickets? |  n |
| Documentation? | n  |

As discussed you simply list the fields you want. And you can filter submission with a expression language.

I was thinking about storing the export file in the storage manager. but those exports are really what we do not want in our storage services.

Maybe we need a user personal, or a session, storage service for the admin-bundle? But what about the CLI then? A volatile storage service? With a password?