### PR TITLE
fix(admin/revision): restore trash locked exception

### DIFF
--- a/EMS/core-bundle/src/Service/DataService.php
+++ b/EMS/core-bundle/src/Service/DataService.php
@@ -1255,6 +1255,8 @@ class DataService
                 $this->lockRevision($revision);
                 $revision->setDraft(true);
                 $this->auditLogger->notice('log.revision.restored', LogRevisionContext::update($revision));
+            } else {
+                $revision->enableSelfUpdate();
             }
             $this->em->persist($revision);
         }


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Restoring a deleted revision throws a not locked exception. This only happens if the revision has also older revisions. Because for the current revision we call the lock before restoring it as a draft.
