### PR TITLE
feat(admin/environment): cli align unpublish not published documents

### DIFF
--- a/EMS/core-bundle/src/Command/Environment/AlignCommand.php
+++ b/EMS/core-bundle/src/Command/Environment/AlignCommand.php
@@ -62,6 +62,7 @@ class AlignCommand extends AbstractEnvironmentCommand
 
         $this->initializeRevisionSearcher(self::LOCK_USER);
         $this->publicationTemplate = $this->getOptionBool(self::OPTION_PUBLICATION_TEMPLATE);
+        $this->publishService->bulkStart($this->revisionSearcher->getSize(), $this->logger);
     }
 
     protected function interact(InputInterface $input, OutputInterface $output): void
@@ -77,9 +78,7 @@ class AlignCommand extends AbstractEnvironmentCommand
         }
 
         $search = $this->revisionSearcher->create($this->source, $this->searchQuery);
-        $bulkSize = $this->revisionSearcher->getSize();
-
-        $this->io->note(\sprintf('The source environment contains %s elements, start aligning environments...', $search->getTotal()));
+        $this->io->section(\sprintf('The source environment contains %s elements, start aligning environments...', $search->getTotal()));
 
         if ($this->dryRun) {
             $this->io->success('Dry run finished');
@@ -88,14 +87,15 @@ class AlignCommand extends AbstractEnvironmentCommand
         }
 
         $targetIsPreviewEnvironment = [];
+        $ouuids = [];
 
         $this->io->progressStart($search->getTotal());
         foreach ($this->revisionSearcher->search($this->source, $search) as $revisions) {
             $this->revisionSearcher->lock($revisions, $this->lockUser);
-            $this->publishService->bulkStart($bulkSize, $this->logger);
 
             foreach ($revisions->transaction() as $revision) {
                 $contentType = $revision->giveContentType();
+                $ouuids[] = $revision->giveOuuid();
 
                 if ($revision->getDeleted()) {
                     ++$this->counters['deleted'];
@@ -112,10 +112,12 @@ class AlignCommand extends AbstractEnvironmentCommand
                 $this->io->progressAdvance();
             }
 
-            $this->publishService->bulkFinished();
             $this->revisionSearcher->unlock($revisions);
         }
+        $this->publishService->bulkFinished();
         $this->io->progressFinish();
+
+        $this->unpublishNotAligned(...$ouuids);
 
         $this->environmentService->clearCache();
 
@@ -161,5 +163,41 @@ class AlignCommand extends AbstractEnvironmentCommand
         ]));
 
         return self::EXECUTE_SUCCESS;
+    }
+
+    private function unpublishNotAligned(string ...$ouuids): void
+    {
+        $this->io->section(\sprintf('Unpublish not aligned documents from "%s"', $this->target->getName()));
+        $countUnpublished = 0;
+
+        $targetSearch = $this->revisionSearcher->create($this->target, $this->searchQuery);
+        $this->io->progressStart($targetSearch->getTotal());
+
+        foreach ($this->revisionSearcher->search($this->target, $targetSearch) as $revisions) {
+            $this->revisionSearcher->lock($revisions, $this->lockUser);
+
+            foreach ($revisions->transaction() as $revision) {
+                $this->io->progressAdvance();
+
+                if (\in_array($revision->getOuuid(), $ouuids, true)) {
+                    continue;
+                }
+
+                if ($revision->giveContentType()->giveEnvironment() === $this->target) {
+                    $this->io->warning(\sprintf('Could not unpublish the document %s, target is default environment', $revision->getEmsLink()));
+                    continue;
+                }
+
+                $this->publishService->bulkUnpublish($revision, $this->target);
+                ++$countUnpublished;
+            }
+
+            $this->revisionSearcher->unlock($revisions);
+        }
+
+        $this->publishService->bulkFinished();
+        $this->io->progressFinish();
+
+        $this->io->note(\sprintf('Unpublished %d documents from "%s"', $countUnpublished, $this->target->getName()));
     }
 }

--- a/EMS/core-bundle/src/Service/PublishService.php
+++ b/EMS/core-bundle/src/Service/PublishService.php
@@ -161,10 +161,6 @@ class PublishService
             throw new \LogicException('Unpublish failed: is default environment');
         }
 
-        if (1 === $this->environmentService->getPublishedForRevision($revision)->count()) {
-            throw new \LogicException('Unpublish failed: requires 1 environment');
-        }
-
         $revision->getEnvironments()->removeElement($environment);
         $this->bulker->delete($environment->getAlias(), $revision->giveOuuid());
     }

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -13,6 +13,10 @@
   * [version 4.x](#version-4x)
   * [Tips and tricks](#tips-and-tricks)
 
+## version 5.25.x
+
+- The `emsco:environment:align` will after publication also unpublish documents that are not aligned.
+
 ## version 5.23.x
 
 From this version, the upload of web's assets via the command `emsch:local:upload-assets` wont upload a zip anymore but each assets independently.


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | y  |
| BC breaks?     |  y |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Archived revisions (not published in default environment), should be unpublished when aligning.

In the feature we should also clean 'hanging' revisions: https://github.com/ems-project/elasticms/issues/1088
> Hanging revisions -> revisions without any environment
