### PR TITLE
fix(cli/file-reader): import miss formated excel

### DIFF
--- a/elasticms-cli/src/Command/FileReader/FileReaderImportCommand.php
+++ b/elasticms-cli/src/Command/FileReader/FileReaderImportCommand.php
@@ -107,6 +107,9 @@ final class FileReaderImportCommand extends AbstractCommand
             $row = [];
             $empty = true;
             foreach ($rowValues as $cellKey => $cell) {
+                if (null === ($header[$cellKey] ?? null) && null === $cell) {
+                    continue;
+                }
                 $row[$header[$cellKey] ?? $cellKey] = $cell;
                 $empty = $empty && (null === $cell);
             }

--- a/elasticms-cli/src/Command/FileReader/FileReaderImportCommand.php
+++ b/elasticms-cli/src/Command/FileReader/FileReaderImportCommand.php
@@ -84,7 +84,7 @@ final class FileReaderImportCommand extends AbstractCommand
 
         $expressionLanguage = new ExpressionLanguage();
         $rows = $this->fileReader->getData($file, false, $this->encoding);
-        $header = \array_map('trim', $rows[0] ?? []);
+        $header = \array_filter(\array_map('trim', $rows[0] ?? []));
 
         $ouuids = [];
         if ($this->deleteMissingDocuments) {


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Time to time we may have kind of ghost columns or ghost row. The file parse see something but everything is empty