### PR TITLE
fix(cli/file-reader): get file from api

### DIFF
--- a/EMS/common-bundle/src/Common/File/FileReader.php
+++ b/EMS/common-bundle/src/Common/File/FileReader.php
@@ -66,7 +66,7 @@ final class FileReader implements FileReaderInterface
             }
 
             if (!$headings) {
-                $headings = \array_map(static fn ($v) => u($v)->trim()->toString(), $row);
+                $headings = \array_map(static fn ($v, $k) => ('' === u($v)->trim()->toString()) ? \strval($k) : u($v)->trim()->toString(), $row, \array_keys($row));
                 continue;
             }
 

--- a/EMS/common-bundle/src/Common/File/FileReader.php
+++ b/EMS/common-bundle/src/Common/File/FileReader.php
@@ -75,7 +75,7 @@ final class FileReader implements FileReaderInterface
                 continue;
             }
 
-            $rowData = \array_filter(\array_combine($headings, $row), static fn ($v) => '' !== $v and null !== $v);
+            $rowData = \array_filter(\array_combine($headings, $row), static fn ($v) => '' !== $v && null !== $v);
             if (\count($rowData) > 0) {
                 yield $rowData;
             }

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -13,6 +13,17 @@
   * [version 4.x](#version-4x)
   * [Tips and tricks](#tips-and-tricks)
 
+## version 5.24.x
+
+There is breaking changes in the options of the [File Reader Import](elasticms-cli/commands?id=file-reader) command. 
+Command's options must be defined in a json format now, and that JSON can be passed to the `--config` option as:
+ * a JSON string
+ * a path to a JSON file
+ * the hash of a JSON file in the storage services
+
+Please update your worker's jobs.
+
+
 ## version 5.23.x
 
 From this version, the upload of web's assets via the command `emsch:local:upload-assets` wont upload a zip anymore but each assets independently.


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? |  n |
| Documentation? | y  |

The file import must be able to retrieve the file to import from the API itself
