### PR TITLE
fix(cli/file-reader): not found config fallback get config from api

### DIFF
--- a/EMS/common-bundle/src/Common/CoreApi/Endpoint/File/File.php
+++ b/EMS/common-bundle/src/Common/CoreApi/Endpoint/File/File.php
@@ -9,6 +9,7 @@ use EMS\CommonBundle\Common\CoreApi\Client;
 use EMS\CommonBundle\Common\CoreApi\Endpoint\Admin\Admin;
 use EMS\CommonBundle\Contracts\CoreApi\Endpoint\File\FileInterface;
 use EMS\CommonBundle\Storage\Archive;
+use EMS\CommonBundle\Storage\File\FileInterface as StorageFileInterface;
 use EMS\CommonBundle\Storage\File\StorageFile;
 use EMS\CommonBundle\Storage\Service\HttpStorage;
 use EMS\CommonBundle\Storage\StorageManager;
@@ -213,5 +214,10 @@ final class File implements FileInterface
         $admin = new Admin($this->client);
         $command = \sprintf('%s %s', Commands::LOAD_ARCHIVE_IN_CACHE, $archiveHash);
         $admin->runCommand($command);
+    }
+
+    public function getFile(string $hash): StorageFileInterface
+    {
+        return new StorageFile($this->getStream($hash));
     }
 }

--- a/EMS/common-bundle/src/Contracts/File/FileManagerInterface.php
+++ b/EMS/common-bundle/src/Contracts/File/FileManagerInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace EMS\CommonBundle\Contracts\File;
 
 use EMS\CommonBundle\Storage\Archive;
+use EMS\CommonBundle\Storage\File\FileInterface;
 use Psr\Http\Message\StreamInterface;
 
 interface FileManagerInterface
@@ -12,6 +13,8 @@ interface FileManagerInterface
     public const HEADS_CHUNK_SIZE = 256;
 
     public function downloadFile(string $hash): string;
+
+    public function getFile(string $hash): FileInterface;
 
     public function getContents(string $hash): string;
 

--- a/elasticms-cli/src/Command/FileReader/FileReaderImportCommand.php
+++ b/elasticms-cli/src/Command/FileReader/FileReaderImportCommand.php
@@ -11,6 +11,7 @@ use EMS\CommonBundle\Common\Command\AbstractCommand;
 use EMS\CommonBundle\Contracts\CoreApi\Endpoint\Data\DataInterface;
 use EMS\CommonBundle\Contracts\File\FileReaderInterface;
 use EMS\CommonBundle\Search\Search;
+use EMS\CommonBundle\Storage\File\FileInterface;
 use EMS\CommonBundle\Storage\NotFoundException;
 use EMS\CommonBundle\Storage\StorageManager;
 use EMS\Helpers\Standard\Hash;
@@ -88,14 +89,9 @@ final class FileReaderImportCommand extends AbstractCommand
                 throw new \RuntimeException(\sprintf('Not authenticated for %s, run ems:admin:login', $this->adminHelper->getCoreApi()->getBaseUrl()));
             }
 
-            try {
-                $filename = $this->storageManager->getFile($this->file)->getFilename();
-            } catch (NotFoundException) {
-                $filename = $this->adminHelper->getCoreApi()->file()->downloadFile($this->file);
-            }
             $config = $this->createConfig(...$this->getOptionStringArray(self::OPTION_CONFIG, false));
 
-            $cells = $this->fileReader->readCells($filename, [
+            $cells = $this->fileReader->readCells($this->getFile($this->file)->getFilename(), [
                 'delimiter' => $config->delimiter,
                 'encoding' => $config->encoding,
                 'exclude_rows' => $config->excludeRows,
@@ -219,5 +215,14 @@ final class FileReaderImportCommand extends AbstractCommand
         }
 
         return $ouuids;
+    }
+
+    private function getFile(string $fileIdentifier): FileInterface
+    {
+        try {
+            return $this->storageManager->getFile($fileIdentifier);
+        } catch (NotFoundException) {
+            return $this->adminHelper->getCoreApi()->file()->getFile($this->file);
+        }
     }
 }

--- a/elasticms-cli/src/Command/FileReader/FileReaderImportCommand.php
+++ b/elasticms-cli/src/Command/FileReader/FileReaderImportCommand.php
@@ -157,7 +157,7 @@ final class FileReaderImportCommand extends AbstractCommand
     {
         $configs = \array_map(fn (string $input) => match (true) {
             Json::isJson($input) => Json::decode($input),
-            default => Json::decode($this->storageManager->getFile($input)->getContent())
+            default => Json::decode($this->getFile($input)->getContent())
         }, $inputs);
 
         return FileReaderImportConfig::createFromArray(


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   |  y |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? |  n |
| Documentation? |  n |

Get the config file from the API if not found locally
