### PR TITLE
fix(admin/field): deep recompute time field type

### DIFF
--- a/EMS/core-bundle/src/Form/DataField/TimeFieldType.php
+++ b/EMS/core-bundle/src/Form/DataField/TimeFieldType.php
@@ -106,8 +106,11 @@ class TimeFieldType extends DataFieldType
     {
         $format = static::getFormat($fieldType->getOptions());
         $converted = !\is_array($data) ? \DateTime::createFromFormat($format, \strval($data)) : false;
+        $convertedFromStoreFormat = !\is_array($data) ? \DateTime::createFromFormat($this::STOREFORMAT, \strval($data)) : false;
         if ($converted) {
             $out = $converted->format($this::STOREFORMAT);
+        } elseif ($convertedFromStoreFormat) {
+            $out = $convertedFromStoreFormat->format($this::STOREFORMAT);
         } else {
             $out = null;
         }


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  |  n |
| Fixed tickets? | n  |
| Documentation? | n  |

In deep recompute the raw data is used, so we are loosing the conversions raw format <-> display format
