### PR TITLE
fix(common/mime-types): add XLIFF mimetype support

### DIFF
--- a/EMS/common-bundle/src/Storage/Processor/Config.php
+++ b/EMS/common-bundle/src/Storage/Processor/Config.php
@@ -566,6 +566,8 @@ final class Config
             'application/vnd.ms-excel' => 'xls',
             'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' => 'xlsx',
             'application/xml' => 'xml',
+            'application/x-xliff+xml' => 'xlf',
+            'application/xliff+xml' => 'xlf',
             'image/x-xpixmap' => 'xpm',
             'image/x-xwindowdump' => 'xwd',
             'text/yaml' => 'yml',

--- a/EMS/core-bundle/src/Command/Xliff/ExtractCommand.php
+++ b/EMS/core-bundle/src/Command/Xliff/ExtractCommand.php
@@ -183,7 +183,7 @@ final class ExtractCommand extends AbstractCommand
             [
                 EmsFields::CONTENT_FILE_HASH_FIELD => $hash,
                 EmsFields::CONTENT_FILE_NAME_FIELD => \basename($this->xliffBasename),
-                EmsFields::CONTENT_MIME_TYPE_FIELD => MimeTypes::APPLICATION_XML->value,
+                EmsFields::CONTENT_MIME_TYPE_FIELD => $this->getMimetype(),
             ],
             [],
             'ems_asset',
@@ -229,8 +229,16 @@ final class ExtractCommand extends AbstractCommand
             'query' => $this->searchQuery,
             'fields' => $this->fields,
         ]);
-        $mailTemplate->addAttachment($tempFile->path, \basename($this->xliffBasename), MimeTypes::APPLICATION_XML->value);
+        $mailTemplate->addAttachment($tempFile->path, \basename($this->xliffBasename), $this->getMimetype());
 
         $this->mailerService->sendMailTemplate($mailTemplate);
+    }
+
+    private function getMimetype(): string
+    {
+        return match ($this->xliffVersion) {
+            Extractor::XLIFF_1_2 => MimeTypes::APPLICATION_XLIFF_LEGACY->value,
+            default => MimeTypes::APPLICATION_XLIFF->value,
+        };
     }
 }

--- a/EMS/helpers/src/Html/MimeTypes.php
+++ b/EMS/helpers/src/Html/MimeTypes.php
@@ -7,6 +7,8 @@ namespace EMS\Helpers\Html;
 enum MimeTypes: string
 {
     case APPLICATION_ZIP = 'application/zip';
+    case APPLICATION_XLIFF_LEGACY = 'application/x-xliff+xml';
+    case APPLICATION_XLIFF = 'application/xliff+xml';
     case APPLICATION_XML = 'application/xml';
     case APPLICATION_OCTET_STREAM = 'application/octet-stream';
     case IMAGE_PNG = 'image/png';


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   |  n |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? |  n |
| Documentation? |  n |

file extension is "corrected" to xml it must stay xlf
