### PR TITLE
feat(common/twig): new filter ems_date

### DIFF
--- a/EMS/common-bundle/src/Twig/CommonExtension.php
+++ b/EMS/common-bundle/src/Twig/CommonExtension.php
@@ -7,6 +7,7 @@ use EMS\CommonBundle\Common\EMSLink;
 use EMS\CommonBundle\Common\Standard\Base64;
 use EMS\CommonBundle\Helper\Text\Encoder;
 use EMS\Helpers\Standard\Color;
+use EMS\Helpers\Standard\DateTime;
 use EMS\Helpers\Standard\UuidGenerator;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
@@ -68,6 +69,7 @@ class CommonExtension extends AbstractExtension
             new TwigFilter('ems_link', fn ($emsLink) => EMSLink::fromText($emsLink)),
             new TwigFilter('ems_valid_mail', [TextRuntime::class, 'isValidEmail']),
             new TwigFilter('ems_uuid', [UuidGenerator::class, 'fromValue']),
+            new TwigFilter('ems_date', DateTime::createFromFormat(...)),
         ];
     }
 

--- a/docs/dev/common-bundle/twig.md
+++ b/docs/dev/common-bundle/twig.md
@@ -25,6 +25,7 @@
   * [ems_link](#ems_link)
   * [ems_valid_mail](#ems_valid_mail)
   * [ems_uuid](#ems_uuid-1)
+  * [ems_date](#ems_date)
 <!-- TOC -->
 
 # Twig Functions
@@ -421,4 +422,14 @@ Generate a version 5 UUID from a value. [More info](https://uuid.ramsey.dev/en/s
 {{ 'my_unique_id_value'|ems_uuid }} 
 ```
 
+## ems_date
+
+Generate a \DateTimeImmutable object from a value.
+
+```twig
+{% set date = '31/12/1998 0:00:00'|ems_date('j/m/Y H:i:s') %}
+
+{{ date.format('d-m-Y') }}
+{{ date.timezone }}
+```
 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  n |
| New feature?   |  y |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? |  y |

Using the normal twig `date` filter will throw exceptions if your format is 'strange'
```twig
{{ '31/12/1998 0:00:00'|date  }} {# throws exception "Failed to parse time string (31/12/1998 0:00:00) at position 0 (3): Unexpected character" #}
```
Now we can use the new `ems_date` filter which will use the DateTime standard for creating a true \DateTimeImmutable object

```twig
{{ '31/12/1998 0:00:00'|ems_date('j/m/Y H:i:s').format('d-m-Y H:i:s') }} {# output = 31-12-1998 00:00:00 #}
```
