### PR TITLE
feat(common/twig): new filter ems_int

### DIFF
--- a/EMS/common-bundle/src/Twig/CommonExtension.php
+++ b/EMS/common-bundle/src/Twig/CommonExtension.php
@@ -70,6 +70,7 @@ class CommonExtension extends AbstractExtension
             new TwigFilter('ems_valid_mail', [TextRuntime::class, 'isValidEmail']),
             new TwigFilter('ems_uuid', [UuidGenerator::class, 'fromValue']),
             new TwigFilter('ems_date', DateTime::createFromFormat(...)),
+            new TwigFilter('ems_int', intval(...)),
         ];
     }
 

--- a/docs/dev/common-bundle/twig.md
+++ b/docs/dev/common-bundle/twig.md
@@ -26,6 +26,7 @@
   * [ems_valid_mail](#ems_valid_mail)
   * [ems_uuid](#ems_uuid-1)
   * [ems_date](#ems_date)
+  * [ems_int](#ems_int)
 <!-- TOC -->
 
 # Twig Functions
@@ -433,3 +434,10 @@ Generate a \DateTimeImmutable object from a value.
 {{ date.timezone }}
 ```
 
+## ems_int
+
+Use php \intval function on input
+
+```twig
+{% set size = app.request.query.get('size', 0)|ems_int %}
+```


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  n |
| New feature?   | y  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | y  |

Simple twig filter for casting a string to a true int. Usefull for when you want to pass a size and offset to the `emsch_search` function, it needs to be a true int not a string.
