### PR TITLE
fix(web/local): upload assets heads returns true

### DIFF
--- a/EMS/client-helper-bundle/src/Command/Local/UploadAssetsCommand.php
+++ b/EMS/client-helper-bundle/src/Command/Local/UploadAssetsCommand.php
@@ -147,6 +147,11 @@ final class UploadAssetsCommand extends AbstractLocalCommand
         $archive = Archive::fromDirectory($directory, $algo);
         $progressBar = $this->io->createProgressBar($archive->getCount());
         foreach ($this->coreApi->file()->heads(...$archive->getHashes()) as $hash) {
+            if (true === $hash) {
+                $progressBar->advance();
+                continue;
+            }
+
             $file = $archive->getFirstFileByHash($hash);
             $uploadHash = $this->coreApi->file()->uploadFile($directory.DIRECTORY_SEPARATOR.$file->filename);
             if ($uploadHash !== $hash) {


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Problem:
```bash
php bin/console emsch:local:upload-assets

Local development - Upload assets
=================================

                                                                                                                        
 [ERROR] File with hash 1 not found                                                                                     
                                                                                                                        

```

Since 5.24.0 -> https://github.com/ems-project/elasticms/pull/1076
The heads api is returning string|true. 

But the true check was not implemented in the UploadAssetsCommand


