### PR TITLE
fix(web/translations): support locales without EMSCH_LOCALES

### DIFF
--- a/EMS/client-helper-bundle/src/Helper/Translation/TranslationDocument.php
+++ b/EMS/client-helper-bundle/src/Helper/Translation/TranslationDocument.php
@@ -42,15 +42,7 @@ final class TranslationDocument implements BuilderDocumentInterface
      */
     public function getDataSource(): array
     {
-        $source = ['key' => $this->source['key']];
-
-        foreach ($this->locales as $locale) {
-            if (isset($this->source['label_'.$locale])) {
-                $source['label_'.$locale] = $this->source['label_'.$locale];
-            }
-        }
-
-        return $source;
+        return \array_filter($this->source, fn ($key) => 'key' === $key || \str_starts_with($key, 'label_'), ARRAY_FILTER_USE_KEY);
     }
 
     /**

--- a/EMS/client-helper-bundle/src/Helper/Translation/TranslationFiles.php
+++ b/EMS/client-helper-bundle/src/Helper/Translation/TranslationFiles.php
@@ -22,10 +22,11 @@ final class TranslationFiles implements \IteratorAggregate, \Countable
     {
         $path = $directory.\DIRECTORY_SEPARATOR.self::DIRECTORY;
 
-        if (\file_exists($path)) {
-            foreach (Finder::create()->in($path)->files()->name('*.yaml') as $file) {
-                $this->files[] = new TranslationFile($file);
-            }
+        if (!\file_exists($path)) {
+            return;
+        }
+        foreach (Finder::create()->in($path)->files()->name('*.yaml') as $file) {
+            $this->files[] = new TranslationFile($file);
         }
     }
 

--- a/demo/skeleton/routes.yaml
+++ b/demo/skeleton/routes.yaml
@@ -121,7 +121,7 @@ emsch_login:
     config:
         controller: emsch.controller.security.login
         path: /login
-        method: [ POST, GET ]
+        method: [POST, GET]
     template_static: template/security/login.html.twig
 ems:
     config:
@@ -135,29 +135,28 @@ ems_versions:
     template_static: template/security/versions.html.twig
 ems_version_new:
     config:
-        method: [ GET ]
+        method: [GET]
         path: /ems/versions/new
         defaults: { _authenticated: true }
     template_static: template/security/version.html.twig
 ems_version_detail:
     config:
-        method: [ GET ]
-        path: /ems/versions/{ouuid}
+        method: [GET]
+        path: '/ems/versions/{ouuid}'
         defaults: { _authenticated: true }
     query: '{"query":{"bool":{"must":[{"term":{"_contenttype":{"value":"release"}}},{"term":{"_id":{"value":"%ouuid%"}}}]}}}'
     template_static: template/security/version.html.twig
 ems_version_create:
     config:
-        method: [ POST ]
+        method: [POST]
         path: /ems/versions/create
         controller: 'EMS\ClientHelperBundle\Controller\ApiController::createDocumentFromForm'
-        defaults: { _authenticated: true, apiName: backend, contentType: release, redirectUrl: '/ems/versions/%ouuid%', validationTemplate: '@EMSCH/template/security/version_validate.twig' }
+        defaults: { _authenticated: true, apiName: backend, contentType: release, redirectUrl: /ems/versions/%ouuid%, validationTemplate: '@EMSCH/template/security/version_validate.twig' }
     query: '{"query":{"bool":{"must":[{"term":{"_contenttype":{"value":"release"}}},{"term":{"_id":{"value":"%id%"}}}]}}}'
 ems_version_update:
     config:
-        method: [ POST ]
-        path: /ems/versions/{ouuid}
+        method: [POST]
+        path: '/ems/versions/{ouuid}'
         controller: 'EMS\ClientHelperBundle\Controller\ApiController::updateDocumentFromForm'
-        defaults: { _authenticated: true, apiName: backend, contentType: release, redirectUrl: '/ems/versions/%ouuid%', validationTemplate: '@EMSCH/template/security/version_validate.twig' }
+        defaults: { _authenticated: true, apiName: backend, contentType: release, redirectUrl: /ems/versions/%ouuid%, validationTemplate: '@EMSCH/template/security/version_validate.twig' }
     query: '{"query":{"bool":{"must":[{"term":{"_contenttype":{"value":"release"}}},{"term":{"_id":{"value":"%id%"}}}]}}}'
-

--- a/demo/skeleton/translations/messages.fr.yaml
+++ b/demo/skeleton/translations/messages.fr.yaml
@@ -27,6 +27,15 @@ ems:
     back_to_ems: 'Retour à eMS'
 ems_form:
     loading: 'en cours de chargement...'
+emsch:
+    security:
+        exception:
+            bad_credentials: 'Nom d''utilisateur ou mot de passe invalide'
+            error: 'Une erreur s''est produite !'
+        form:
+            password: 'Mot de passe'
+            submit: 'Se connecter'
+            username: 'Nom d''utilisateur'
 features:
     discover: 'Découvrez toutes les fonctionnalités'
 files_browse: 'Choisir des fichiers'
@@ -41,6 +50,7 @@ js:
 language:
     selection: 'select language'
 locale: Français
+login: 'Se connecter'
 missing:
     description: 'Changer de langue pour voir les versions alternatives.'
     title: 'Ce contenu n''est pas disponible en français'

--- a/demo/skeleton/translations/messages.nl.yaml
+++ b/demo/skeleton/translations/messages.nl.yaml
@@ -27,6 +27,15 @@ ems:
     back_to_ems: 'Terug naar eMS'
 ems_form:
     loading: 'bezig met laden...'
+emsch:
+    security:
+        exception:
+            bad_credentials: 'Ongeldige gebruikersnaam of wachtwoord'
+            error: 'Er is iets fout gegaan!'
+        form:
+            password: Wachtwoord
+            submit: Login
+            username: Gebruikersnaam
 features:
     discover: 'Ontdek alle features'
 files_browse: 'Kiezen bestanden'
@@ -41,6 +50,7 @@ js:
 language:
     selection: 'select language'
 locale: Nederlands
+login: Login
 missing:
     description: 'Wijzig de taal om alternatieve versies te zien.'
     title: 'Deze inhoud is niet beschikbaar in het Nederlands'


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

We may local translation files for locales that are not in the EMSCH_LOCALES. In other words the locales of the site web is a subset of the locales handle in the translation content type.