### PR TITLE
fix(helper/file): bigger chunks for tempFile

### DIFF
--- a/EMS/helpers/src/File/TempFile.php
+++ b/EMS/helpers/src/File/TempFile.php
@@ -52,7 +52,7 @@ class TempFile
         }
 
         while (!$stream->eof()) {
-            if (false === \fwrite($handle, $stream->read(8192))) {
+            if (false === \fwrite($handle, $stream->read(File::DEFAULT_CHUNK_SIZE))) {
                 throw new \RuntimeException(\sprintf('Can\'t write in temporary file %s', $this->path));
             }
         }


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Perf issue with too small chunk size.

This PR is for 5.23 only, for >= 5.24 there is #1108 
