### PR TITLE
fix(core/field): a symfony form type name can not start by a dash

### DIFF
--- a/EMS/core-bundle/src/Form/Nature/ItemsType.php
+++ b/EMS/core-bundle/src/Form/Nature/ItemsType.php
@@ -19,7 +19,7 @@ class ItemsType extends AbstractType
         $result = $options['result'];
 
         foreach ($result['hits']['hits'] as $hit) {
-            $builder->add(\join("", [self::PREFIX, $hit['_id']]), HiddenType::class, [
+            $builder->add(\join('', [self::PREFIX, $hit['_id']]), HiddenType::class, [
                     'attr' => [
                     ],
             ]);

--- a/EMS/core-bundle/src/Form/Nature/ItemsType.php
+++ b/EMS/core-bundle/src/Form/Nature/ItemsType.php
@@ -10,6 +10,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class ItemsType extends AbstractType
 {
     public const PREFIX = 'item-';
+
     /**
      * @param FormBuilderInterface<FormBuilderInterface> $builder
      * @param array<string, mixed>                       $options

--- a/EMS/core-bundle/src/Form/Nature/ItemsType.php
+++ b/EMS/core-bundle/src/Form/Nature/ItemsType.php
@@ -9,6 +9,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ItemsType extends AbstractType
 {
+    public const PREFIX = 'item-';
     /**
      * @param FormBuilderInterface<FormBuilderInterface> $builder
      * @param array<string, mixed>                       $options
@@ -18,7 +19,7 @@ class ItemsType extends AbstractType
         $result = $options['result'];
 
         foreach ($result['hits']['hits'] as $hit) {
-            $builder->add($hit['_id'], HiddenType::class, [
+            $builder->add(\join("", [self::PREFIX, $hit['_id']]), HiddenType::class, [
                     'attr' => [
                     ],
             ]);

--- a/EMS/core-bundle/src/Form/View/SorterViewType.php
+++ b/EMS/core-bundle/src/Form/View/SorterViewType.php
@@ -159,7 +159,7 @@ class SorterViewType extends ViewType
 
             foreach ($items as $itemKey => $value) {
                 if (!\str_starts_with($itemKey, ItemsType::PREFIX)) {
-                    throw new \RuntimeException('Invalid item key: ' . $itemKey);
+                    throw new \RuntimeException('Invalid item key: '.$itemKey);
                 }
                 $itemKey = \substr($itemKey, \strlen(ItemsType::PREFIX));
                 try {

--- a/EMS/core-bundle/src/Form/View/SorterViewType.php
+++ b/EMS/core-bundle/src/Form/View/SorterViewType.php
@@ -8,6 +8,7 @@ use EMS\CommonBundle\Service\ElasticaService;
 use EMS\CoreBundle\Entity\View;
 use EMS\CoreBundle\Form\Field\CodeEditorType;
 use EMS\CoreBundle\Form\Field\ContentTypeFieldPickerType;
+use EMS\CoreBundle\Form\Nature\ItemsType;
 use EMS\CoreBundle\Form\Nature\ReorderType;
 use EMS\CoreBundle\Service\DataService;
 use EMS\CoreBundle\Service\Mapping;
@@ -157,6 +158,10 @@ class SorterViewType extends ViewType
             $items = $reorder['items'];
 
             foreach ($items as $itemKey => $value) {
+                if (!\str_starts_with($itemKey, ItemsType::PREFIX)) {
+                    throw new \RuntimeException('Invalid item key: ' . $itemKey);
+                }
+                $itemKey = \substr($itemKey, \strlen(ItemsType::PREFIX));
                 try {
                     $revision = $this->dataService->initNewDraft($view->getContentType()->getName(), $itemKey);
                     $data = $revision->getRawData();

--- a/EMS/core-bundle/src/Resources/views/view/custom/sorter_view.html.twig
+++ b/EMS/core-bundle/src/Resources/views/view/custom/sorter_view.html.twig
@@ -17,7 +17,7 @@
 								<li class="list-group-item ui-sortable-handle">
 									<i class="glyphicon glyphicon-move"></i>
 									{{ document.emsId|data_link }}
-									{{ form_widget(attribute(form.items, document.id)) }}
+									{{ form_widget(attribute(form.items, "item-#{document.id}")) }}
 								</li>
 							{% endif %}
                         {% endfor %}
@@ -32,4 +32,4 @@
 			</div>
 		</div>
 	</div>
-{% endblock %} 
+{% endblock %}


### PR DESCRIPTION
…can starts by a dash (-). So let's prefix ItemsTypes's names

| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   |  n |
| BC breaks?     | n  |
| Deprecations?  |  n |
| Fixed tickets? | n  |
| Documentation? | n  |

A Symfony FormType's name can not start by a dash, but an OUUID can starts by a dash (-). So let's prefix ItemsTypes's names
