### PR TITLE
fix(common/job): escape jobs command

### DIFF
--- a/EMS/common-bundle/src/Common/Job/JobManager.php
+++ b/EMS/common-bundle/src/Common/Job/JobManager.php
@@ -11,6 +11,8 @@ use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 
+use function Symfony\Component\String\u;
+
 class JobManager
 {
     public function __construct(private readonly KernelInterface $kernel, private readonly AdminHelper $adminHelper)
@@ -24,7 +26,10 @@ class JobManager
         try {
             $application = new Application($this->kernel);
             $application->setAutoExit(false);
-            $input = new StringInput($job->getCommand());
+
+            $command = $job->getCommand();
+            $escapedCommand = u($command)->replace('\\', '\\\\')->toString();
+            $input = new StringInput($escapedCommand);
 
             $application->run($input, $output);
             $this->adminHelper->getCoreApi()->admin()->jobCompleted($job);


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Just like the core jobService the jobManager should escape the command before running it.

See https://github.com/ems-project/elasticms/pull/976

https://github.com/ems-project/elasticms/blob/ec52bc307ca02166b673d49fa55845d212f891e9/EMS/core-bundle/src/Service/JobService.php#L144-L150
