### PR TITLE
fix(core/twig): html escape special chars in display label

### DIFF
--- a/EMS/core-bundle/src/Service/Revision/RevisionService.php
+++ b/EMS/core-bundle/src/Service/Revision/RevisionService.php
@@ -160,11 +160,11 @@ class RevisionService implements RevisionServiceInterface
         ]) : null;
 
         if ($evaluateDisplay) {
-            return $evaluateDisplay;
+            return \htmlspecialchars($evaluateDisplay);
         }
 
         if ($contentType->hasLabelField() && isset($rawData[$contentType->giveLabelField()])) {
-            return $rawData[$contentType->giveLabelField()];
+            return \htmlspecialchars($rawData[$contentType->giveLabelField()]);
         }
 
         return match (true) {


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

If the content type label field contains '<title> test' it breaks document linking to this document.
