### PR TITLE
fix(twig): deprecate ems function and filters with deprecation_info

### DIFF
--- a/EMS/client-helper-bundle/src/Twig/HelperExtension.php
+++ b/EMS/client-helper-bundle/src/Twig/HelperExtension.php
@@ -7,6 +7,7 @@ namespace EMS\ClientHelperBundle\Twig;
 use EMS\ClientHelperBundle\Helper\Asset\AssetHelperRuntime;
 use EMS\ClientHelperBundle\Helper\Elasticsearch\ClientRequestRuntime;
 use EMS\CommonBundle\Twig\AssetRuntime;
+use Twig\DeprecatedCallableInfo;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
@@ -34,9 +35,13 @@ final class HelperExtension extends AbstractExtension
             new TwigFunction('emsch_search_config', [ClientRequestRuntime::class, 'searchConfig']),
             new TwigFunction('emsch_http_error', [ClientRequestRuntime::class, 'httpException']),
             new TwigFunction('emsch_asset', [AssetHelperRuntime::class, 'asset'], ['is_safe' => ['html']]),
-            new TwigFunction('emsch_assets', [AssetHelperRuntime::class, 'assets'], ['deprecated' => true, 'alternative' => 'emsch_assets_version']),
+            new TwigFunction('emsch_assets', [AssetHelperRuntime::class, 'assets'], [
+                'deprecation_info' => new DeprecatedCallableInfo('elasticms/client-helper-bundle', '5.19.0', 'emsch_assets_version'),
+            ]),
             new TwigFunction('emsch_assets_version', [AssetHelperRuntime::class, 'setVersion']),
-            new TwigFunction('emsch_unzip', [AssetRuntime::class, 'unzip'], ['deprecated' => true, 'alternative' => 'ems_file_from_archive']),
+            new TwigFunction('emsch_unzip', [AssetRuntime::class, 'unzip'], [
+                'deprecation_info' => new DeprecatedCallableInfo('elasticms/client-helper-bundle', '5.19.0', 'ems_unzip', 'elasticms/common-bundle', '5.19.0'),
+            ]),
         ];
     }
 }

--- a/EMS/common-bundle/src/Twig/CommonExtension.php
+++ b/EMS/common-bundle/src/Twig/CommonExtension.php
@@ -8,6 +8,7 @@ use EMS\CommonBundle\Common\Standard\Base64;
 use EMS\CommonBundle\Helper\Text\Encoder;
 use EMS\Helpers\Standard\Color;
 use EMS\Helpers\Standard\UuidGenerator;
+use Twig\DeprecatedCallableInfo;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
@@ -18,7 +19,6 @@ class CommonExtension extends AbstractExtension
     {
         return [
             new TwigFunction('ems_asset_path', [AssetRuntime::class, 'assetPath'], ['is_safe' => ['html']]),
-            new TwigFunction('ems_unzip', [AssetRuntime::class, 'unzip'], ['deprecated' => true, 'alternative' => 'ems_file_from_archive']),
             new TwigFunction('ems_json_file', [AssetRuntime::class, 'jsonFromFile']),
             new TwigFunction('ems_asset_get_content', [AssetRuntime::class, 'getContent']),
             new TwigFunction('ems_html', [TextRuntime::class, 'emsHtml'], ['is_safe' => ['all']]),
@@ -33,6 +33,9 @@ class CommonExtension extends AbstractExtension
             new TwigFunction('ems_store_delete', [StoreDataRuntime::class, 'delete']),
             new TwigFunction('ems_template_exists', [TemplateRuntime::class, 'templateExists']),
             new TwigFunction('ems_file_from_archive', [AssetRuntime::class, 'fileFromArchive']),
+            new TwigFunction('ems_unzip', [AssetRuntime::class, 'unzip'], [
+                'deprecation_info' => new DeprecatedCallableInfo('elasticms/common-bundle', '5.19.0', 'ems_file_from_archive'),
+            ]),
         ];
     }
 
@@ -51,7 +54,6 @@ class CommonExtension extends AbstractExtension
             new TwigFilter('ems_json_menu_decode', [TextRuntime::class, 'jsonMenuDecode']),
             new TwigFilter('ems_json_menu_nested_decode', [TextRuntime::class, 'jsonMenuNestedDecode']),
             new TwigFilter('ems_json_decode', [TextRuntime::class, 'jsonDecode']),
-            new TwigFilter('ems_webalize', [Encoder::class, 'webalizeForUsers'], ['deprecated' => true, 'alternative' => 'ems_slug']),
             new TwigFilter('ems_ascii_folding', [Encoder::class, 'asciiFolding']),
             new TwigFilter('ems_markdown', [Encoder::class, 'markdownToHtml'], ['is_safe' => ['html']]),
             new TwigFilter('ems_slug', [Encoder::class, 'slug']),
@@ -68,6 +70,9 @@ class CommonExtension extends AbstractExtension
             new TwigFilter('ems_link', fn ($emsLink) => EMSLink::fromText($emsLink)),
             new TwigFilter('ems_valid_mail', [TextRuntime::class, 'isValidEmail']),
             new TwigFilter('ems_uuid', [UuidGenerator::class, 'fromValue']),
+            new TwigFilter('ems_webalize', [Encoder::class, 'webalizeForUsers'], [
+                'deprecation_info' => new DeprecatedCallableInfo('elasticms/common-bundle', '5.17.1', 'ems_slug'),
+            ]),
         ];
     }
 

--- a/EMS/core-bundle/src/Twig/AppExtension.php
+++ b/EMS/core-bundle/src/Twig/AppExtension.php
@@ -50,6 +50,7 @@ use Symfony\Component\Mime\Email;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Twig\DeprecatedCallableInfo;
 use Twig\Environment as TwigEnvironment;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
@@ -106,7 +107,6 @@ class AppExtension extends AbstractExtension
             new TwigFunction('emsco_generate_email', $this->generateEmailMessage(...)),
             new TwigFunction('emsco_send_email', $this->sendEmail(...)),
             new TwigFunction('emsco_users_enabled', [UserRuntime::class, 'getUsersEnabled']),
-            new TwigFunction('emsco_uuid', [Uuid::class, 'uuid4'], ['deprecated' => true]),
             new TwigFunction('emsco_datatable', [DatatableRuntime::class, 'generateDatatable'], ['is_safe' => ['html']]),
             new TwigFunction('emsco_datatable_excel_path', [DatatableRuntime::class, 'getExcelPath'], ['is_safe' => ['html']]),
             new TwigFunction('emsco_datatable_csv_path', [DatatableRuntime::class, 'getCsvPath'], ['is_safe' => ['html']]),
@@ -129,10 +129,18 @@ class AppExtension extends AbstractExtension
             new TwigFunction('emsco_save_contents', $this->saveContents(...)),
             new TwigFunction('emsco_notice', $this->notice(...)),
             new TwigFunction('emsco_warning', $this->warning(...)),
-            // deprecated
-            new TwigFunction('cant_be_finalized', $this->cantBeFinalized(...), ['deprecated' => true, 'alternative' => 'emsco_cant_be_finalized']),
-            new TwigFunction('get_default_environments', [EnvironmentRuntime::class, 'getDefaultEnvironmentNames'], ['deprecated' => true, 'alternative' => 'emsco_get_default_environment_names']),
-            new TwigFunction('get_content_types', [ContentTypeRuntime::class, 'getContentTypes'], ['deprecated' => true, 'alternative' => 'emsco_get_content_types']),
+            new TwigFunction('emsco_uuid', [Uuid::class, 'uuid4'], [
+                'deprecation_info' => new DeprecatedCallableInfo('elasticms/core-bundle', '5.4.1', 'ems_uuid', 'elasticms/common-bundle', '5.4.1'),
+            ]),
+            new TwigFunction('cant_be_finalized', $this->cantBeFinalized(...), [
+                'deprecation_info' => new DeprecatedCallableInfo('elasticms/core-bundle', '5.7.0', 'emsco_cant_be_finalized'),
+            ]),
+            new TwigFunction('get_default_environments', [EnvironmentRuntime::class, 'getDefaultEnvironmentNames'], [
+                'deprecation_info' => new DeprecatedCallableInfo('elasticms/core-bundle', '5.0.0', 'emsco_get_default_environment_names'),
+            ]),
+            new TwigFunction('get_content_types', [ContentTypeRuntime::class, 'getContentTypes'], [
+                'deprecation_info' => new DeprecatedCallableInfo('elasticms/core-bundle', '5.19.0', 'emsco_get_content_types'),
+            ]),
         ];
     }
 
@@ -169,7 +177,7 @@ class AppExtension extends AbstractExtension
             new TwigFilter('displayname', $this->displayName(...)),
             new TwigFilter('date_difference', $this->dateDifference(...)),
             new TwigFilter('debug', $this->debug(...)),
-            new TwigFilter('search', $this->deprecatedSearch(...), ['deprecated' => true, 'alternative' => 'emsco_search']),
+            new TwigFilter('search', $this->deprecatedSearch(...)),
             new TwigFilter('emsco_search', $this->search(...)),
             new TwigFilter('call_user_func', $this->callUserFunc(...)),
             new TwigFilter('merge_recursive', $this->arrayMergeRecursive(...)),
@@ -190,12 +198,25 @@ class AppExtension extends AbstractExtension
             new TwigFilter('emsco_get', $this->get(...)),
             new TwigFilter('emsco_get_content_type', [ContentTypeRuntime::class, 'getContentType']),
             // deprecated
-            new TwigFilter('data', $this->data(...), ['deprecated' => true, 'alternative' => 'emsco_get']),
-            new TwigFilter('url_generator', Encoder::webalize(...), ['deprecated' => true, 'alternative' => 'ems_webalize']),
-            new TwigFilter('emsco_webalize', Encoder::webalize(...), ['deprecated' => true, 'alternative' => 'ems_webalize']),
-            new TwigFilter('get_environment', [EnvironmentRuntime::class, 'getEnvironment'], ['deprecated' => true, 'alternative' => 'emsco_get_environment']),
-            new TwigFilter('get_content_type', [ContentTypeRuntime::class, 'getContentType'], ['deprecated' => true, 'alternative' => 'emsco_get_contentType']),
-            new TwigFilter('data_label', $this->dataLabel(...), ['is_safe' => ['html'], 'deprecated' => true, 'alternative' => 'emsco_display']),
+            new TwigFilter('data', $this->data(...), [
+                'deprecation_info' => new DeprecatedCallableInfo('elasticms/core-bundle', '5.8.0', 'emsco_get'),
+            ]),
+            new TwigFilter('url_generator', Encoder::webalize(...), [
+                'deprecation_info' => new DeprecatedCallableInfo('elasticms/core-bundle', '5.0.0', 'ems_slug', 'elasticms/common-bundle', '5.17.1'),
+            ]),
+            new TwigFilter('emsco_webalize', Encoder::webalize(...), [
+                'deprecation_info' => new DeprecatedCallableInfo('elasticms/core-bundle', '5.0.0', 'ems_slug', 'elasticms/common-bundle', '5.17.1'),
+            ]),
+            new TwigFilter('get_environment', [EnvironmentRuntime::class, 'getEnvironment'], [
+                'deprecation_info' => new DeprecatedCallableInfo('elasticms/core-bundle', '5.0.0', 'emsco_get_environment'),
+            ]),
+            new TwigFilter('get_content_type', [ContentTypeRuntime::class, 'getContentType'], [
+                'deprecation_info' => new DeprecatedCallableInfo('elasticms/core-bundle', '5.0.0', 'emsco_get_contentType'),
+            ]),
+            new TwigFilter('data_label', $this->dataLabel(...), [
+                'is_safe' => ['html'],
+                'deprecation_info' => new DeprecatedCallableInfo('elasticms/core-bundle', '5.4.0', 'emsco_display'),
+            ]),
         ];
     }
 
@@ -702,8 +723,6 @@ class AppExtension extends AbstractExtension
     }
 
     /**
-     * @deprecated
-     *
      * @param array<mixed> $params
      *
      * @return array<mixed>


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

The deprecated, deprecating_package, alternative options on Twig functions/filters/Tests are deprecated as of Twig 3.15, and will be removed in Twig 4.0. Use the deprecation_info option instead.

After this pr the twig lint is now returning deprecation notices about spaceless

Also removed the deprecation for core 'search' filter. Because 5 versions are still using it, we need to improve the emsco_search in 6.x and again deprecated the 'search' filter.

The 'deprecation_info' was first introduced in twig 3.15 on 9/9/2024, that's why the base needs to be 5.24.
5.23 is using twig 3.14
