### PR TITLE
fix(admin/twig): escape label in data links

### DIFF
--- a/EMS/core-bundle/src/Resources/views/data/revisions-data.html.twig
+++ b/EMS/core-bundle/src/Resources/views/data/revisions-data.html.twig
@@ -309,7 +309,7 @@
 			{% else %}
 				<div class="btn-group">
 					{% for obj in referrerResponse.getDocuments %}
-						{{ obj.emsId|data_link|raw }}
+						{{ obj.emsId|data_link }}
 					{% endfor %}
 				</div>
 			{% endif %}

--- a/EMS/core-bundle/src/Service/Revision/RevisionService.php
+++ b/EMS/core-bundle/src/Service/Revision/RevisionService.php
@@ -160,11 +160,11 @@ class RevisionService implements RevisionServiceInterface
         ]) : null;
 
         if ($evaluateDisplay) {
-            return \htmlspecialchars($evaluateDisplay);
+            return $evaluateDisplay;
         }
 
         if ($contentType->hasLabelField() && isset($rawData[$contentType->giveLabelField()])) {
-            return \htmlspecialchars($rawData[$contentType->giveLabelField()]);
+            return $rawData[$contentType->giveLabelField()];
         }
 
         return match (true) {

--- a/EMS/core-bundle/src/Twig/AppExtension.php
+++ b/EMS/core-bundle/src/Twig/AppExtension.php
@@ -935,7 +935,7 @@ class AppExtension extends AbstractExtension
             $document = $this->searchService->getDocument($contentType, $emsLink->getOuuid());
             $emsLink = $document->getEmsLink(); // versioned documents
             $emsSource = $document->getEMSSource();
-            $label .= \sprintf('<span>%s</span>', $this->revisionService->display($document));
+            $label .= \sprintf('<span>%s</span>', \htmlentities($this->revisionService->display($document)));
         } catch (NotFoundException) {
             $label .= \sprintf('<span>%s</span>', $emsLink->getEmsId());
         }


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

with the OR #1124, the document's display was double encoded at many places (document's title, in overviews, ...) in fact the bug was at the data_link twig filter level (probably for a very long time)
