### PR TITLE
fix(admin/submission): export command use ems property accessor 

### DIFF
--- a/EMS/core-bundle/src/Command/Submission/ExportCommand.php
+++ b/EMS/core-bundle/src/Command/Submission/ExportCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace EMS\CoreBundle\Command\Submission;
 
 use EMS\CommonBundle\Common\Command\AbstractCommand;
+use EMS\CommonBundle\Common\PropertyAccess\PropertyAccessor;
 use EMS\CommonBundle\Contracts\SpreadsheetGeneratorServiceInterface;
 use EMS\CommonBundle\Service\ExpressionService;
 use EMS\CoreBundle\Commands;
@@ -41,7 +42,7 @@ class ExportCommand extends AbstractCommand
             ->addArgument(
                 self::ARG_FIELDS,
                 InputArgument::IS_ARRAY,
-                'Fields to export'
+                'Fields to export in a property accessor format [instance] [name] [locale] [submission_date] [data][email] [data][multi-choice][level_0] [data][multi-choice][level_1]'
             )->addOption(
                 self::OPTION_FILTER,
                 null,
@@ -69,6 +70,7 @@ class ExportCommand extends AbstractCommand
         $sheet = [];
 
         $this->io->progressStart($this->formSubmissionService->count());
+        $propertyAccessor = PropertyAccessor::createPropertyAccessor();
         foreach ($this->formSubmissionService->getUnprocessed() as $submission) {
             $data = [
                 'instance' => $submission->getInstance(),
@@ -83,7 +85,7 @@ class ExportCommand extends AbstractCommand
             }
             $line = [];
             foreach ($this->fields as $field) {
-                $line[] = $data['data'][$field] ?? $data[$field] ?? '';
+                $line[] = $propertyAccessor->getValue($data, $field) ?? '';
             }
             $sheet[] = $line;
             $this->io->progressAdvance();


### PR DESCRIPTION


| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  |  n |
| Fixed tickets? | n  |
| Documentation? | n  |

to be able to export nested choice fields,  otherwize if you try to export a nested choices fields an error will be thrown. 
