### PR TITLE
fix(file-structure::push): avoid silent error when it's not possible to update the .hash file

### DIFF
--- a/EMS/common-bundle/src/Command/FileStructure/FileStructurePushCommand.php
+++ b/EMS/common-bundle/src/Command/FileStructure/FileStructurePushCommand.php
@@ -127,13 +127,13 @@ class FileStructurePushCommand extends AbstractCommand
         $progressBar->finish();
         $this->io->newLine();
 
-        \file_put_contents($hashFilename, $hash);
-
         if ($this->output->isQuiet()) {
             echo $hash;
         } else {
             $this->io->success(\sprintf('Archive %s have been uploaded with the directory content of %s', $hash, $this->folderPath));
         }
+
+        File::putContents($hashFilename, $hash);
 
         return self::EXECUTE_SUCCESS;
     }

--- a/EMS/helpers/src/File/File.php
+++ b/EMS/helpers/src/File/File.php
@@ -32,6 +32,13 @@ class File
         return new self(new \SplFileInfo($filename));
     }
 
+    public static function putContents(string $filename, string $contents): void
+    {
+        if (false === \file_put_contents($filename, $contents)) {
+            throw new \RuntimeException(\sprintf('Unexpected false result on file_put_contents for file %s', $filename));
+        }
+    }
+
     public function getContents(): string
     {
         if (false === $contents = \file_get_contents($this->file->getRealPath())) {


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

