### PR TITLE
fix: deprecations and upgrade packages (domPdf, phpOffice, guzzle)

### DIFF
--- a/EMS/client-helper-bundle/tests/Integration/App/config/config.yml
+++ b/EMS/client-helper-bundle/tests/Integration/App/config/config.yml
@@ -17,6 +17,8 @@ framework:
     resource: 'config/routes.yml'
     utf8: true
     strict_requirements: ~
+  validation:
+    email_validation_mode: html5
 
 security:
   firewalls:

--- a/EMS/client-helper-bundle/tests/Integration/App/config/config.yml
+++ b/EMS/client-helper-bundle/tests/Integration/App/config/config.yml
@@ -4,6 +4,7 @@ parameters:
   env(EMSCH_ENVS): '{"preview":{"regex":"/.*/","alias":"test_preview","backend":"https://localhost"}}'
 
 framework:
+  http_method_override: false
   secret: 1621180219f163d89dc399e88cfc1807ab6448cf
   csrf_protection: ~
   session:

--- a/EMS/client-helper-bundle/tests/Integration/App/config/config.yml
+++ b/EMS/client-helper-bundle/tests/Integration/App/config/config.yml
@@ -5,6 +5,7 @@ parameters:
 
 framework:
   http_method_override: false
+  handle_all_throwables: true
   secret: 1621180219f163d89dc399e88cfc1807ab6448cf
   csrf_protection: ~
   session:

--- a/EMS/client-helper-bundle/tests/Integration/App/config/config.yml
+++ b/EMS/client-helper-bundle/tests/Integration/App/config/config.yml
@@ -17,6 +17,8 @@ framework:
     resource: 'config/routes.yml'
     utf8: true
     strict_requirements: ~
+  php_errors:
+    log: true
   validation:
     email_validation_mode: html5
 

--- a/EMS/client-helper-bundle/tests/Integration/App/config/config.yml
+++ b/EMS/client-helper-bundle/tests/Integration/App/config/config.yml
@@ -34,6 +34,7 @@ doctrine:
     auto_generate_proxy_classes: '%kernel.debug%'
     naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware
     auto_mapping: true
+    enable_lazy_ghost_objects: true
 
 twig:
   debug: true

--- a/EMS/client-helper-bundle/tests/Integration/App/config/config.yml
+++ b/EMS/client-helper-bundle/tests/Integration/App/config/config.yml
@@ -9,6 +9,7 @@ framework:
   secret: 1621180219f163d89dc399e88cfc1807ab6448cf
   csrf_protection: ~
   session:
+    cookie_samesite: strict
     cookie_secure: auto
     handler_id: ~
     storage_factory_id: session.storage.factory.native

--- a/EMS/client-helper-bundle/tests/Integration/App/config/config.yml
+++ b/EMS/client-helper-bundle/tests/Integration/App/config/config.yml
@@ -7,6 +7,7 @@ framework:
   secret: 1621180219f163d89dc399e88cfc1807ab6448cf
   csrf_protection: ~
   session:
+    cookie_secure: auto
     handler_id: ~
     storage_factory_id: session.storage.factory.native
   router:

--- a/EMS/common-bundle/composer.json
+++ b/EMS/common-bundle/composer.json
@@ -25,7 +25,7 @@
         "cebe/markdown": "^1.2",
         "doctrine/doctrine-bundle": "^2.11",
         "doctrine/orm": "^2.17",
-        "dompdf/dompdf": "^v2.0",
+        "dompdf/dompdf": "^v3.1",
         "elasticms/helpers": "6.0.*",
         "guzzlehttp/guzzle": "^7.8",
         "maennchen/zipstream-php": "^3.0",

--- a/EMS/common-bundle/composer.json
+++ b/EMS/common-bundle/composer.json
@@ -29,7 +29,7 @@
         "elasticms/helpers": "6.0.*",
         "guzzlehttp/guzzle": "^7.8",
         "maennchen/zipstream-php": "^3.0",
-        "phpoffice/phpspreadsheet": "^1.29",
+        "phpoffice/phpspreadsheet": "^3.8",
         "promphp/prometheus_client_php": "^2.9",
         "psr/simple-cache": "^3.0",
         "ramsey/uuid-doctrine": "^2.1",

--- a/EMS/common-bundle/composer.json
+++ b/EMS/common-bundle/composer.json
@@ -31,7 +31,7 @@
         "maennchen/zipstream-php": "^3.0",
         "phpoffice/phpspreadsheet": "^1.29",
         "promphp/prometheus_client_php": "^2.9",
-        "psr/simple-cache": "^2.0",
+        "psr/simple-cache": "^3.0",
         "ramsey/uuid-doctrine": "^2.1",
         "ruflin/elastica": "^7.3",
         "symfony/console": "6.4.*",

--- a/EMS/common-bundle/src/Command/BatchCommand.php
+++ b/EMS/common-bundle/src/Command/BatchCommand.php
@@ -9,6 +9,7 @@ use EMS\CommonBundle\Common\Command\AbstractCommand;
 use EMS\Helpers\File\File;
 use EMS\Helpers\Standard\Json;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -20,9 +21,13 @@ use Twig\TemplateWrapper;
 
 use function Symfony\Component\String\u;
 
+#[AsCommand(
+    name: Commands::BATCH,
+    description: 'Run commands defined in twig',
+    hidden: false
+)]
 class BatchCommand extends AbstractCommand
 {
-    protected static $defaultName = Commands::BATCH;
     private const string ARGUMENT_TEMPLATE = 'template';
     private const string OPTION_CONTEXT = 'context';
 
@@ -36,7 +41,6 @@ class BatchCommand extends AbstractCommand
     {
         parent::configure();
         $this
-            ->setDescription('Run commands defined in twig')
             ->addArgument(self::ARGUMENT_TEMPLATE, InputArgument::REQUIRED, 'template name, path or twig code')
             ->addOption(self::OPTION_CONTEXT, null, InputOption::VALUE_REQUIRED, 'context passed to twig')
         ;

--- a/EMS/common-bundle/src/Command/FileStructure/FileStructurePublishCommand.php
+++ b/EMS/common-bundle/src/Command/FileStructure/FileStructurePublishCommand.php
@@ -14,14 +14,19 @@ use EMS\CommonBundle\Exception\FileStructureNotSyncException;
 use EMS\CommonBundle\Storage\Archive;
 use EMS\CommonBundle\Storage\StorageManager;
 use EMS\Helpers\Standard\Json;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::FILE_STRUCTURE_PUBLISH,
+    description: 'Publish the file structure of an ElasticMS archive into a S3 bucket',
+    hidden: false
+)]
 class FileStructurePublishCommand extends AbstractCommand
 {
-    protected static $defaultName = Commands::FILE_STRUCTURE_PUBLISH;
     public const ARGUMENT_ARCHIVE_HASH = 'hash';
     public const ARGUMENT_TARGET = 'target';
     public const OPTION_S3_CREDENTIAL = 's3-credential';
@@ -45,7 +50,6 @@ class FileStructurePublishCommand extends AbstractCommand
     {
         parent::configure();
         $this
-            ->setDescription('Publish the file structure of an ElasticMS archive into a S3 bucket')
             ->addArgument(self::ARGUMENT_ARCHIVE_HASH, InputArgument::REQUIRED, 'Elasticsearch index')
             ->addArgument(self::ARGUMENT_TARGET, InputArgument::REQUIRED, 'Target (S3 bucket)')
             ->addOption(self::OPTION_S3_CREDENTIAL, null, InputOption::VALUE_OPTIONAL, 'S3 credential in a JSON format')

--- a/EMS/common-bundle/src/Command/FileStructure/FileStructurePullCommand.php
+++ b/EMS/common-bundle/src/Command/FileStructure/FileStructurePullCommand.php
@@ -11,6 +11,7 @@ use EMS\CommonBundle\Contracts\File\FileManagerInterface;
 use EMS\CommonBundle\Storage\Archive;
 use EMS\CommonBundle\Storage\StorageManager;
 use EMS\Helpers\Standard\Type;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -18,9 +19,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 
+#[AsCommand(
+    name: Commands::FILE_STRUCTURE_PULL,
+    description: 'Pull an EMS archive into a local folder (and overwrite it)',
+    hidden: false
+)]
 class FileStructurePullCommand extends AbstractCommand
 {
-    protected static $defaultName = Commands::FILE_STRUCTURE_PULL;
     private const string ARGUMENT_ARCHIVE_HASH = 'hash';
     private const string ARGUMENT_FOLDER = 'folder';
     private const string OPTION_ADMIN = 'admin';
@@ -41,7 +46,6 @@ class FileStructurePullCommand extends AbstractCommand
     {
         parent::configure();
         $this
-            ->setDescription('Pull an EMS archive into a local folder (and overwrite it)')
             ->addArgument(self::ARGUMENT_ARCHIVE_HASH, InputArgument::REQUIRED, 'Hash of the ElasticMS Archive')
             ->addArgument(self::ARGUMENT_FOLDER, InputArgument::REQUIRED, 'Target folder')
             ->addOption(self::OPTION_ADMIN, null, InputOption::VALUE_NONE, 'Pull from admin')

--- a/EMS/common-bundle/src/Command/FileStructure/FileStructurePushCommand.php
+++ b/EMS/common-bundle/src/Command/FileStructure/FileStructurePushCommand.php
@@ -13,14 +13,19 @@ use EMS\CommonBundle\Storage\StorageManager;
 use EMS\Helpers\File\File;
 use EMS\Helpers\Html\MimeTypes;
 use EMS\Helpers\Standard\Json;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::FILE_STRUCTURE_PUSH,
+    description: 'Push an EMS Archive file structure into a EMS Admin storage services (via the API)',
+    hidden: false
+)]
 class FileStructurePushCommand extends AbstractCommand
 {
-    protected static $defaultName = Commands::FILE_STRUCTURE_PUSH;
     private const string ARGUMENT_FOLDER = 'folder';
     private const string OPTION_ADMIN = 'admin';
     private const string OPTION_CHUNK_SIZE = 'chunk-size';
@@ -43,7 +48,6 @@ class FileStructurePushCommand extends AbstractCommand
     {
         parent::configure();
         $this
-            ->setDescription('Push an EMS Archive file structure into a EMS Admin storage services (via the API)')
             ->addArgument(self::ARGUMENT_FOLDER, InputArgument::REQUIRED, 'Source folder')
             ->addOption(self::OPTION_ADMIN, null, InputOption::VALUE_NONE, 'Push to admin')
             ->addOption(self::OPTION_CHUNK_SIZE, null, InputOption::VALUE_OPTIONAL, 'Set the heads method chunk size', FileManagerInterface::HEADS_CHUNK_SIZE)

--- a/EMS/common-bundle/src/Command/Storage/ClearCacheCommand.php
+++ b/EMS/common-bundle/src/Command/Storage/ClearCacheCommand.php
@@ -7,23 +7,20 @@ namespace EMS\CommonBundle\Command\Storage;
 use EMS\CommonBundle\Commands;
 use EMS\CommonBundle\Common\Command\AbstractCommand;
 use EMS\CommonBundle\Storage\StorageManager;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::CLEAR_CACHE,
+    description: 'Clear storage services caches',
+    hidden: false
+)]
 class ClearCacheCommand extends AbstractCommand
 {
-    protected static $defaultName = Commands::CLEAR_CACHE;
-
     public function __construct(private readonly StorageManager $storageManager)
     {
         parent::__construct();
-    }
-
-    #[\Override]
-    protected function configure(): void
-    {
-        parent::configure();
-        $this->setDescription('Clear storage services caches');
     }
 
     #[\Override]

--- a/EMS/common-bundle/src/Command/Storage/LoadArchiveItemsInCacheCommand.php
+++ b/EMS/common-bundle/src/Command/Storage/LoadArchiveItemsInCacheCommand.php
@@ -12,6 +12,7 @@ use EMS\CommonBundle\Storage\StorageManager;
 use EMS\Helpers\File\TempDirectory;
 use EMS\Helpers\File\TempFile;
 use EMS\Helpers\Html\MimeTypes;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -19,11 +20,15 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
+#[AsCommand(
+    name: Commands::LOAD_ARCHIVE_IN_CACHE,
+    description: 'Load archive\'s items in cache',
+    hidden: false
+)]
 class LoadArchiveItemsInCacheCommand extends AbstractCommand
 {
     public const ARGUMENT_ARCHIVE_HASH = 'archive-hash';
     public const OPTION_CONTINUE = 'continue';
-    protected static $defaultName = Commands::LOAD_ARCHIVE_IN_CACHE;
     private string $archiveHash;
     private int $continue;
 
@@ -37,7 +42,6 @@ class LoadArchiveItemsInCacheCommand extends AbstractCommand
     {
         parent::configure();
         $this
-            ->setDescription('Load archive\'s items in cache')
             ->addArgument(self::ARGUMENT_ARCHIVE_HASH, InputArgument::REQUIRED, 'Hash of the archive file')
             ->addOption(self::OPTION_CONTINUE, null, InputOption::VALUE_OPTIONAL, 'Restart the load in cache from the specified item in the archive', 0)
         ;

--- a/EMS/common-bundle/src/Command/Submission/ForwardCommand.php
+++ b/EMS/common-bundle/src/Command/Submission/ForwardCommand.php
@@ -13,6 +13,7 @@ use EMS\Helpers\Html\MimeTypes;
 use EMS\Helpers\Security\HashcashToken;
 use EMS\Helpers\Standard\Json;
 use EMS\Helpers\Standard\Type;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -23,10 +24,13 @@ use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\Mime\Part\DataPart;
 use Symfony\Component\Mime\Part\Multipart\FormDataPart;
 
+#[AsCommand(
+    name: Commands::SUBMISSION_FORWARD,
+    description: 'Forward a form submission form the admin to a form\'s url.',
+    hidden: false
+)]
 class ForwardCommand extends AbstractCommand
 {
-    protected static $defaultName = Commands::SUBMISSION_FORWARD;
-
     public const ARG_FORM_UUID_FROM = 'form-uuid';
     public const ARG_FORM_URL_TO = 'post-url';
     private string $fromUuid;
@@ -41,7 +45,6 @@ class ForwardCommand extends AbstractCommand
     protected function configure(): void
     {
         $this
-            ->setDescription('Forward a form submission form the admin to a form\'s url')
             ->addArgument(
                 self::ARG_FORM_UUID_FROM,
                 InputArgument::REQUIRED,

--- a/EMS/common-bundle/src/Resources/config/services.xml
+++ b/EMS/common-bundle/src/Resources/config/services.xml
@@ -68,8 +68,8 @@
             <tag name="doctrine.event_listener" event="postGenerateSchema"/>
         </service>
         <service id="ems.event_listener.ip_address_listener" class="EMS\CommonBundle\EventListener\IpAddressListener">
-            <argument type="service" id="ems.request_matcher.trusted_ips"/>
             <argument>%ems.metric.enabled%</argument>
+            <argument key="$trustedIps">%ems_common.request.trusted_ips%</argument>
             <tag name="kernel.event_subscriber" />
         </service>
 
@@ -100,10 +100,6 @@
             <argument type="service" id="ems_common.core_api" />
             <argument type="service" id="ems_common.core_api.token_store" />
             <argument type="service" id="logger" />
-        </service>
-
-        <service id="ems.request_matcher.trusted_ips" class="Symfony\Component\HttpFoundation\RequestMatcher">
-            <argument key="$ips">%ems_common.request.trusted_ips%</argument>
         </service>
 
         <!-- twig -->

--- a/EMS/common-bundle/tests/Integration/App/config/config.yml
+++ b/EMS/common-bundle/tests/Integration/App/config/config.yml
@@ -4,6 +4,7 @@ parameters:
 framework:
   secret: 1621180219f163d89dc399e88cfc1807ab6448cf
   session:
+    cookie_secure: auto
     handler_id: ~
     storage_factory_id: session.storage.factory.native
   router:

--- a/EMS/common-bundle/tests/Integration/App/config/config.yml
+++ b/EMS/common-bundle/tests/Integration/App/config/config.yml
@@ -3,6 +3,7 @@ parameters:
 
 framework:
   http_method_override: false
+  handle_all_throwables: true
   secret: 1621180219f163d89dc399e88cfc1807ab6448cf
   session:
     cookie_secure: auto

--- a/EMS/common-bundle/tests/Integration/App/config/config.yml
+++ b/EMS/common-bundle/tests/Integration/App/config/config.yml
@@ -14,6 +14,8 @@ framework:
     resource: ~
     utf8: true
     strict_requirements: ~
+  php_errors:
+    log: true
   validation:
     email_validation_mode: html5
 

--- a/EMS/common-bundle/tests/Integration/App/config/config.yml
+++ b/EMS/common-bundle/tests/Integration/App/config/config.yml
@@ -6,6 +6,7 @@ framework:
   handle_all_throwables: true
   secret: 1621180219f163d89dc399e88cfc1807ab6448cf
   session:
+    cookie_samesite: strict
     cookie_secure: auto
     handler_id: ~
     storage_factory_id: session.storage.factory.native

--- a/EMS/common-bundle/tests/Integration/App/config/config.yml
+++ b/EMS/common-bundle/tests/Integration/App/config/config.yml
@@ -14,6 +14,8 @@ framework:
     resource: ~
     utf8: true
     strict_requirements: ~
+  validation:
+    email_validation_mode: html5
 
 doctrine:
   dbal:

--- a/EMS/common-bundle/tests/Integration/App/config/config.yml
+++ b/EMS/common-bundle/tests/Integration/App/config/config.yml
@@ -2,6 +2,7 @@ parameters:
   locale: 'en'
 
 framework:
+  http_method_override: false
   secret: 1621180219f163d89dc399e88cfc1807ab6448cf
   session:
     cookie_secure: auto

--- a/EMS/common-bundle/tests/Integration/App/config/config.yml
+++ b/EMS/common-bundle/tests/Integration/App/config/config.yml
@@ -26,6 +26,7 @@ doctrine:
     auto_generate_proxy_classes: '%kernel.debug%'
     naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware
     auto_mapping: true
+    enable_lazy_ghost_objects: true
 
 ems_common:
   backend_url: 'https://localhost'

--- a/EMS/common-bundle/tests/Unit/Controller/FileControllerAiTest.php
+++ b/EMS/common-bundle/tests/Unit/Controller/FileControllerAiTest.php
@@ -103,6 +103,7 @@ class FileControllerAiTest extends TestCase
         $this->assertTrue($request->hasSession());
     }
 
+    #[IgnoreDeprecations]
     public function testGetFile(): void
     {
         $this->requestRuntime->expects($this->once())

--- a/EMS/common-bundle/tests/Unit/DependencyInjection/EMSCommonExtensionAiTest.php
+++ b/EMS/common-bundle/tests/Unit/DependencyInjection/EMSCommonExtensionAiTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace EMS\Tests\CommonBundle\Unit\DependencyInjection;
 
 use EMS\CommonBundle\DependencyInjection\EMSCommonExtension;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -20,6 +21,7 @@ final class EMSCommonExtensionAiTest extends TestCase
         $this->container = new ContainerBuilder();
     }
 
+    #[IgnoreDeprecations]
     public function testLoadWithFullConfig(): void
     {
         $configs = [

--- a/EMS/common-bundle/tests/Unit/Twig/TextRuntimeTest.php
+++ b/EMS/common-bundle/tests/Unit/Twig/TextRuntimeTest.php
@@ -14,6 +14,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 class TextRuntimeTest extends TestCase
 {
     private LoggerInterface $logger;
+    private ValidatorInterface $validator;
 
     #[\Override]
     public function setUp(): void

--- a/EMS/core-bundle/src/Command/Asset/RefreshFileFieldCommand.php
+++ b/EMS/core-bundle/src/Command/Asset/RefreshFileFieldCommand.php
@@ -18,24 +18,23 @@ use EMS\CoreBundle\Service\FileService;
 use EMS\CoreBundle\Service\Revision\RevisionService;
 use EMS\Helpers\Html\MimeTypes;
 use EMS\Helpers\Standard\Json;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::ASSET_REFRESH_FILE_FIELD,
+    description: 'Refresh file field and regenerate resized images base on the EMSCO_IMAGE_MAX_SIZE environment variable.',
+    hidden: false
+)]
 class RefreshFileFieldCommand extends AbstractCommand
 {
     private const string USER = 'SYSTEM_REFRESH_FILE_FIELDS';
-    protected static $defaultName = Commands::ASSET_REFRESH_FILE_FIELD;
     private User $fakeUser;
 
     public function __construct(private readonly RevisionService $revisionService, private readonly StorageManager $storageManager, private readonly FileService $fileService, private readonly int $imageMaxSize)
     {
         parent::__construct();
-    }
-
-    #[\Override]
-    protected function configure(): void
-    {
-        $this->setDescription('Refresh file field and regenerate resized images base on the EMSCO_IMAGE_MAX_SIZE environment variable.');
     }
 
     #[\Override]

--- a/EMS/core-bundle/src/Command/Revision/Task/TaskNotificationMailCommand.php
+++ b/EMS/core-bundle/src/Command/Revision/Task/TaskNotificationMailCommand.php
@@ -9,10 +9,16 @@ use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Core\Revision\Task\TaskMailer;
 use EMS\CoreBundle\Core\Revision\Task\TaskManager;
 use EMS\CoreBundle\Core\Revision\Task\TaskStatus;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::REVISION_TASK_NOTIFICATION_MAIL,
+    description: 'Send notification mail for tasks',
+    hidden: false
+)]
 final class TaskNotificationMailCommand extends AbstractCommand
 {
     private string $subject;
@@ -21,7 +27,6 @@ final class TaskNotificationMailCommand extends AbstractCommand
     private ?\DateTimeImmutable $deadlineStart = null;
     private ?\DateTimeImmutable $deadlineEnd = null;
 
-    protected static $defaultName = Commands::REVISION_TASK_NOTIFICATION_MAIL;
     private const string OPTION_SUBJECT = 'subject';
     private const string OPTION_INCLUDE_TASK_MANAGERS = 'include-task-managers';
     private const string OPTION_DEADLINE_START = 'deadline-start';
@@ -39,7 +44,6 @@ final class TaskNotificationMailCommand extends AbstractCommand
     protected function configure(): void
     {
         $this
-            ->setDescription('Send notification mail for tasks')
             ->addOption(self::OPTION_SUBJECT, null, InputOption::VALUE_REQUIRED, 'Set mail subject', 'notification tasks')
             ->addOption(self::OPTION_DEADLINE_START, null, InputOption::VALUE_REQUIRED, 'Start deadline from now "-1 days"')
             ->addOption(self::OPTION_DEADLINE_END, null, InputOption::VALUE_REQUIRED, 'End deadline from now "+1 days"')

--- a/EMS/core-bundle/src/Command/Submission/ExportCommand.php
+++ b/EMS/core-bundle/src/Command/Submission/ExportCommand.php
@@ -13,15 +13,20 @@ use EMS\CoreBundle\Core\Mail\MailerService;
 use EMS\CoreBundle\Service\Form\Submission\FormSubmissionService;
 use EMS\Helpers\File\File;
 use EMS\Helpers\File\TempFile;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: Commands::SUBMISSION_EXPORT,
+    description: 'Extract form submissions',
+    hidden: false
+)]
 class ExportCommand extends AbstractCommand
 {
     public const MAIL_TEMPLATE = '@EMSCore/email/submissions-export.html.twig';
-    protected static $defaultName = Commands::SUBMISSION_EXPORT;
     public const ARG_FIELDS = 'fields';
     public const OPTION_FILTER = 'filter';
     public const OPTION_FILENAME = 'filename';
@@ -53,7 +58,6 @@ class ExportCommand extends AbstractCommand
     protected function configure(): void
     {
         $this
-            ->setDescription('Extract form submissions')
             ->addArgument(
                 self::ARG_FIELDS,
                 InputArgument::IS_ARRAY,

--- a/EMS/core-bundle/tests/Integration/App/config/config.yaml
+++ b/EMS/core-bundle/tests/Integration/App/config/config.yaml
@@ -18,6 +18,8 @@ framework:
     resource: '%kernel.project_dir%/config/routes.yaml'
     utf8: true
     strict_requirements: ~
+  php_errors:
+    log: true
   validation:
     email_validation_mode: html5
 

--- a/EMS/core-bundle/tests/Integration/App/config/config.yaml
+++ b/EMS/core-bundle/tests/Integration/App/config/config.yaml
@@ -30,6 +30,7 @@ doctrine:
     auto_generate_proxy_classes: '%kernel.debug%'
     naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware
     auto_mapping: true
+    enable_lazy_ghost_objects: true
 
 twig:
   debug: true

--- a/EMS/core-bundle/tests/Integration/App/config/config.yaml
+++ b/EMS/core-bundle/tests/Integration/App/config/config.yaml
@@ -10,6 +10,7 @@ framework:
   secret: 1621180219f163d89dc399e88cfc1807ab6448cf
   csrf_protection: ~
   session:
+    cookie_samesite: strict
     cookie_secure: auto
     handler_id: ~
     storage_factory_id: session.storage.factory.native

--- a/EMS/core-bundle/tests/Integration/App/config/config.yaml
+++ b/EMS/core-bundle/tests/Integration/App/config/config.yaml
@@ -5,6 +5,7 @@ parameters:
 
 framework:
   http_method_override: false
+  handle_all_throwables: true
   test: true
   secret: 1621180219f163d89dc399e88cfc1807ab6448cf
   csrf_protection: ~

--- a/EMS/core-bundle/tests/Integration/App/config/config.yaml
+++ b/EMS/core-bundle/tests/Integration/App/config/config.yaml
@@ -18,6 +18,8 @@ framework:
     resource: '%kernel.project_dir%/config/routes.yaml'
     utf8: true
     strict_requirements: ~
+  validation:
+    email_validation_mode: html5
 
 doctrine:
   dbal:

--- a/EMS/core-bundle/tests/Integration/App/config/config.yaml
+++ b/EMS/core-bundle/tests/Integration/App/config/config.yaml
@@ -4,6 +4,7 @@ parameters:
   env(EMSCH_ENVS): '{"preview":{"regex":"/.*/","alias":"test_preview","backend":"https://localhost"}}'
 
 framework:
+  http_method_override: false
   test: true
   secret: 1621180219f163d89dc399e88cfc1807ab6448cf
   csrf_protection: ~

--- a/EMS/core-bundle/tests/Integration/App/config/config.yaml
+++ b/EMS/core-bundle/tests/Integration/App/config/config.yaml
@@ -8,6 +8,7 @@ framework:
   secret: 1621180219f163d89dc399e88cfc1807ab6448cf
   csrf_protection: ~
   session:
+    cookie_secure: auto
     handler_id: ~
     storage_factory_id: session.storage.factory.native
   router:

--- a/EMS/core-bundle/tests/Unit/Twig/I18nRuntimeTest.php
+++ b/EMS/core-bundle/tests/Unit/Twig/I18nRuntimeTest.php
@@ -12,15 +12,15 @@ use PHPUnit\Framework\TestCase;
 
 class I18nRuntimeTest extends TestCase
 {
-    private readonly UserManager $service;
+    private readonly I18nService $i18nService;
     private I18nRuntime $i18nRuntime;
 
     #[\Override]
     public function setUp(): void
     {
         $this->i18nService = $this->createMock(I18nService::class);
-        $this->userManager = $this->createMock(UserManager::class);
-        $this->i18nRuntime = new I18nRuntime($this->i18nService, $this->userManager);
+        $userManager = $this->createMock(UserManager::class);
+        $this->i18nRuntime = new I18nRuntime($this->i18nService, $userManager);
     }
 
     public function testFindAllI18nIsNull()

--- a/EMS/form-bundle/tests/Integration/App/config/config.yml
+++ b/EMS/form-bundle/tests/Integration/App/config/config.yml
@@ -17,6 +17,8 @@ framework:
     resource: 'config/routes.yml'
     utf8: true
     strict_requirements: ~
+  validation:
+    email_validation_mode: html5
 
 security:
   firewalls:

--- a/EMS/form-bundle/tests/Integration/App/config/config.yml
+++ b/EMS/form-bundle/tests/Integration/App/config/config.yml
@@ -4,6 +4,7 @@ parameters:
   env(EMSCH_ENVS): '{"preview":{"regex":"/.*/","alias":"test_preview","backend":"https://localhost"}}'
 
 framework:
+  http_method_override: false
   secret: 1621180219f163d89dc399e88cfc1807ab6448cf
   csrf_protection: ~
   session:

--- a/EMS/form-bundle/tests/Integration/App/config/config.yml
+++ b/EMS/form-bundle/tests/Integration/App/config/config.yml
@@ -5,6 +5,7 @@ parameters:
 
 framework:
   http_method_override: false
+  handle_all_throwables: true
   secret: 1621180219f163d89dc399e88cfc1807ab6448cf
   csrf_protection: ~
   session:

--- a/EMS/form-bundle/tests/Integration/App/config/config.yml
+++ b/EMS/form-bundle/tests/Integration/App/config/config.yml
@@ -17,6 +17,8 @@ framework:
     resource: 'config/routes.yml'
     utf8: true
     strict_requirements: ~
+  php_errors:
+    log: true
   validation:
     email_validation_mode: html5
 

--- a/EMS/form-bundle/tests/Integration/App/config/config.yml
+++ b/EMS/form-bundle/tests/Integration/App/config/config.yml
@@ -34,6 +34,7 @@ doctrine:
     auto_generate_proxy_classes: '%kernel.debug%'
     naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware
     auto_mapping: true
+    enable_lazy_ghost_objects: true
 
 twig:
   debug: true

--- a/EMS/form-bundle/tests/Integration/App/config/config.yml
+++ b/EMS/form-bundle/tests/Integration/App/config/config.yml
@@ -9,6 +9,7 @@ framework:
   secret: 1621180219f163d89dc399e88cfc1807ab6448cf
   csrf_protection: ~
   session:
+    cookie_samesite: strict
     cookie_secure: auto
     handler_id: ~
     storage_factory_id: session.storage.factory.native

--- a/EMS/form-bundle/tests/Integration/App/config/config.yml
+++ b/EMS/form-bundle/tests/Integration/App/config/config.yml
@@ -7,6 +7,7 @@ framework:
   secret: 1621180219f163d89dc399e88cfc1807ab6448cf
   csrf_protection: ~
   session:
+    cookie_secure: auto
     handler_id: ~
     storage_factory_id: session.storage.factory.native
   router:

--- a/EMS/submission-bundle/tests/Functional/App/config/config.yml
+++ b/EMS/submission-bundle/tests/Functional/App/config/config.yml
@@ -6,6 +6,7 @@ ems_submission:
 
 framework:
   http_method_override: false
+  handle_all_throwables: true
   secret: 1621180219f163d89dc399e88cfc1807ab6448cf
   session:
     cookie_secure: auto

--- a/EMS/submission-bundle/tests/Functional/App/config/config.yml
+++ b/EMS/submission-bundle/tests/Functional/App/config/config.yml
@@ -21,6 +21,8 @@ framework:
     strict_requirements: ~
   profiler:
     enabled: true
+  validation:
+    email_validation_mode: html5
 
 twig:
   debug: true

--- a/EMS/submission-bundle/tests/Functional/App/config/config.yml
+++ b/EMS/submission-bundle/tests/Functional/App/config/config.yml
@@ -21,6 +21,8 @@ framework:
     strict_requirements: ~
   profiler:
     enabled: true
+  php_errors:
+    log: true
   validation:
     email_validation_mode: html5
 

--- a/EMS/submission-bundle/tests/Functional/App/config/config.yml
+++ b/EMS/submission-bundle/tests/Functional/App/config/config.yml
@@ -7,6 +7,7 @@ ems_submission:
 framework:
   secret: 1621180219f163d89dc399e88cfc1807ab6448cf
   session:
+    cookie_secure: auto
     handler_id: ~
     storage_factory_id: session.storage.factory.native
   mailer:

--- a/EMS/submission-bundle/tests/Functional/App/config/config.yml
+++ b/EMS/submission-bundle/tests/Functional/App/config/config.yml
@@ -9,6 +9,7 @@ framework:
   handle_all_throwables: true
   secret: 1621180219f163d89dc399e88cfc1807ab6448cf
   session:
+    cookie_samesite: strict
     cookie_secure: auto
     handler_id: ~
     storage_factory_id: session.storage.factory.native

--- a/EMS/submission-bundle/tests/Functional/App/config/config.yml
+++ b/EMS/submission-bundle/tests/Functional/App/config/config.yml
@@ -5,6 +5,7 @@ ems_submission:
     - { connection: "http-conn", user: "userTest", password: "testPass"}
 
 framework:
+  http_method_override: false
   secret: 1621180219f163d89dc399e88cfc1807ab6448cf
   session:
     cookie_secure: auto

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "endroid/qr-code-bundle": "^6.0",
         "giggsey/libphonenumber-for-php": "^8.13",
         "guzzlehttp/guzzle": "^7.8",
-        "kevinrob/guzzle-cache-middleware": "^4.1",
+        "kevinrob/guzzle-cache-middleware": "^6.0",
         "league/flysystem-memory": "^3.19",
         "league/flysystem-sftp-v3": "^3.22",
         "maennchen/zipstream-php": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "league/flysystem-sftp-v3": "^3.22",
         "maennchen/zipstream-php": "^3.0",
         "onelogin/php-saml": "^4.1",
-        "phpoffice/phpspreadsheet": "^1.29",
+        "phpoffice/phpspreadsheet": "^3.8",
         "promphp/prometheus_client_php": "^2.9",
         "psr/simple-cache": "^3.0",
         "ramsey/uuid-doctrine": "^2.1",

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "doctrine/doctrine-bundle": "^2.11",
         "doctrine/doctrine-migrations-bundle": "^3.2",
         "doctrine/orm": "^2.17",
-        "dompdf/dompdf": "^v2.0",
+        "dompdf/dompdf": "^v3.1",
         "dragonmantank/cron-expression": "^3.3",
         "endroid/qr-code-bundle": "^6.0",
         "giggsey/libphonenumber-for-php": "^8.13",

--- a/composer.json
+++ b/composer.json
@@ -202,6 +202,9 @@
         "phpcs": "PHP_CS_FIXER_IGNORE_ENV=1 php-cs-fixer fix",
         "phpstan": "phpstan analyse --memory-limit 1G",
         "phpunit": "phpunit --display-deprecations",
+        "phpunit-admin": "phpunit -c elasticms-admin/phpunit.xml.dist  --display-deprecations",
+        "phpunit-cli": "phpunit -c elasticms-cli/phpunit.xml.dist  --display-deprecations",
+        "phpunit-web": "phpunit -c elasticms-web/phpunit.xml.dist  --display-deprecations",
         "phpall": [
             "@phpunit",
             "@phpstan",

--- a/composer.lock
+++ b/composer.lock
@@ -2478,16 +2478,16 @@
         },
         {
             "name": "firebase/php-jwt",
-            "version": "v6.10.2",
+            "version": "v6.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/firebase/php-jwt.git",
-                "reference": "30c19ed0f3264cb660ea496895cfb6ef7ee3653b"
+                "reference": "8f718f4dfc9c5d5f0c994cdfd103921b43592712"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/30c19ed0f3264cb660ea496895cfb6ef7ee3653b",
-                "reference": "30c19ed0f3264cb660ea496895cfb6ef7ee3653b",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/8f718f4dfc9c5d5f0c994cdfd103921b43592712",
+                "reference": "8f718f4dfc9c5d5f0c994cdfd103921b43592712",
                 "shasum": ""
             },
             "require": {
@@ -2535,9 +2535,9 @@
             ],
             "support": {
                 "issues": "https://github.com/firebase/php-jwt/issues",
-                "source": "https://github.com/firebase/php-jwt/tree/v6.10.2"
+                "source": "https://github.com/firebase/php-jwt/tree/v6.11.0"
             },
-            "time": "2024-11-24T11:22:49+00:00"
+            "time": "2025-01-23T05:11:06+00:00"
         },
         {
             "name": "giggsey/libphonenumber-for-php",
@@ -14707,12 +14707,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "2135caa192c134f0a421ee680fa9c0e346841dbc"
+                "reference": "fa05b1cdeb1d38692aea5d34bed226b682403a6d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/2135caa192c134f0a421ee680fa9c0e346841dbc",
-                "reference": "2135caa192c134f0a421ee680fa9c0e346841dbc",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/fa05b1cdeb1d38692aea5d34bed226b682403a6d",
+                "reference": "fa05b1cdeb1d38692aea5d34bed226b682403a6d",
                 "shasum": ""
             },
             "conflict": {
@@ -15185,7 +15185,7 @@
                 "phpfastcache/phpfastcache": "<6.1.5|>=7,<7.1.2|>=8,<8.0.7",
                 "phpmailer/phpmailer": "<6.5",
                 "phpmussel/phpmussel": ">=1,<1.6",
-                "phpmyadmin/phpmyadmin": "<5.2.1",
+                "phpmyadmin/phpmyadmin": "<5.2.2",
                 "phpmyfaq/phpmyfaq": "<3.2.5|==3.2.5|>=3.2.10,<=4.0.1",
                 "phpoffice/common": "<0.2.9",
                 "phpoffice/phpexcel": "<1.8.1",
@@ -15569,7 +15569,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-22T19:04:49+00:00"
+            "time": "2025-01-23T18:06:21+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/composer.lock
+++ b/composer.lock
@@ -62,16 +62,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.337.2",
+            "version": "3.338.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "f885dd803a257da9d54e72a4750bba73e1196aee"
+                "reference": "b456832a41f4638ad8d117cedd6efaed4017e651"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/f885dd803a257da9d54e72a4750bba73e1196aee",
-                "reference": "f885dd803a257da9d54e72a4750bba73e1196aee",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/b456832a41f4638ad8d117cedd6efaed4017e651",
+                "reference": "b456832a41f4638ad8d117cedd6efaed4017e651",
                 "shasum": ""
             },
             "require": {
@@ -79,31 +79,31 @@
                 "ext-json": "*",
                 "ext-pcre": "*",
                 "ext-simplexml": "*",
-                "guzzlehttp/guzzle": "^6.5.8 || ^7.4.5",
-                "guzzlehttp/promises": "^1.4.0 || ^2.0",
-                "guzzlehttp/psr7": "^1.9.1 || ^2.4.5",
-                "mtdowling/jmespath.php": "^2.6",
-                "php": ">=7.2.5",
-                "psr/http-message": "^1.0 || ^2.0"
+                "guzzlehttp/guzzle": "^7.4.5",
+                "guzzlehttp/promises": "^2.0",
+                "guzzlehttp/psr7": "^2.4.5",
+                "mtdowling/jmespath.php": "^2.8.0",
+                "php": ">=8.1",
+                "psr/http-message": "^2.0"
             },
             "require-dev": {
                 "andrewsville/php-token-reflection": "^1.4",
                 "aws/aws-php-sns-message-validator": "~1.0",
                 "behat/behat": "~3.0",
-                "composer/composer": "^1.10.22",
+                "composer/composer": "^2.7.8",
                 "dms/phpunit-arraysubset-asserts": "^0.4.0",
                 "doctrine/cache": "~1.4",
                 "ext-dom": "*",
                 "ext-openssl": "*",
                 "ext-pcntl": "*",
                 "ext-sockets": "*",
-                "nette/neon": "^2.3",
                 "paragonie/random_compat": ">= 2",
                 "phpunit/phpunit": "^5.6.3 || ^8.5 || ^9.5",
-                "psr/cache": "^1.0 || ^2.0 || ^3.0",
-                "psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
-                "sebastian/comparator": "^1.2.3 || ^4.0",
-                "yoast/phpunit-polyfills": "^1.0"
+                "psr/cache": "^2.0 || ^3.0",
+                "psr/simple-cache": "^2.0 || ^3.0",
+                "sebastian/comparator": "^1.2.3 || ^4.0 || ^5.0",
+                "symfony/filesystem": "^v6.4.0 || ^v7.1.0",
+                "yoast/phpunit-polyfills": "^2.0"
             },
             "suggest": {
                 "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
@@ -152,11 +152,11 @@
                 "sdk"
             ],
             "support": {
-                "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
+                "forum": "https://github.com/aws/aws-sdk-php/discussions",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.337.2"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.338.0"
             },
-            "time": "2025-01-17T19:10:04+00:00"
+            "time": "2025-01-22T19:15:24+00:00"
         },
         {
             "name": "bacon/bacon-qr-code",
@@ -274,16 +274,16 @@
         },
         {
             "name": "caxy/php-htmldiff",
-            "version": "v0.1.15",
+            "version": "v0.1.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/caxy/php-htmldiff.git",
-                "reference": "6342b02ddb86fd36093ad7e2db2efc21f01ab7cd"
+                "reference": "5c580b4f09285c078f0c5cb261573412a736a8cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/caxy/php-htmldiff/zipball/6342b02ddb86fd36093ad7e2db2efc21f01ab7cd",
-                "reference": "6342b02ddb86fd36093ad7e2db2efc21f01ab7cd",
+                "url": "https://api.github.com/repos/caxy/php-htmldiff/zipball/5c580b4f09285c078f0c5cb261573412a736a8cb",
+                "reference": "5c580b4f09285c078f0c5cb261573412a736a8cb",
                 "shasum": ""
             },
             "require": {
@@ -329,9 +329,9 @@
             ],
             "support": {
                 "issues": "https://github.com/caxy/php-htmldiff/issues",
-                "source": "https://github.com/caxy/php-htmldiff/tree/v0.1.15"
+                "source": "https://github.com/caxy/php-htmldiff/tree/v0.1.16"
             },
-            "time": "2023-11-05T23:49:04+00:00"
+            "time": "2025-01-22T17:03:45+00:00"
         },
         {
             "name": "cebe/markdown",
@@ -13645,16 +13645,16 @@
         },
         {
             "name": "phpstan/phpstan-phpunit",
-            "version": "2.0.3",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-phpunit.git",
-                "reference": "e32ac656788a5bf3dedda89e6a2cad5643bf1a18"
+                "reference": "d09e152f403c843998d7a52b5d87040c937525dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/e32ac656788a5bf3dedda89e6a2cad5643bf1a18",
-                "reference": "e32ac656788a5bf3dedda89e6a2cad5643bf1a18",
+                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/d09e152f403c843998d7a52b5d87040c937525dd",
+                "reference": "d09e152f403c843998d7a52b5d87040c937525dd",
                 "shasum": ""
             },
             "require": {
@@ -13690,28 +13690,28 @@
             "description": "PHPUnit extensions and rules for PHPStan",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-phpunit/issues",
-                "source": "https://github.com/phpstan/phpstan-phpunit/tree/2.0.3"
+                "source": "https://github.com/phpstan/phpstan-phpunit/tree/2.0.4"
             },
-            "time": "2024-12-19T09:14:43+00:00"
+            "time": "2025-01-22T13:07:38+00:00"
         },
         {
             "name": "phpstan/phpstan-symfony",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-symfony.git",
-                "reference": "c08cd8e54a08d651bc402d304cfa161c3c3766c4"
+                "reference": "65f02c7e585f3c7372e42e14d3d87da034031553"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-symfony/zipball/c08cd8e54a08d651bc402d304cfa161c3c3766c4",
-                "reference": "c08cd8e54a08d651bc402d304cfa161c3c3766c4",
+                "url": "https://api.github.com/repos/phpstan/phpstan-symfony/zipball/65f02c7e585f3c7372e42e14d3d87da034031553",
+                "reference": "65f02c7e585f3c7372e42e14d3d87da034031553",
                 "shasum": ""
             },
             "require": {
                 "ext-simplexml": "*",
                 "php": "^7.4 || ^8.0",
-                "phpstan/phpstan": "^2.0"
+                "phpstan/phpstan": "^2.1.2"
             },
             "conflict": {
                 "symfony/framework-bundle": "<3.0"
@@ -13761,9 +13761,9 @@
             "description": "Symfony Framework extensions and rules for PHPStan",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-symfony/issues",
-                "source": "https://github.com/phpstan/phpstan-symfony/tree/2.0.1"
+                "source": "https://github.com/phpstan/phpstan-symfony/tree/2.0.2"
             },
-            "time": "2025-01-04T13:58:15+00:00"
+            "time": "2025-01-21T18:57:07+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -14707,12 +14707,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "e7a38fcc13e4ddfe9a28d5c7bf50aa9a9da758ec"
+                "reference": "2135caa192c134f0a421ee680fa9c0e346841dbc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/e7a38fcc13e4ddfe9a28d5c7bf50aa9a9da758ec",
-                "reference": "e7a38fcc13e4ddfe9a28d5c7bf50aa9a9da758ec",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/2135caa192c134f0a421ee680fa9c0e346841dbc",
+                "reference": "2135caa192c134f0a421ee680fa9c0e346841dbc",
                 "shasum": ""
             },
             "conflict": {
@@ -14807,7 +14807,7 @@
                 "cockpit-hq/cockpit": "<2.7|==2.7",
                 "codeception/codeception": "<3.1.3|>=4,<4.1.22",
                 "codeigniter/framework": "<3.1.9",
-                "codeigniter4/framework": "<4.4.7",
+                "codeigniter4/framework": "<4.5.8",
                 "codeigniter4/shield": "<1.0.0.0-beta8",
                 "codiad/codiad": "<=2.8.4",
                 "composer/composer": "<1.10.27|>=2,<2.2.24|>=2.3,<2.7.7",
@@ -14822,7 +14822,7 @@
                 "contao/managed-edition": "<=1.5",
                 "corveda/phpsandbox": "<1.3.5",
                 "cosenary/instagram": "<=2.3",
-                "craftcms/cms": "<4.13.2|>=5,<5.5.2",
+                "craftcms/cms": "<4.13.8|>=5,<5.5.5",
                 "croogo/croogo": "<4",
                 "cuyz/valinor": "<0.12",
                 "czim/file-handling": "<1.5|>=2,<2.3",
@@ -15189,7 +15189,7 @@
                 "phpmyfaq/phpmyfaq": "<3.2.5|==3.2.5|>=3.2.10,<=4.0.1",
                 "phpoffice/common": "<0.2.9",
                 "phpoffice/phpexcel": "<1.8.1",
-                "phpoffice/phpspreadsheet": "<=1.29.6|>=2,<=2.1.5|>=2.2,<=2.3.4|>=3,<3.7",
+                "phpoffice/phpspreadsheet": "<1.29.8|>=2,<2.1.7|>=2.2,<2.3.6|>=3,<3.8",
                 "phpseclib/phpseclib": "<2.0.47|>=3,<3.0.36",
                 "phpservermon/phpservermon": "<3.6",
                 "phpsysinfo/phpsysinfo": "<3.4.3",
@@ -15219,6 +15219,7 @@
                 "prestashop/gamification": "<2.3.2",
                 "prestashop/prestashop": "<8.1.6",
                 "prestashop/productcomments": "<5.0.2",
+                "prestashop/ps_contactinfo": "<=3.3.2",
                 "prestashop/ps_emailsubscription": "<2.6.1",
                 "prestashop/ps_facetedsearch": "<3.4.1",
                 "prestashop/ps_linklist": "<3.1",
@@ -15477,7 +15478,7 @@
                 "xataface/xataface": "<3",
                 "xpressengine/xpressengine": "<3.0.15",
                 "yab/quarx": "<2.4.5",
-                "yeswiki/yeswiki": "<=4.4.4",
+                "yeswiki/yeswiki": "<=4.4.5",
                 "yetiforce/yetiforce-crm": "<6.5",
                 "yidashi/yii2cmf": "<=2",
                 "yii2mod/yii2-cms": "<1.9.2",
@@ -15568,7 +15569,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-15T23:05:13+00:00"
+            "time": "2025-01-22T19:04:49+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "201806b2b97a0ccf1e2e09c96d792971",
+    "content-hash": "b17a68b8cb56985a16bc15f29390ca0d",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -62,16 +62,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.338.0",
+            "version": "3.338.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "b456832a41f4638ad8d117cedd6efaed4017e651"
+                "reference": "20f57e432a4696054598921e24734834ed034f5e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/b456832a41f4638ad8d117cedd6efaed4017e651",
-                "reference": "b456832a41f4638ad8d117cedd6efaed4017e651",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/20f57e432a4696054598921e24734834ed034f5e",
+                "reference": "20f57e432a4696054598921e24734834ed034f5e",
                 "shasum": ""
             },
             "require": {
@@ -154,9 +154,9 @@
             "support": {
                 "forum": "https://github.com/aws/aws-sdk-php/discussions",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.338.0"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.338.1"
             },
-            "time": "2025-01-22T19:15:24+00:00"
+            "time": "2025-01-23T19:07:00+00:00"
         },
         {
             "name": "bacon/bacon-qr-code",
@@ -2999,34 +2999,34 @@
         },
         {
             "name": "kevinrob/guzzle-cache-middleware",
-            "version": "v4.1.2",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Kevinrob/guzzle-cache-middleware.git",
-                "reference": "2546d1035e844da378b03e1fb42d3d1cf53187e2"
+                "reference": "61305ed694e763e887a04f61e71e2292bb4fbad1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Kevinrob/guzzle-cache-middleware/zipball/2546d1035e844da378b03e1fb42d3d1cf53187e2",
-                "reference": "2546d1035e844da378b03e1fb42d3d1cf53187e2",
+                "url": "https://api.github.com/repos/Kevinrob/guzzle-cache-middleware/zipball/61305ed694e763e887a04f61e71e2292bb4fbad1",
+                "reference": "61305ed694e763e887a04f61e71e2292bb4fbad1",
                 "shasum": ""
             },
             "require": {
-                "guzzlehttp/guzzle": "^6.0 || ^7.0",
-                "guzzlehttp/promises": "^1.4 || ^2.0",
-                "guzzlehttp/psr7": "^1.7.0 || ^2.0.0",
-                "php": ">=7.2.0"
+                "guzzlehttp/guzzle": "^7.9.2",
+                "guzzlehttp/promises": "^2.0.3",
+                "guzzlehttp/psr7": "^2.7.0",
+                "php": ">=8.1"
             },
             "require-dev": {
                 "cache/array-adapter": "^0.4 || ^0.5 || ^1.0",
                 "cache/simple-cache-bridge": "^0.1 || ^1.0",
                 "doctrine/cache": "^1.10",
                 "illuminate/cache": "^5.0",
-                "league/flysystem": "^1.0",
-                "phpunit/phpunit": "^8.5.15 || ^9.5",
+                "league/flysystem": "^2.5",
+                "phpunit/phpunit": "^9.6.21",
                 "psr/cache": "^1.0",
                 "symfony/cache": "^4.4 || ^5.0",
-                "symfony/phpunit-bridge": "^4.4 || ^5.0"
+                "symfony/phpunit-bridge": "^7.1.4"
             },
             "suggest": {
                 "doctrine/cache": "This library has a lot of ready-to-use cache storage (to be used with Kevinrob\\GuzzleCache\\Storage\\DoctrineCacheStorage). Use only versions >=1.4.0 < 2.0.0",
@@ -3078,9 +3078,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Kevinrob/guzzle-cache-middleware/issues",
-                "source": "https://github.com/Kevinrob/guzzle-cache-middleware/tree/v4.1.2"
+                "source": "https://github.com/Kevinrob/guzzle-cache-middleware/tree/6.0.0"
             },
-            "time": "2023-06-14T11:19:21+00:00"
+            "time": "2024-10-17T09:11:54+00:00"
         },
         {
             "name": "league/flysystem",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b17a68b8cb56985a16bc15f29390ca0d",
+    "content-hash": "2a6ffc60d14961e7951824153f3f976a",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -1843,32 +1843,34 @@
         },
         {
             "name": "dompdf/dompdf",
-            "version": "v2.0.8",
+            "version": "v3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dompdf/dompdf.git",
-                "reference": "c20247574601700e1f7c8dab39310fca1964dc52"
+                "reference": "a51bd7a063a65499446919286fb18b518177155a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dompdf/dompdf/zipball/c20247574601700e1f7c8dab39310fca1964dc52",
-                "reference": "c20247574601700e1f7c8dab39310fca1964dc52",
+                "url": "https://api.github.com/repos/dompdf/dompdf/zipball/a51bd7a063a65499446919286fb18b518177155a",
+                "reference": "a51bd7a063a65499446919286fb18b518177155a",
                 "shasum": ""
             },
             "require": {
+                "dompdf/php-font-lib": "^1.0.0",
+                "dompdf/php-svg-lib": "^1.0.0",
                 "ext-dom": "*",
                 "ext-mbstring": "*",
                 "masterminds/html5": "^2.0",
-                "phenx/php-font-lib": ">=0.5.4 <1.0.0",
-                "phenx/php-svg-lib": ">=0.5.2 <1.0.0",
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
+                "ext-gd": "*",
                 "ext-json": "*",
                 "ext-zip": "*",
                 "mockery/mockery": "^1.3",
-                "phpunit/phpunit": "^7.5 || ^8 || ^9",
-                "squizlabs/php_codesniffer": "^3.5"
+                "phpunit/phpunit": "^7.5 || ^8 || ^9 || ^10 || ^11",
+                "squizlabs/php_codesniffer": "^3.5",
+                "symfony/process": "^4.4 || ^5.4 || ^6.2 || ^7.0"
             },
             "suggest": {
                 "ext-gd": "Needed to process images",
@@ -1899,9 +1901,100 @@
             "homepage": "https://github.com/dompdf/dompdf",
             "support": {
                 "issues": "https://github.com/dompdf/dompdf/issues",
-                "source": "https://github.com/dompdf/dompdf/tree/v2.0.8"
+                "source": "https://github.com/dompdf/dompdf/tree/v3.1.0"
             },
-            "time": "2024-04-29T13:06:17+00:00"
+            "time": "2025-01-15T14:09:04+00:00"
+        },
+        {
+            "name": "dompdf/php-font-lib",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/php-font-lib.git",
+                "reference": "6137b7d4232b7f16c882c75e4ca3991dbcf6fe2d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/php-font-lib/zipball/6137b7d4232b7f16c882c75e4ca3991dbcf6fe2d",
+                "reference": "6137b7d4232b7f16c882c75e4ca3991dbcf6fe2d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^3 || ^4 || ^5 || ^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "FontLib\\": "src/FontLib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "The FontLib Community",
+                    "homepage": "https://github.com/dompdf/php-font-lib/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "A library to read, parse, export and make subsets of different types of font files.",
+            "homepage": "https://github.com/dompdf/php-font-lib",
+            "support": {
+                "issues": "https://github.com/dompdf/php-font-lib/issues",
+                "source": "https://github.com/dompdf/php-font-lib/tree/1.0.1"
+            },
+            "time": "2024-12-02T14:37:59+00:00"
+        },
+        {
+            "name": "dompdf/php-svg-lib",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/php-svg-lib.git",
+                "reference": "eb045e518185298eb6ff8d80d0d0c6b17aecd9af"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/php-svg-lib/zipball/eb045e518185298eb6ff8d80d0d0c6b17aecd9af",
+                "reference": "eb045e518185298eb6ff8d80d0d0c6b17aecd9af",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8.0",
+                "sabberworm/php-css-parser": "^8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Svg\\": "src/Svg"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "The SvgLib Community",
+                    "homepage": "https://github.com/dompdf/php-svg-lib/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "A library to read, parse and export to PDF SVG files.",
+            "homepage": "https://github.com/dompdf/php-svg-lib",
+            "support": {
+                "issues": "https://github.com/dompdf/php-svg-lib/issues",
+                "source": "https://github.com/dompdf/php-svg-lib/tree/1.0.0"
+            },
+            "time": "2024-04-29T13:26:35+00:00"
         },
         {
             "name": "dragonmantank/cron-expression",
@@ -4320,96 +4413,6 @@
                 "source": "https://github.com/paragonie/random_compat"
             },
             "time": "2020-10-15T08:29:30+00:00"
-        },
-        {
-            "name": "phenx/php-font-lib",
-            "version": "0.5.6",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/dompdf/php-font-lib.git",
-                "reference": "a1681e9793040740a405ac5b189275059e2a9863"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/dompdf/php-font-lib/zipball/a1681e9793040740a405ac5b189275059e2a9863",
-                "reference": "a1681e9793040740a405ac5b189275059e2a9863",
-                "shasum": ""
-            },
-            "require": {
-                "ext-mbstring": "*"
-            },
-            "require-dev": {
-                "symfony/phpunit-bridge": "^3 || ^4 || ^5 || ^6"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "FontLib\\": "src/FontLib"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "LGPL-2.1-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Ménager",
-                    "email": "fabien.menager@gmail.com"
-                }
-            ],
-            "description": "A library to read, parse, export and make subsets of different types of font files.",
-            "homepage": "https://github.com/PhenX/php-font-lib",
-            "support": {
-                "issues": "https://github.com/dompdf/php-font-lib/issues",
-                "source": "https://github.com/dompdf/php-font-lib/tree/0.5.6"
-            },
-            "time": "2024-01-29T14:45:26+00:00"
-        },
-        {
-            "name": "phenx/php-svg-lib",
-            "version": "0.5.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/dompdf/php-svg-lib.git",
-                "reference": "46b25da81613a9cf43c83b2a8c2c1bdab27df691"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/dompdf/php-svg-lib/zipball/46b25da81613a9cf43c83b2a8c2c1bdab27df691",
-                "reference": "46b25da81613a9cf43c83b2a8c2c1bdab27df691",
-                "shasum": ""
-            },
-            "require": {
-                "ext-mbstring": "*",
-                "php": "^7.1 || ^8.0",
-                "sabberworm/php-css-parser": "^8.4"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Svg\\": "src/Svg"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "LGPL-3.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Ménager",
-                    "email": "fabien.menager@gmail.com"
-                }
-            ],
-            "description": "A library to read, parse and export to PDF SVG files.",
-            "homepage": "https://github.com/PhenX/php-svg-lib",
-            "support": {
-                "issues": "https://github.com/dompdf/php-svg-lib/issues",
-                "source": "https://github.com/dompdf/php-svg-lib/tree/0.5.4"
-            },
-            "time": "2024-04-08T12:52:34+00:00"
         },
         {
             "name": "phpoffice/phpspreadsheet",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2a6ffc60d14961e7951824153f3f976a",
+    "content-hash": "4a64f04525543a84ef4decff0e32eb33",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -4416,16 +4416,16 @@
         },
         {
             "name": "phpoffice/phpspreadsheet",
-            "version": "1.29.8",
+            "version": "3.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPOffice/PhpSpreadsheet.git",
-                "reference": "089ffdfc04b5fcf25a3503d81a4e589f247e20e3"
+                "reference": "949c799c3538f3158bcf6c5f4d8a403027be0fbd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/089ffdfc04b5fcf25a3503d81a4e589f247e20e3",
-                "reference": "089ffdfc04b5fcf25a3503d81a4e589f247e20e3",
+                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/949c799c3538f3158bcf6c5f4d8a403027be0fbd",
+                "reference": "949c799c3538f3158bcf6c5f4d8a403027be0fbd",
                 "shasum": ""
             },
             "require": {
@@ -4442,25 +4442,24 @@
                 "ext-xmlwriter": "*",
                 "ext-zip": "*",
                 "ext-zlib": "*",
-                "ezyang/htmlpurifier": "^4.15",
                 "maennchen/zipstream-php": "^2.1 || ^3.0",
                 "markbaker/complex": "^3.0",
                 "markbaker/matrix": "^3.0",
-                "php": "^7.4 || ^8.0",
+                "php": "^8.1",
                 "psr/http-client": "^1.0",
                 "psr/http-factory": "^1.0",
                 "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
             },
             "require-dev": {
                 "dealerdirect/phpcodesniffer-composer-installer": "dev-main",
-                "dompdf/dompdf": "^1.0 || ^2.0 || ^3.0",
+                "dompdf/dompdf": "^2.0 || ^3.0",
                 "friendsofphp/php-cs-fixer": "^3.2",
                 "mitoteam/jpgraph": "^10.3",
                 "mpdf/mpdf": "^8.1.1",
                 "phpcompatibility/php-compatibility": "^9.3",
                 "phpstan/phpstan": "^1.1",
                 "phpstan/phpstan-phpunit": "^1.0",
-                "phpunit/phpunit": "^8.5 || ^9.0",
+                "phpunit/phpunit": "^10.5",
                 "squizlabs/php_codesniffer": "^3.7",
                 "tecnickcom/tcpdf": "^6.5"
             },
@@ -4515,9 +4514,9 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPOffice/PhpSpreadsheet/issues",
-                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/1.29.8"
+                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/3.8.0"
             },
-            "time": "2025-01-12T03:16:27+00:00"
+            "time": "2025-01-12T03:48:58+00:00"
         },
         {
             "name": "phpseclib/phpseclib",

--- a/elasticms-admin/.gitattributes
+++ b/elasticms-admin/.gitattributes
@@ -2,6 +2,7 @@
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /tests export-ignore
+/phpunit.xml.dist export-ignore
 
 # Set the default behavior, in case people don't have core.autocrlf set.
 * text=auto

--- a/elasticms-admin/composer.json
+++ b/elasticms-admin/composer.json
@@ -41,11 +41,7 @@
         "symfony/web-link": "6.4.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
-        "symfony/browser-kit": "6.4.*",
-        "symfony/css-selector": "6.4.*",
         "symfony/debug-bundle": "6.4.*",
-        "symfony/phpunit-bridge": "6.4.*",
         "symfony/web-profiler-bundle": "6.4.*"
     },
     "config": {

--- a/elasticms-admin/phpunit.xml.dist
+++ b/elasticms-admin/phpunit.xml.dist
@@ -1,52 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.1/phpunit.xsd"
-         backupGlobals="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          colors="true"
-         bootstrap="vendor/autoload.php"
->
+         bootstrap="../vendor/autoload.php"
+         cacheDirectory="../.cache/.phpunit.cache/admin"
+         failOnPhpunitDeprecation="true"
+         failOnNotice="true"
+         failOnRisky="true"
+         failOnWarning="true">
+
     <php>
-        <ini name="error_reporting" value="-1" />
+        <ini name="error_reporting" value="-1"/>
+        <ini name="intl.default_locale" value="en"/>
+        <ini name="intl.error_level" value="0"/>
+        <ini name="memory_limit" value="-1"/>
         <env name="KERNEL_CLASS" value="App\Admin\Kernel" />
-        <env name="APP_ENV" value="test" />
-        <env name="APP_DEBUG" value="1" />
-        <env name="APP_SECRET" value="s$cretf0rt3st" />
-        <env name="SHELL_VERBOSITY" value="-1" />
-        <!-- define your env variables for the test env here -->
-
-        <!-- ###+ symfony/swiftmailer-bundle ### -->
-        <!-- For Gmail as a transport, use: "gmail://username:password@localhost" -->
-        <!-- For a generic SMTP server, use: "smtp://localhost:25?encryption=&auth_mode=" -->
-        <!-- Delivery is disabled by default via "null://localhost" -->
-        <env name="MAILER_URL" value="null://localhost"/>
-        <!-- ###- symfony/swiftmailer-bundle ### -->
-
-        <!-- ###+ doctrine/doctrine-bundle ### -->
-        <!-- Format described at http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url -->
-        <!-- For an SQLite database, use: "sqlite:///%kernel.project_dir%/var/data.db" -->
-        <!-- Configure your db driver and server_version in config/packages/doctrine.yaml -->
+        <env name="APP_ENV" value="test"/>
+        <env name="APP_DEBUG" value="1"/>
+        <env name="APP_SECRET" value="s$cretf0rt3st"/>
+        <env name="SHELL_VERBOSITY" value="-1"/>
         <env name="DATABASE_URL" value="mysql://db_user:db_password@127.0.0.1:3306/db_name"/>
-        <!-- ###- doctrine/doctrine-bundle ### -->
     </php>
 
+    <source ignoreSuppressionOfDeprecations="true">
+        <include>
+            <directory>./src/</directory>
+        </include>
+
+        <deprecationTrigger>
+            <function>trigger_deprecation</function>
+            <method>Doctrine\Deprecations\Deprecation::trigger</method>
+            <method>Doctrine\Deprecations\Deprecation::delegateTriggerToBackend</method>
+        </deprecationTrigger>
+    </source>
+
     <testsuites>
-        <testsuite name="Project Test Suite">
+        <testsuite name="EMS - Admin">
             <directory>tests/</directory>
         </testsuite>
-        <testsuite name="Elasticms Core Test Suite">
-            <directory>vendor/elasticms/core-bundle/tests</directory>
-        </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./src/</directory>
-        </whitelist>
-    </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
-    </listeners>
 </phpunit>

--- a/elasticms-admin/tests/bootstrap.php
+++ b/elasticms-admin/tests/bootstrap.php
@@ -6,10 +6,10 @@ use Symfony\Component\Dotenv\Dotenv;
 
 require \dirname(__DIR__).'/../vendor/autoload.php';
 
-if (method_exists(Dotenv::class, 'bootEnv')) {
-    new Dotenv()->bootEnv(dirname(__DIR__).'/.env');
+if (\method_exists(Dotenv::class, 'bootEnv')) {
+    new Dotenv()->bootEnv(\dirname(__DIR__).'/.env');
 }
 
 if ($_SERVER['APP_DEBUG']) {
-    umask(0000);
+    \umask(0o000);
 }

--- a/elasticms-admin/tests/bootstrap.php
+++ b/elasticms-admin/tests/bootstrap.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 use Symfony\Component\Dotenv\Dotenv;
 
-require \dirname(__DIR__).'/vendor/autoload.php';
+require \dirname(__DIR__).'/../vendor/autoload.php';
 
-if (\file_exists(\dirname(__DIR__).'/config/bootstrap.php')) {
-    require \dirname(__DIR__).'/config/bootstrap.php';
-} elseif (\method_exists(Dotenv::class, 'bootEnv')) {
-    (new Dotenv())->bootEnv(\dirname(__DIR__).'/.env');
+if (method_exists(Dotenv::class, 'bootEnv')) {
+    new Dotenv()->bootEnv(dirname(__DIR__).'/.env');
+}
+
+if ($_SERVER['APP_DEBUG']) {
+    umask(0000);
 }

--- a/elasticms-cli/.gitattributes
+++ b/elasticms-cli/.gitattributes
@@ -2,6 +2,7 @@
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /tests export-ignore
+/phpunit.xml.dist export-ignore
 
 # Set the default behavior, in case people don't have core.autocrlf set.
 * text=auto

--- a/elasticms-cli/composer.json
+++ b/elasticms-cli/composer.json
@@ -36,8 +36,8 @@
         "symfony/yaml": "6.4.*"
     },
     "require-dev": {
-        "phpdocumentor/reflection-docblock": "^5.3",
-        "phpunit/phpunit": "^9.5"
+        "symfony/debug-bundle": "6.4.*",
+        "symfony/web-profiler-bundle": "6.4.*"
     },
     "config": {
         "allow-plugins": {

--- a/elasticms-cli/composer.json
+++ b/elasticms-cli/composer.json
@@ -21,7 +21,7 @@
         "ext-sqlite3": "*",
         "doctrine/doctrine-migrations-bundle": "^3.2",
         "elasticms/common-bundle": "6.0.*",
-        "kevinrob/guzzle-cache-middleware": "^4.1",
+        "kevinrob/guzzle-cache-middleware": "^6.0",
         "symfony/console": "6.4.*",
         "symfony/css-selector": "6.4.*",
         "symfony/dotenv": "6.4.*",

--- a/elasticms-cli/phpunit.xml.dist
+++ b/elasticms-cli/phpunit.xml.dist
@@ -1,28 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          colors="true"
-         bootstrap="vendor/autoload.php"
+         bootstrap="../vendor/autoload.php"
+         cacheDirectory="../.cache/.phpunit.cache/cli"
+         failOnPhpunitDeprecation="true"
+         failOnNotice="true"
          failOnRisky="true"
-         failOnWarning="true"
->
+         failOnWarning="true">
+
     <php>
         <ini name="error_reporting" value="-1"/>
         <ini name="intl.default_locale" value="en"/>
         <ini name="intl.error_level" value="0"/>
-        <ini name="memory_limit" value="256"/>
-        <env name="SYMFONY_PHPUNIT_VERSION" value="9.5"/>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0"/>
+        <ini name="memory_limit" value="-1"/>
+        <env name="KERNEL_CLASS" value="App\CLI\Kernel" />
+        <env name="APP_ENV" value="test"/>
+        <env name="APP_DEBUG" value="1"/>
+        <env name="APP_SECRET" value="s$cretf0rt3st"/>
+        <env name="SHELL_VERBOSITY" value="-1"/>
+        <env name="DATABASE_URL" value="mysql://db_user:db_password@127.0.0.1:3306/db_name"/>
     </php>
+
+    <source ignoreSuppressionOfDeprecations="true">
+        <include>
+            <directory>./src/</directory>
+        </include>
+
+        <deprecationTrigger>
+            <function>trigger_deprecation</function>
+            <method>Doctrine\Deprecations\Deprecation::trigger</method>
+            <method>Doctrine\Deprecations\Deprecation::delegateTriggerToBackend</method>
+        </deprecationTrigger>
+    </source>
+
     <testsuites>
-        <testsuite name="Unit suite">
-            <directory>./tests</directory>
+        <testsuite name="EMS - CLI">
+            <directory>tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory>src</directory>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/elasticms-cli/tests/bootstrap.php
+++ b/elasticms-cli/tests/bootstrap.php
@@ -6,10 +6,10 @@ use Symfony\Component\Dotenv\Dotenv;
 
 require \dirname(__DIR__).'/../vendor/autoload.php';
 
-if (method_exists(Dotenv::class, 'bootEnv')) {
-    new Dotenv()->bootEnv(dirname(__DIR__).'/.env');
+if (\method_exists(Dotenv::class, 'bootEnv')) {
+    new Dotenv()->bootEnv(\dirname(__DIR__).'/.env');
 }
 
 if ($_SERVER['APP_DEBUG']) {
-    umask(0000);
+    \umask(0o000);
 }

--- a/elasticms-cli/tests/bootstrap.php
+++ b/elasticms-cli/tests/bootstrap.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 use Symfony\Component\Dotenv\Dotenv;
 
-require \dirname(__DIR__).'/vendor/autoload.php';
+require \dirname(__DIR__).'/../vendor/autoload.php';
 
-if (\file_exists(\dirname(__DIR__).'/config/bootstrap.php')) {
-    require \dirname(__DIR__).'/config/bootstrap.php';
-} elseif (\method_exists(Dotenv::class, 'bootEnv')) {
-    (new Dotenv())->bootEnv(\dirname(__DIR__).'/.env');
+if (method_exists(Dotenv::class, 'bootEnv')) {
+    new Dotenv()->bootEnv(dirname(__DIR__).'/.env');
+}
+
+if ($_SERVER['APP_DEBUG']) {
+    umask(0000);
 }

--- a/elasticms-web/.gitattributes
+++ b/elasticms-web/.gitattributes
@@ -2,6 +2,7 @@
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /tests export-ignore
+/phpunit.xml.dist export-ignore
 
 # Set the default behavior, in case people don't have core.autocrlf set.
 * text=auto

--- a/elasticms-web/composer.json
+++ b/elasticms-web/composer.json
@@ -42,11 +42,7 @@
         "twig/intl-extra": "^3.8"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
-        "symfony/browser-kit": "6.4.*",
-        "symfony/css-selector": "6.4.*",
         "symfony/debug-bundle": "6.4.*",
-        "symfony/phpunit-bridge": "6.4.*",
         "symfony/web-profiler-bundle": "6.4.*"
     },
     "config": {

--- a/elasticms-web/phpunit.xml.dist
+++ b/elasticms-web/phpunit.xml.dist
@@ -1,35 +1,44 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.5/phpunit.xsd"
-         backupGlobals="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          colors="true"
-         bootstrap="vendor/autoload.php"
->
+         bootstrap="../vendor/autoload.php"
+         cacheDirectory="../.cache/.phpunit.cache/web"
+         failOnPhpunitDeprecation="true"
+         failOnNotice="true"
+         failOnRisky="true"
+         failOnWarning="true">
+
     <php>
-        <ini name="error_reporting" value="-1" />
+        <ini name="error_reporting" value="-1"/>
+        <ini name="intl.default_locale" value="en"/>
+        <ini name="intl.error_level" value="0"/>
+        <ini name="memory_limit" value="-1"/>
         <env name="KERNEL_CLASS" value="App\Web\Kernel" />
-        <env name="APP_ENV" value="test" />
-        <env name="APP_DEBUG" value="1" />
-        <env name="APP_SECRET" value="s$cretf0rt3st" />
-        <env name="SHELL_VERBOSITY" value="-1" />
-        <!-- define your env variables for the test env here -->
+        <env name="APP_ENV" value="test"/>
+        <env name="APP_DEBUG" value="1"/>
+        <env name="APP_SECRET" value="s$cretf0rt3st"/>
+        <env name="SHELL_VERBOSITY" value="-1"/>
+        <env name="MAILER_URL" value="null://localhost"/>
+        <env name="DATABASE_URL" value="mysql://db_user:db_password@127.0.0.1:3306/db_name"/>
     </php>
 
+    <source ignoreSuppressionOfDeprecations="true">
+        <include>
+            <directory>./src/</directory>
+        </include>
+
+        <deprecationTrigger>
+            <function>trigger_deprecation</function>
+            <method>Doctrine\Deprecations\Deprecation::trigger</method>
+            <method>Doctrine\Deprecations\Deprecation::delegateTriggerToBackend</method>
+        </deprecationTrigger>
+    </source>
+
     <testsuites>
-        <testsuite name="Project Test Suite">
+        <testsuite name="EMS - Web">
             <directory>tests/</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./src/</directory>
-        </whitelist>
-    </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
-    </listeners>
 </phpunit>

--- a/elasticms-web/tests/bootstrap.php
+++ b/elasticms-web/tests/bootstrap.php
@@ -6,10 +6,10 @@ use Symfony\Component\Dotenv\Dotenv;
 
 require \dirname(__DIR__).'/../vendor/autoload.php';
 
-if (method_exists(Dotenv::class, 'bootEnv')) {
-    new Dotenv()->bootEnv(dirname(__DIR__).'/.env');
+if (\method_exists(Dotenv::class, 'bootEnv')) {
+    new Dotenv()->bootEnv(\dirname(__DIR__).'/.env');
 }
 
 if ($_SERVER['APP_DEBUG']) {
-    umask(0000);
+    \umask(0o000);
 }

--- a/elasticms-web/tests/bootstrap.php
+++ b/elasticms-web/tests/bootstrap.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 use Symfony\Component\Dotenv\Dotenv;
 
-require \dirname(__DIR__).'/vendor/autoload.php';
+require \dirname(__DIR__).'/../vendor/autoload.php';
 
-if (\file_exists(\dirname(__DIR__).'/config/bootstrap.php')) {
-    require \dirname(__DIR__).'/config/bootstrap.php';
-} elseif (\method_exists(Dotenv::class, 'bootEnv')) {
-    (new Dotenv())->bootEnv(\dirname(__DIR__).'/.env');
+if (method_exists(Dotenv::class, 'bootEnv')) {
+    new Dotenv()->bootEnv(dirname(__DIR__).'/.env');
+}
+
+if ($_SERVER['APP_DEBUG']) {
+    umask(0000);
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,8 +10,20 @@
          failOnRisky="true"
          failOnWarning="true">
 
-    <source ignoreSuppressionOfDeprecations="true">
+    <php>
+        <ini name="error_reporting" value="-1"/>
+        <ini name="intl.default_locale" value="en"/>
+        <ini name="intl.error_level" value="0"/>
+        <ini name="memory_limit" value="-1"/>
+        <env name="APP_ENV" value="test"/>
+        <env name="APP_DEBUG" value="1"/>
+        <env name="APP_SECRET" value="s$cretf0rt3st"/>
+        <env name="SHELL_VERBOSITY" value="-1"/>
+        <env name="MAILER_URL" value="null://localhost"/>
+        <env name="DATABASE_URL" value="mysql://db_user:db_password@127.0.0.1:3306/db_name"/>
+    </php>
 
+    <source ignoreSuppressionOfDeprecations="true">
         <include>
             <directory>./elasticms-admin/src/</directory>
             <directory>./elasticms-cli/src/</directory>
@@ -31,19 +43,6 @@
             <method>Doctrine\Deprecations\Deprecation::delegateTriggerToBackend</method>
         </deprecationTrigger>
     </source>
-
-    <php>
-        <ini name="error_reporting" value="-1"/>
-        <ini name="intl.default_locale" value="en"/>
-        <ini name="intl.error_level" value="0"/>
-        <ini name="memory_limit" value="-1"/>
-        <env name="APP_ENV" value="test"/>
-        <env name="APP_DEBUG" value="1"/>
-        <env name="APP_SECRET" value="s$cretf0rt3st"/>
-        <env name="SHELL_VERBOSITY" value="-1"/>
-        <env name="MAILER_URL" value="null://localhost"/>
-        <env name="DATABASE_URL" value="mysql://db_user:db_password@127.0.0.1:3306/db_name"/>
-    </php>
 
     <testsuites>
         <testsuite name="Unit suite">


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  n |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

- [x] upgrade dompdf/dompdf from 2.0.8 -> 3.1.0 (tested generate pdf)
- [x] upgrade phpoffice/phpspreadsheet (1.29.8 => 3.8.0) (tested generate and read excel)
- [x] upgrade kevinrob/guzzle-cache-middleware from 4.1 -> 6.0 (looks good only php84 deprecations)
- [x] resolved remaining symfony deprecations
- [x] resolved php84 deprecations in tests
- [x] removed phpunit for dev dependencies for applications (admin/cli/web)
       the applications still have a phpunit.xml.dist which is only run from the monorepo check composer scripts phunit-(admin|cli|web)

