### PR TITLE
fix(helper): prevent tempFile destructor from being called too early

### DIFF
--- a/EMS/helpers/src/File/TempFile.php
+++ b/EMS/helpers/src/File/TempFile.php
@@ -9,10 +9,12 @@ use Psr\Http\Message\StreamInterface;
 
 class TempFile
 {
+    public static ?self $preventDestruct = null;
     private const string PREFIX = 'EMS_temp_file_';
 
     private function __construct(public readonly string $path)
     {
+        self::$preventDestruct = $this;
     }
 
     public function __destruct()


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

When running file-reader:import got an error message: File "/tmp/EMS_temp_file_no61lpabc1qq2doIThQ" does not exist.

Because the tempFile was destructed and deleted, caused by previous pr: https://github.com/ems-project/elasticms/pull/1147/commits/1e9e2868cac5badc34552ab7f5339d94ae9720fc

Keeping a static public references prevents the destruct from beeing called too early

