### PR TITLE
fix: temp file and directory use new destruct collector

### DIFF
--- a/EMS/helpers/src/File/TempDestructCollector.php
+++ b/EMS/helpers/src/File/TempDestructCollector.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\Helpers\File;
+
+class TempDestructCollector
+{
+    /** @var array<string, TempFile|TempDirectory> */
+    public static array $collect = [];
+
+    public static function add(TempFile|TempDirectory $temp): void
+    {
+        self::$collect[$temp->path] = $temp;
+    }
+}

--- a/EMS/helpers/src/File/TempDirectory.php
+++ b/EMS/helpers/src/File/TempDirectory.php
@@ -12,28 +12,18 @@ class TempDirectory
 {
     private const string PREFIX = 'EMS_temp_dir_';
     private readonly Filesystem $filesystem;
-    /** @var self[] */
-    private static array $collector = [];
 
     private function __construct(public readonly string $path)
     {
         $this->filesystem = new Filesystem();
         $this->filesystem->remove($this->path);
         $this->filesystem->mkdir($this->path);
-        self::$collector[] = $this;
+        TempDestructCollector::add($this);
     }
 
     public function __destruct()
     {
         $this->filesystem->remove($this->path);
-    }
-
-    /**
-     * @return self[]
-     */
-    public static function getIterator(): array
-    {
-        return self::$collector;
     }
 
     public static function create(): self

--- a/EMS/helpers/src/File/TempFile.php
+++ b/EMS/helpers/src/File/TempFile.php
@@ -9,12 +9,11 @@ use Psr\Http\Message\StreamInterface;
 
 class TempFile
 {
-    public static ?self $preventDestruct = null;
     private const string PREFIX = 'EMS_temp_file_';
 
     private function __construct(public readonly string $path)
     {
-        self::$preventDestruct = $this;
+        TempDestructCollector::add($this);
     }
 
     public function __destruct()


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   |  n |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

To make sure the temp objects do not get destructed until the end we added a new destruct collector.

We said to introduced a abstract class for tempFile & tempDirectory, but this creates to much overhead and phpstan is not happy this approach. Because both classes can only be created by a static constructor function. You can not add a private constructor on a abstract class ... So for now kept it simple.
