### PR TITLE
fix(helper/color): gd alpha's range is [0,127] while HLML alpha range is [0,255]

### DIFF
--- a/EMS/common-bundle/src/Storage/Processor/Image.php
+++ b/EMS/common-bundle/src/Storage/Processor/Image.php
@@ -423,7 +423,7 @@ class Image
         $color = new Color($colorString);
         $colors = [];
         for ($i = 0; $i < 128; ++$i) {
-            $color->alpha = $i;
+            $color->setAlphaGdValue($i);
             $colors[$i] = $color->getColorId($image);
         }
         for ($x = 0; $x < $width; ++$x) {

--- a/EMS/helpers/src/Standard/Color.php
+++ b/EMS/helpers/src/Standard/Color.php
@@ -326,6 +326,6 @@ class Color
      */
     public function setAlphaGdValue(int $i): void
     {
-        $this->alpha = 2 * $i;
+        $this->alpha = 2 * $i + (127 === $i ? 1 : 0);
     }
 }

--- a/EMS/helpers/src/Standard/Color.php
+++ b/EMS/helpers/src/Standard/Color.php
@@ -171,13 +171,13 @@ class Color
         'yellowgreen' => '9ACD32'];
 
     /** @var int<0,255> */
-    public int $red;
+    private int $red;
     /** @var int<0,255> */
-    public int $green;
+    private int $green;
     /** @var int<0,255> */
-    public int $blue;
+    private int $blue;
     /** @var int<0,255> */
-    public int $alpha;
+    private int $alpha;
 
     public function __construct(string $color)
     {
@@ -319,5 +319,13 @@ class Color
         }
 
         return $rgb;
+    }
+
+    /**
+     * @param int<0, 127> $i
+     */
+    public function setAlphaGdValue(int $i): void
+    {
+        $this->alpha = 2 * $i;
     }
 }

--- a/EMS/helpers/src/Standard/Color.php
+++ b/EMS/helpers/src/Standard/Color.php
@@ -328,4 +328,36 @@ class Color
     {
         $this->alpha = 2 * $i + (127 === $i ? 1 : 0);
     }
+
+    /**
+     * @return int<0, 255>
+     */
+    public function getRed(): int
+    {
+        return $this->red;
+    }
+
+    /**
+     * @return int<0, 255>
+     */
+    public function getGreen(): int
+    {
+        return $this->green;
+    }
+
+    /**
+     * @return int<0, 255>
+     */
+    public function getBlue(): int
+    {
+        return $this->blue;
+    }
+
+    /**
+     * @return int<0, 255>
+     */
+    public function getAlpha(): int
+    {
+        return $this->alpha;
+    }
 }

--- a/EMS/helpers/tests/Unit/Standard/ColorAiTest.php
+++ b/EMS/helpers/tests/Unit/Standard/ColorAiTest.php
@@ -12,53 +12,25 @@ class ColorAiTest extends TestCase
     public function testConstructorWithEMSColor()
     {
         $color = new Color('ems-blue');
-        $this->assertEquals(60, $color->red);
-        $this->assertEquals(141, $color->green);
-        $this->assertEquals(188, $color->blue);
+        $this->assertEquals(60, $color->getRed());
+        $this->assertEquals(141, $color->getGreen());
+        $this->assertEquals(188, $color->getBlue());
     }
 
     public function testConstructorWithStandardHtmlColor()
     {
         $color = new Color('blue');
-        $this->assertEquals(0, $color->red);
-        $this->assertEquals(0, $color->green);
-        $this->assertEquals(255, $color->blue);
+        $this->assertEquals(0, $color->getRed());
+        $this->assertEquals(0, $color->getGreen());
+        $this->assertEquals(255, $color->getBlue());
     }
 
     public function testConstructorWithHexColor()
     {
         $color = new Color('#FF5733');
-        $this->assertEquals(255, $color->red);
-        $this->assertEquals(87, $color->green);
-        $this->assertEquals(51, $color->blue);
-    }
-
-    public function testGetSetRed()
-    {
-        $color = new Color('#000000');
-        $color->red = 123;
-        $this->assertEquals(123, $color->red);
-    }
-
-    public function testGetSetGreen()
-    {
-        $color = new Color('#000000');
-        $color->green = 123;
-        $this->assertEquals(123, $color->green);
-    }
-
-    public function testGetSetBlue()
-    {
-        $color = new Color('#000000');
-        $color->blue = 123;
-        $this->assertEquals(123, $color->blue);
-    }
-
-    public function testGetSetAlpha()
-    {
-        $color = new Color('#000000');
-        $color->alpha = 123;
-        $this->assertEquals(123, $color->alpha);
+        $this->assertEquals(255, $color->getRed());
+        $this->assertEquals(87, $color->getGreen());
+        $this->assertEquals(51, $color->getBlue());
     }
 
     public function testGetColorId()
@@ -87,9 +59,9 @@ class ColorAiTest extends TestCase
     {
         $color = new Color('#FFFFFF');
         $complementary = $color->getComplementary();
-        $this->assertEquals(0, $complementary->red);
-        $this->assertEquals(0, $complementary->green);
-        $this->assertEquals(0, $complementary->blue);
+        $this->assertEquals(0, $complementary->getRed());
+        $this->assertEquals(0, $complementary->getGreen());
+        $this->assertEquals(0, $complementary->getBlue());
     }
 
     public function testGetRGB()
@@ -101,7 +73,7 @@ class ColorAiTest extends TestCase
     public function testGetRGBA()
     {
         $color = new Color('#FF5733');
-        $color->alpha = 127;
-        $this->assertEquals('#FF57337F', $color->getRGBA());
+        $color->setAlphaGdValue(127);
+        $this->assertEquals('#FF5733FF', $color->getRGBA());
     }
 }

--- a/EMS/helpers/tests/Unit/Standard/ColorTest.php
+++ b/EMS/helpers/tests/Unit/Standard/ColorTest.php
@@ -29,7 +29,7 @@ class ColorTest extends TestCase
     public function testAlpha(): void
     {
         $red = Color::fromString('red');
-        $red->alpha = 128;
+        $red->setAlphaGdValue(64);
         $this->assertSame('#FF000080', $red->html());
         $this->assertSame('#FFFFFFFE', Color::fromString('FFFFFFFE')->html());
         $this->assertSame('white', Color::fromString('FFFFFFFF')->html());


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

After the PR #1159 admin's favicon was having blur background instead of transparent