### PR TITLE
fix(admin): slug config names use separator '_'

### DIFF
--- a/EMS/core-bundle/src/Controller/ContentManagement/ActionController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/ActionController.php
@@ -90,7 +90,7 @@ final class ActionController extends AbstractController
 
         if ($form->isSubmitted() && $form->isValid()) {
             $action->setOrderKey($this->actionService->count('', $contentType) + 1);
-            $action->setName(new Encoder()->slug($action->getName())->toString());
+            $action->setName(new Encoder()->slug(text: $action->getName(), separator: '_')->toString());
             $this->templateRepository->save($action);
             $this->logger->notice('log.action.added', [
                 'action_name' => $action->getName(),

--- a/EMS/core-bundle/src/Core/Dashboard/DashboardManager.php
+++ b/EMS/core-bundle/src/Core/Dashboard/DashboardManager.php
@@ -75,7 +75,7 @@ class DashboardManager implements EntityServiceInterface
         if (0 === $dashboard->getOrderKey()) {
             $dashboard->setOrderKey($this->dashboardRepository->counter() + 1);
         }
-        $dashboard->setName(new Encoder()->slug($dashboard->getName())->toString());
+        $dashboard->setName(new Encoder()->slug(text: $dashboard->getName(), separator: '_')->toString());
         $this->dashboardRepository->create($dashboard);
     }
 

--- a/EMS/core-bundle/src/Core/Form/FormManager.php
+++ b/EMS/core-bundle/src/Core/Form/FormManager.php
@@ -68,7 +68,7 @@ class FormManager implements EntityServiceInterface
         if (0 === $form->getOrderKey()) {
             $form->setOrderKey($this->formRepository->counter() + 1);
         }
-        $form->setName(new Encoder()->slug($form->getName())->toString());
+        $form->setName(new Encoder()->slug(text: $form->getName(), separator: '_')->toString());
         $this->formRepository->create($form);
     }
 

--- a/EMS/core-bundle/src/Core/Job/ScheduleManager.php
+++ b/EMS/core-bundle/src/Core/Job/ScheduleManager.php
@@ -34,7 +34,7 @@ class ScheduleManager implements EntityServiceInterface
         if (0 === $schedule->getOrderKey()) {
             $schedule->setOrderKey($this->scheduleRepository->counter() + 1);
         }
-        $schedule->setName(new Encoder()->slug($schedule->getName())->toString());
+        $schedule->setName(new Encoder()->slug(text: $schedule->getName(), separator: '_')->toString());
         $this->scheduleRepository->create($schedule);
     }
 

--- a/EMS/core-bundle/src/Core/ManagedAlias/ManagedAliasManager.php
+++ b/EMS/core-bundle/src/Core/ManagedAlias/ManagedAliasManager.php
@@ -113,7 +113,7 @@ class ManagedAliasManager implements EntityServiceInterface
         if (!$managedAlias->hasAlias()) {
             $managedAlias->setAlias($this->instanceId);
         }
-        $managedAlias->setName(new Encoder()->slug($managedAlias->getName())->toString());
+        $managedAlias->setName(new Encoder()->slug(text: $managedAlias->getName(), separator: '_')->toString());
         $this->repository->update($managedAlias);
     }
 }

--- a/EMS/core-bundle/src/Core/View/ViewManager.php
+++ b/EMS/core-bundle/src/Core/View/ViewManager.php
@@ -73,7 +73,7 @@ class ViewManager implements EntityServiceInterface
         if (0 === $view->getOrderKey()) {
             $view->setOrderKey($this->viewRepository->counter($view->getContentType()) + 1);
         }
-        $view->setName(new Encoder()->slug($view->getName())->toString());
+        $view->setName(new Encoder()->slug(text: $view->getName(), separator: '_')->toString());
         $this->viewRepository->create($view);
     }
 

--- a/EMS/core-bundle/src/Entity/QuerySearch.php
+++ b/EMS/core-bundle/src/Entity/QuerySearch.php
@@ -69,7 +69,7 @@ class QuerySearch extends JsonDeserializer implements \JsonSerializable, EntityI
 
     public function setName(string $name): void
     {
-        $this->name = new Encoder()->slug($name)->toString();
+        $this->name = new Encoder()->slug(text: $name, separator: '_')->toString();
     }
 
     public function addEnvironment(Environment $environment): QuerySearch

--- a/EMS/core-bundle/src/Resources/DoctrineMigrations/pdo_mysql/Version20220716091159.php
+++ b/EMS/core-bundle/src/Resources/DoctrineMigrations/pdo_mysql/Version20220716091159.php
@@ -54,7 +54,7 @@ final class Version20220716091159 extends AbstractMigration
             }
             $this->addSql("UPDATE $table SET name = :name WHERE id = :id", [
                 'id' => $view['id'],
-                'name' => new Encoder()->slug($view['name'])->toString(),
+                'name' => new Encoder()->slug(text: $view['name'], separator: '_')->toString(),
             ]);
         }
     }

--- a/EMS/core-bundle/src/Resources/DoctrineMigrations/pdo_pgsql/Version20220716091159.php
+++ b/EMS/core-bundle/src/Resources/DoctrineMigrations/pdo_pgsql/Version20220716091159.php
@@ -51,7 +51,7 @@ final class Version20220716091159 extends AbstractMigration
             }
             $this->addSql("UPDATE $table SET name = :name WHERE id = :id", [
                 'id' => $view['id'],
-                'name' => new Encoder()->slug($view['name'])->toString(),
+                'name' => new Encoder()->slug(text: $view['name'], separator: '_')->toString(),
             ]);
         }
     }

--- a/EMS/core-bundle/src/Service/Channel/ChannelService.php
+++ b/EMS/core-bundle/src/Service/Channel/ChannelService.php
@@ -30,7 +30,7 @@ final readonly class ChannelService implements EntityServiceInterface
         if (0 === $channel->getOrderKey()) {
             $channel->setOrderKey($this->channelRepository->counter() + 1);
         }
-        $channel->setName(new Encoder()->slug($channel->getName())->toString());
+        $channel->setName(new Encoder()->slug(text: $channel->getName(), separator: '_')->toString());
         $this->channelRepository->create($channel);
     }
 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Otherwise, we have BC change, we should keep using '_'. Broken in previous pr, by remove the internal use of webalize.