### PR TITLE
fix(common/vite): make vite optional 

### DIFF
--- a/CHANGELOG-6.x.md
+++ b/CHANGELOG-6.x.md
@@ -1,6 +1,6 @@
 # Changelog 6.x
 
-## 6.0.0 (2025-02-03)
+## 6.0.0 (2025-02-04)
 ### Features
 * feat(admin): media library and datatable improvements by @Davidmattei in https://github.com/ems-project/elasticms/pull/1005
 * feat(admin): wywiwyg editor field for ckeditor 4 or 5 by @theus77 in https://github.com/ems-project/elasticms/pull/1129
@@ -13,7 +13,6 @@
 * feat(core/field-type): new FieldTypeService for building tree by @Davidmattei in https://github.com/ems-project/elasticms/pull/788
 * feat(core/users): permissions overview (r-n-r-summary) by @OzkanO2 in https://github.com/ems-project/elasticms/pull/780
 * feat(demo): use vite instead of webpack by @Davidmattei in https://github.com/ems-project/elasticms/pull/1178
-* feat(docker): Add a NPM_EXTRA_CMD to customize the npm config by @theus77 in https://github.com/ems-project/elasticms/pull/1175
 * feat(elasticsearch/mapping): new EMSCO_DYNAMIC_MAPPING  configuration by @theus77 in https://github.com/ems-project/elasticms/pull/711
 * feat(ems): add core bridge (api & service) by @Davidmattei in https://github.com/ems-project/elasticms/pull/1143
 * feat(web/emsch): add FormController with FormType by @Davidmattei in https://github.com/ems-project/elasticms/pull/1138
@@ -25,24 +24,18 @@
 * fix(admin): hide sensitive info to non authenticated users by @theus77 in https://github.com/ems-project/elasticms/pull/758
 * fix(admin): migration issues by @Davidmattei in https://github.com/ems-project/elasticms/pull/1122
 * fix(admin): slug config names use separator '_' by @Davidmattei in https://github.com/ems-project/elasticms/pull/1173
-* fix(admin/field): add help text support for VersionTagFieldType by @theus77 in https://github.com/ems-project/elasticms/pull/1170
-* fix(admin/submission): export command use ems property accessor  by @theus77 in https://github.com/ems-project/elasticms/pull/1142
-* fix(admin/twig): escape label in data links by @theus77 in https://github.com/ems-project/elasticms/pull/1132
 * fix(autosave): empty warnings by @theus77 in https://github.com/ems-project/elasticms/pull/792
 * fix(bootstrap 5): need a clearfix when text counter and no help by @theus77 in https://github.com/ems-project/elasticms/pull/839
-* fix(common/twig): add ems_asset_head(s) and implement for wysiwyg field by @theus77 in https://github.com/ems-project/elasticms/pull/1171
 * fix(core/bootstrap5): tabs in edit revision by @theus77 in https://github.com/ems-project/elasticms/pull/734
 * fix(core/flash-messages): obvious duplicate alerts by @theus77 in https://github.com/ems-project/elasticms/pull/794
 * fix(core/rector): entities $id is not readonly by @theus77 in https://github.com/ems-project/elasticms/pull/735
 * fix(core/revision): empty environment actions, no dropdown by @Davidmattei in https://github.com/ems-project/elasticms/pull/885
-* fix(core/twig): html escape special chars in display label by @Davidmattei in https://github.com/ems-project/elasticms/pull/1124
 * fix(core/ui): select2 icon picker by @theus77 in https://github.com/ems-project/elasticms/pull/1158
 * fix(core/wywiwyg): delegate label to RevisionService::display by @theus77 in https://github.com/ems-project/elasticms/pull/840
 * fix(demo): double css import by @theus77 in https://github.com/ems-project/elasticms/pull/791
 * fix(demo): using session in stateless api calls by @Davidmattei in https://github.com/ems-project/elasticms/pull/776
 * fix(demo/structure): get default environment for section by @theus77 in https://github.com/ems-project/elasticms/pull/709
 * fix(docker): introduce POSTGRES_VERSION env variable by @Davidmattei in https://github.com/ems-project/elasticms/pull/1137
-* fix(file-structure::push): avoid silent error when it's not possible to update the .hash file by @theus77 in https://github.com/ems-project/elasticms/pull/1146
 * fix(helper): prevent tempFile destructor from being called too early by @Davidmattei in https://github.com/ems-project/elasticms/pull/1160
 * fix(helper/color): gd alpha's range is [0,127] while HLML alpha range is [0,255] by @theus77 in https://github.com/ems-project/elasticms/pull/1168
 * fix(phpstan): resolve baseline issues by @Davidmattei in https://github.com/ems-project/elasticms/pull/1128
@@ -58,9 +51,6 @@
 * fix(symfony/6.4): remove sensio/framework-extra-bundle & annotations  by @Davidmattei in https://github.com/ems-project/elasticms/pull/708
 * fix(symfony/6.4): throw UserNotFoundException if ldap server (dn == '') is not defined by @theus77 in https://github.com/ems-project/elasticms/pull/700
 * fix(twig): apply deprecation_info for twig functions and filters by @Davidmattei in https://github.com/ems-project/elasticms/pull/1126
-* fix(twig): deprecate ems function and filters with deprecation_info by @Davidmattei in https://github.com/ems-project/elasticms/pull/1125
-* fix(web): error templates based on request format (json, xml, html, ...) by @theus77 in https://github.com/ems-project/elasticms/pull/1152
-* fix(web): performance issue with getHierarchy function by @theus77 in https://github.com/ems-project/elasticms/pull/1155
 * fix: closuse in elastica exception by @theus77 in https://github.com/ems-project/elasticms/pull/1150
 * fix: deprecations and upgrade packages (domPdf, phpOffice, guzzle) by @Davidmattei in https://github.com/ems-project/elasticms/pull/1153
 * fix: index are deprecated (an cause issues) by @theus77 in https://github.com/ems-project/elasticms/pull/1151
@@ -133,7 +123,6 @@
 ### Chores
 * chore(phpcs): enable modernize_types_casting by @Davidmattei in https://github.com/ems-project/elasticms/pull/1166
 * chore(phpcs): enable no alias functions by @Davidmattei in https://github.com/ems-project/elasticms/pull/1167
-* chore: add POSTGRES_VERSION environment variable for dev docker by @theus77 in https://github.com/ems-project/elasticms/pull/1148
 * chore: composer lint script by @Davidmattei in https://github.com/ems-project/elasticms/pull/1164
 * chore: enable strict types by @Davidmattei in https://github.com/ems-project/elasticms/pull/1133
 * chore: fix last phpUnit deprecations (doctrine) by @Davidmattei in https://github.com/ems-project/elasticms/pull/1157

--- a/elasticms-admin/composer.lock
+++ b/elasticms-admin/composer.lock
@@ -62,16 +62,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.339.4",
+            "version": "3.339.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "ea62ad03645ef7a1d3f1cda2de49f0869de3c582"
+                "reference": "7ca04301a620c9400d00108fa338ad37acf19247"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/ea62ad03645ef7a1d3f1cda2de49f0869de3c582",
-                "reference": "ea62ad03645ef7a1d3f1cda2de49f0869de3c582",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/7ca04301a620c9400d00108fa338ad37acf19247",
+                "reference": "7ca04301a620c9400d00108fa338ad37acf19247",
                 "shasum": ""
             },
             "require": {
@@ -154,9 +154,9 @@
             "support": {
                 "forum": "https://github.com/aws/aws-sdk-php/discussions",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.339.4"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.339.5"
             },
-            "time": "2025-01-31T19:04:39+00:00"
+            "time": "2025-02-03T19:04:31+00:00"
         },
         {
             "name": "brick/math",
@@ -2000,12 +2000,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ems-project/EMSAdminUIBundle.git",
-                "reference": "7493fe477e5a9941a32d00a02204ca25ba66cfae"
+                "reference": "b494f86b069b7637da26ce16e97ac9c19d0808f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ems-project/EMSAdminUIBundle/zipball/7493fe477e5a9941a32d00a02204ca25ba66cfae",
-                "reference": "7493fe477e5a9941a32d00a02204ca25ba66cfae",
+                "url": "https://api.github.com/repos/ems-project/EMSAdminUIBundle/zipball/b494f86b069b7637da26ce16e97ac9c19d0808f3",
+                "reference": "b494f86b069b7637da26ce16e97ac9c19d0808f3",
                 "shasum": ""
             },
             "require": {
@@ -2037,7 +2037,7 @@
             "support": {
                 "source": "https://github.com/ems-project/EMSAdminUIBundle/tree/6.0.0"
             },
-            "time": "2025-02-03T08:29:42+00:00"
+            "time": "2025-02-04T14:15:13+00:00"
         },
         {
             "name": "elasticms/client-helper-bundle",
@@ -2045,12 +2045,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ems-project/EMSClientHelperBundle.git",
-                "reference": "8dace3da2bf2aafef346ef2a4d817ee523f7818a"
+                "reference": "e4743f5f54b4c8ef8c245be2ef1b768df88a87f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ems-project/EMSClientHelperBundle/zipball/8dace3da2bf2aafef346ef2a4d817ee523f7818a",
-                "reference": "8dace3da2bf2aafef346ef2a4d817ee523f7818a",
+                "url": "https://api.github.com/repos/ems-project/EMSClientHelperBundle/zipball/e4743f5f54b4c8ef8c245be2ef1b768df88a87f1",
+                "reference": "e4743f5f54b4c8ef8c245be2ef1b768df88a87f1",
                 "shasum": ""
             },
             "require": {
@@ -2094,7 +2094,7 @@
             "support": {
                 "source": "https://github.com/ems-project/EMSClientHelperBundle/tree/6.0.0"
             },
-            "time": "2025-02-02T09:28:57+00:00"
+            "time": "2025-02-04T14:15:13+00:00"
         },
         {
             "name": "elasticms/common-bundle",
@@ -2102,12 +2102,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ems-project/EMSCommonBundle.git",
-                "reference": "15a390f1f95aa3539296fe3bf38474b8a02a948c"
+                "reference": "4509dccf65feb25f6d2dbc815b7f50a6668e37c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ems-project/EMSCommonBundle/zipball/15a390f1f95aa3539296fe3bf38474b8a02a948c",
-                "reference": "15a390f1f95aa3539296fe3bf38474b8a02a948c",
+                "url": "https://api.github.com/repos/ems-project/EMSCommonBundle/zipball/4509dccf65feb25f6d2dbc815b7f50a6668e37c4",
+                "reference": "4509dccf65feb25f6d2dbc815b7f50a6668e37c4",
                 "shasum": ""
             },
             "require": {
@@ -2181,7 +2181,7 @@
             "support": {
                 "source": "https://github.com/ems-project/EMSCommonBundle/tree/6.0.0"
             },
-            "time": "2025-02-02T09:28:57+00:00"
+            "time": "2025-02-04T14:15:13+00:00"
         },
         {
             "name": "elasticms/core-bundle",
@@ -2189,12 +2189,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ems-project/EMSCoreBundle.git",
-                "reference": "8d4b05fea58fd0b0f9916bb97076eba0b1c05ee0"
+                "reference": "3d42dc1c7605c89cf047f6b7f52d914ef0944d74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ems-project/EMSCoreBundle/zipball/8d4b05fea58fd0b0f9916bb97076eba0b1c05ee0",
-                "reference": "8d4b05fea58fd0b0f9916bb97076eba0b1c05ee0",
+                "url": "https://api.github.com/repos/ems-project/EMSCoreBundle/zipball/3d42dc1c7605c89cf047f6b7f52d914ef0944d74",
+                "reference": "3d42dc1c7605c89cf047f6b7f52d914ef0944d74",
                 "shasum": ""
             },
             "require": {
@@ -2249,7 +2249,7 @@
             "support": {
                 "source": "https://github.com/ems-project/EMSCoreBundle/tree/6.0.0"
             },
-            "time": "2025-02-03T15:24:20+00:00"
+            "time": "2025-02-03T17:33:14+00:00"
         },
         {
             "name": "elasticms/form-bundle",

--- a/elasticms-cli/composer.lock
+++ b/elasticms-cli/composer.lock
@@ -62,16 +62,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.339.4",
+            "version": "3.339.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "ea62ad03645ef7a1d3f1cda2de49f0869de3c582"
+                "reference": "7ca04301a620c9400d00108fa338ad37acf19247"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/ea62ad03645ef7a1d3f1cda2de49f0869de3c582",
-                "reference": "ea62ad03645ef7a1d3f1cda2de49f0869de3c582",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/7ca04301a620c9400d00108fa338ad37acf19247",
+                "reference": "7ca04301a620c9400d00108fa338ad37acf19247",
                 "shasum": ""
             },
             "require": {
@@ -154,9 +154,9 @@
             "support": {
                 "forum": "https://github.com/aws/aws-sdk-php/discussions",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.339.4"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.339.5"
             },
-            "time": "2025-01-31T19:04:39+00:00"
+            "time": "2025-02-03T19:04:31+00:00"
         },
         {
             "name": "brick/math",
@@ -1731,12 +1731,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ems-project/EMSCommonBundle.git",
-                "reference": "15a390f1f95aa3539296fe3bf38474b8a02a948c"
+                "reference": "4509dccf65feb25f6d2dbc815b7f50a6668e37c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ems-project/EMSCommonBundle/zipball/15a390f1f95aa3539296fe3bf38474b8a02a948c",
-                "reference": "15a390f1f95aa3539296fe3bf38474b8a02a948c",
+                "url": "https://api.github.com/repos/ems-project/EMSCommonBundle/zipball/4509dccf65feb25f6d2dbc815b7f50a6668e37c4",
+                "reference": "4509dccf65feb25f6d2dbc815b7f50a6668e37c4",
                 "shasum": ""
             },
             "require": {
@@ -1810,7 +1810,7 @@
             "support": {
                 "source": "https://github.com/ems-project/EMSCommonBundle/tree/6.0.0"
             },
-            "time": "2025-02-02T09:28:57+00:00"
+            "time": "2025-02-04T14:15:13+00:00"
         },
         {
             "name": "elasticms/helpers",

--- a/elasticms-web/composer.lock
+++ b/elasticms-web/composer.lock
@@ -62,16 +62,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.339.4",
+            "version": "3.339.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "ea62ad03645ef7a1d3f1cda2de49f0869de3c582"
+                "reference": "7ca04301a620c9400d00108fa338ad37acf19247"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/ea62ad03645ef7a1d3f1cda2de49f0869de3c582",
-                "reference": "ea62ad03645ef7a1d3f1cda2de49f0869de3c582",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/7ca04301a620c9400d00108fa338ad37acf19247",
+                "reference": "7ca04301a620c9400d00108fa338ad37acf19247",
                 "shasum": ""
             },
             "require": {
@@ -154,9 +154,9 @@
             "support": {
                 "forum": "https://github.com/aws/aws-sdk-php/discussions",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.339.4"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.339.5"
             },
-            "time": "2025-01-31T19:04:39+00:00"
+            "time": "2025-02-03T19:04:31+00:00"
         },
         {
             "name": "bacon/bacon-qr-code",
@@ -1978,12 +1978,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ems-project/EMSClientHelperBundle.git",
-                "reference": "8dace3da2bf2aafef346ef2a4d817ee523f7818a"
+                "reference": "e4743f5f54b4c8ef8c245be2ef1b768df88a87f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ems-project/EMSClientHelperBundle/zipball/8dace3da2bf2aafef346ef2a4d817ee523f7818a",
-                "reference": "8dace3da2bf2aafef346ef2a4d817ee523f7818a",
+                "url": "https://api.github.com/repos/ems-project/EMSClientHelperBundle/zipball/e4743f5f54b4c8ef8c245be2ef1b768df88a87f1",
+                "reference": "e4743f5f54b4c8ef8c245be2ef1b768df88a87f1",
                 "shasum": ""
             },
             "require": {
@@ -2027,7 +2027,7 @@
             "support": {
                 "source": "https://github.com/ems-project/EMSClientHelperBundle/tree/6.0.0"
             },
-            "time": "2025-02-02T09:28:57+00:00"
+            "time": "2025-02-04T14:15:13+00:00"
         },
         {
             "name": "elasticms/common-bundle",
@@ -2035,12 +2035,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ems-project/EMSCommonBundle.git",
-                "reference": "15a390f1f95aa3539296fe3bf38474b8a02a948c"
+                "reference": "4509dccf65feb25f6d2dbc815b7f50a6668e37c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ems-project/EMSCommonBundle/zipball/15a390f1f95aa3539296fe3bf38474b8a02a948c",
-                "reference": "15a390f1f95aa3539296fe3bf38474b8a02a948c",
+                "url": "https://api.github.com/repos/ems-project/EMSCommonBundle/zipball/4509dccf65feb25f6d2dbc815b7f50a6668e37c4",
+                "reference": "4509dccf65feb25f6d2dbc815b7f50a6668e37c4",
                 "shasum": ""
             },
             "require": {
@@ -2114,7 +2114,7 @@
             "support": {
                 "source": "https://github.com/ems-project/EMSCommonBundle/tree/6.0.0"
             },
-            "time": "2025-02-02T09:28:57+00:00"
+            "time": "2025-02-04T14:15:13+00:00"
         },
         {
             "name": "elasticms/form-bundle",


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   |  n |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Currently if the ems archive is not containing a .vite/manifest we receive an error.

File .vite/manifest.json not found in archive 6fd0de0fada9fabb3059463bf8007359cb3bb043
