### PR TITLE
fix(demo): fix favicon redirect to avoid _get_file_path: true

### DIFF
--- a/demo/skeleton/template/redirects/favicon.json.twig
+++ b/demo/skeleton/template/redirects/favicon.json.twig
@@ -1,16 +1,19 @@
-{% extends '@EMSCH/template/variables.twig' %}
+{%- extends '@EMSCH/template/variables.twig' -%}
 
-{%- block request %}
-    {% apply spaceless %}
-        {{ {
-            path: emsch_asset('img/head/icon.png', {
-                _config_type: 'image',
-                _image_format: 'png',
-                _width: 48,
-                _height: 48,
-                _get_file_path: true,
-            }),
-        }|json_encode|raw }}
-    {% endapply %}
-{% endblock request -%}
+{%- block request -%}
+    {%- set path = emsch_asset('img/head/icon.png', {
+        _config_type: 'image',
+        _image_format: 'png',
+        _width: 48,
+        _height: 48,
+    })|split('/') -%}
+    {{- {
+        controller: 'EMS\\CommonBundle\\Controller\\FileController::asset',
+        path: {
+            hash_config: path[path|length-3],
+            hash: 'processor',
+            filename: path[path|length-1]
+        }
+    }|json_encode|raw -}}
+{%- endblock request -%}
 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   |  n |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? |  n |
| Documentation? | n  |

not perfect but solve a perf issue
