### PR TITLE
fix(common): (new Encoder())->slug replaces '.' by '-'. 

### DIFF
--- a/EMS/common-bundle/src/Twig/AssetRuntime.php
+++ b/EMS/common-bundle/src/Twig/AssetRuntime.php
@@ -96,7 +96,11 @@ class AssetRuntime
         }
 
         if (!($config[EmsFields::ASSET_CONFIG_GET_FILE_PATH] ?? false)) {
-            $basename = (new Encoder())->slug(\basename($filename));
+            $extension = \pathinfo($filename, PATHINFO_EXTENSION);
+            $basename = (new Encoder())->slug(\basename($filename, '.'.$extension));
+            if (\strlen($extension) > 0) {
+                $basename .= '.'.$extension;
+            }
 
             return $this->urlGenerator->generate($route, [
                 'hash_config' => $hashConfig,


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   |  n |
| BC breaks?     |  n |
| Deprecations?  |  n |
| Fixed tickets? |  n |
| Documentation? | n  |

But here we need to preserve the file's extension
