### PR TITLE
fix(emsch/template): rollback exits use template builder

### DIFF
--- a/EMS/client-helper-bundle/src/Helper/Elasticsearch/Settings.php
+++ b/EMS/client-helper-bundle/src/Helper/Elasticsearch/Settings.php
@@ -70,15 +70,6 @@ final class Settings
         return $this->templateContentTypes[$contentTypeName];
     }
 
-    public function hasTemplateContentType(string $contentTypeName): bool
-    {
-        if (empty($this->templateContentTypes)) {
-            throw new \RuntimeException('Missing config EMSCH_TEMPLATES');
-        }
-
-        return isset($this->templateContentTypes[$contentTypeName]);
-    }
-
     /**
      * @return ContentType[]
      */

--- a/EMS/client-helper-bundle/src/Helper/Templating/TemplateBuilder.php
+++ b/EMS/client-helper-bundle/src/Helper/Templating/TemplateBuilder.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace EMS\ClientHelperBundle\Helper\Templating;
 
-use EMS\ClientHelperBundle\Exception\SingleResultException;
 use EMS\ClientHelperBundle\Helper\Builder\AbstractBuilder;
 use EMS\ClientHelperBundle\Helper\Environment\Environment;
 
@@ -71,24 +70,5 @@ final class TemplateBuilder extends AbstractBuilder
         $contentType = $settings->getTemplateContentType($templateName->getContentType());
 
         return $contentType->isLastPublishedAfterTime($time);
-    }
-
-    public function exists(Environment $environment, TemplateName $templateName): bool
-    {
-        $settings = $this->settings($environment);
-        if ($environment->isLocalPulled()) {
-            return null !== $environment->getLocal()->getTemplates($settings)->find($templateName);
-        }
-        if (!$settings->hasTemplateContentType($templateName->getContentType())) {
-            return false;
-        }
-
-        try {
-            $this->buildTemplate($environment, $templateName);
-        } catch (SingleResultException) {
-            return false;
-        }
-
-        return true;
     }
 }

--- a/EMS/client-helper-bundle/src/Helper/Templating/TemplateLoader.php
+++ b/EMS/client-helper-bundle/src/Helper/Templating/TemplateLoader.php
@@ -69,13 +69,8 @@ final class TemplateLoader implements LoaderInterface
         if (null === $this->environmentHelper->getCurrentEnvironment()) {
             return false;
         }
-        if (!TemplateName::validate($name)) {
-            return false;
-        }
-        $environment = $this->getEnvironment();
-        $templateName = new TemplateName($name);
 
-        return $this->builder->exists($environment, $templateName);
+        return TemplateName::validate($name);
     }
 
     private function getEnvironment(): Environment

--- a/demo/skeleton/template/variables.twig
+++ b/demo/skeleton/template/variables.twig
@@ -6,7 +6,7 @@
     {% set wyiwygReplaces = {
         'src="https://www.youtube.com/': 'allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen src="https://www.youtube-nocookie.com/',
     } %}
-    {% do emsch_assets_version(ems_template_exists('@EMSCH/template/asset_hash.twig') ? include('@EMSCH/template/asset_hash.twig') : 'demo', null) %}
+    {% do emsch_assets_version(include('@EMSCH/template/asset_hash.twig'), null) %}
     {% set baseUrl = '/' %}
     {% if app.user %}
         {% set baseUrl = "/channel/#{trans_default_domain}" %}


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

https://github.com/ems-project/elasticms/pull/1062

Rollback this pr, because it's blocking using twig cache. Because is exists is called before twig calls isFresh. Meaning for each template we query the cluster.
