### PR TITLE
feat(admin/field): multiplexed tab with emsch.locales parameter

### DIFF
--- a/EMS/admin-ui-bundle/templates/bootstrap5/macros/data-field-type.html.twig
+++ b/EMS/admin-ui-bundle/templates/bootstrap5/macros/data-field-type.html.twig
@@ -331,20 +331,20 @@
 
     {% if dataField.fieldType.displayOptions.label is defined and dataField.fieldType.displayOptions.label %}
         <div class="card card-default">
-        {% if parentType not in ['EMS\\CoreBundle\\Form\\DataField\\TabsFieldType', 'EMS\\CoreBundle\\Form\\DataField\\MultiplexedTabContainerFieldType'] %}
-            <div class="card-heading">
-                <h3 class="card-title">
-                    {% if dataField.fieldType.displayOptions.icon is defined %}
-                        <i class="{{ dataField.fieldType.displayOptions.icon }}"></i>
-                    {% endif %}
-                    {% if dataField.fieldType.displayOptions.label is defined and dataField.fieldType.displayOptions.label%}
-                        {{ dataField.fieldType.displayOptions.label }}
-                    {% else %}
-                        {{ dataField.fieldType.name }}
-                    {% endif %}
-                </h3>
-            </div>
-        {% endif %}
+            {% if parentType not in ['EMS\\CoreBundle\\Form\\DataField\\TabsFieldType', 'EMS\\CoreBundle\\Form\\DataField\\MultiplexedTabContainerFieldType'] %}
+                <div class="card-heading">
+                    <h3 class="card-title">
+                        {% if dataField.fieldType.displayOptions.icon is defined %}
+                            <i class="{{ dataField.fieldType.displayOptions.icon }}"></i>
+                        {% endif %}
+                        {% if dataField.fieldType.displayOptions.label is defined and dataField.fieldType.displayOptions.label%}
+                            {{ dataField.fieldType.displayOptions.label }}
+                        {% else %}
+                            {{ dataField.fieldType.name }}
+                        {% endif %}
+                    </h3>
+                </div>
+            {% endif %}
         <div class="card-body container-fluid">
     {% endif %}
 
@@ -409,49 +409,34 @@
 {% endblock %}
 
 {% block EMS_CoreBundle_Form_DataField_MultiplexedTabContainerFieldType %}
-    {% set labels = dataField.fieldType.displayOptions.labels|default('')|replace({"\r":''})|split('\n') %}
-    {% set values = dataField.fieldType.displayOptions.values|default('')|replace({"\r":''})|split('\n') %}
-    {% set choices = [] %}
-    {% for value in values %}
-        {% set choices = choices|merge({(value): attribute(labels, loop.index0)|default(value)}) %}
-    {% endfor %}
-
-    {% if locale != null and locale in values %}
-        {% set values = [locale]|merge(values|filter(v => v != locale))  %}
-    {% endif %}
-
-    {% if dataField.fieldType.displayOptions.localePreferredFirst|default(false) and app.user.language in values %}
-        {% set values = values|sort((a, b) => a == app.user.language ? -1 : b == app.user.language ? 1 : 0) %}
-    {% endif %}
-
-    <div class="card card-{{ theme_color }} card-outline card-outline-tabs">
-        <div class="card-header p-0 border-bottom-0">
-            <ul class="nav nav-tabs" role="tablist">
-                {% for value in values|default([]) %}
-                    <li class="nav-item {% if loop.index == 1%}active{% endif %}">
-                        <a href="#item_{{ path|join('_')~'_'~loop.index0 }}__tab" data-bs-toggle="pill" class="nav-link{% if loop.index == 1%} active{% endif %}" id="{{ path|join('_')~'_'~loop.index0 }}-tab"  data-bs-target="#item_{{ path|join('_')~'_'~loop.index0 }}__tab" role="tab" aria-selected="{% if loop.index == 1%}true{%else%}false{% endif %}">
-                            {{ attribute(choices, value) }}
-                        </a>
-                    </li>
-                {% endfor %}
-            </ul>
+<div class="card card-{{ theme_color }} card-outline card-outline-tabs">
+    <div class="card-header p-0 border-bottom-0">
+        <ul class="nav nav-tabs" role="tablist">
+            {% for key, item in  dataField.getChildren %}
+                <li class="nav-item {% if loop.index == 1%}active{% endif %}">
+                    <a href="#item_{{ path|join('_')~'_'~loop.index0 }}__tab" data-bs-toggle="pill" class="nav-link{% if loop.index == 1%} active{% endif %}" id="{{ path|join('_')~'_'~loop.index0 }}-tab"  data-bs-target="#item_{{ path|join('_')~'_'~loop.index0 }}__tab" role="tab" aria-selected="{% if loop.index == 1%}true{%else%}false{% endif %}">
+                        {{ item.formLabel ?? key }}
+                    </a>
+                </li>
+            {% endfor %}
+        </ul>
     </div>
     <div class="card-body">
         <div class="tab-content">
-            {% for value in values|default([]) %}
+            {% for key, item in  dataField.getChildren %}
                 <div class="tab-pane{% if loop.index == 1%} active{% endif %}" id="item_{{ path|join('_')~'_'~loop.index0 }}__tab">
-                    {% set childData = source[value]|default([]) %}
-                    {% set childCompareData = compareRawData[value]|default([]) %}
+                    {% set childData = source[key]|default([]) %}
+                    {% set childCompareData = compareRawData[key]|default([]) %}
                     <div class="row">
-                            {% for grandchild in dataField.getChildren.get(value).getChildren|default([]) %}
-                                <div class="{% if grandchild.fieldType.displayOptions.class is defined and grandchild.fieldType.displayOptions.class  %}{{ grandchild.fieldType.displayOptions.class }}{%else%}col-md-12{% endif %}">
-                        {{ _self.renderDataFieldBlock(grandchild, childData, compare, childCompareData, '', path|merge([loop.index0]), locale) }}
+                        {% for grandchild in item.getChildren|default([]) %}
+                            <div class="{% if grandchild.fieldType.displayOptions.class is defined and grandchild.fieldType.displayOptions.class  %}{{ grandchild.fieldType.displayOptions.class }}{%else%}col-md-12{% endif %}">
+                                {{ _self.renderDataFieldBlock(grandchild, childData, compare, childCompareData, '', path|merge([loop.index0]), locale) }}
+                            </div>
+                            {% if grandchild.fieldType.displayOptions.lastOfRow is defined and grandchild.fieldType.displayOptions.lastOfRow %}
+                                <div class="clearfix"></div>
+                            {% endif %}
+                        {% endfor %}
                     </div>
-                                {% if grandchild.fieldType.displayOptions.lastOfRow is defined and grandchild.fieldType.displayOptions.lastOfRow %}
-                                    <div class="clearfix"></div>
-                                {% endif %}
-                            {% endfor %}
-                        </div>
                 </div>
             {% endfor %}
         </div>
@@ -477,28 +462,18 @@
             <ul class="nav nav-tabs">
                 {% set counter = 1 %}
                 {% set tabs = dataField.getChildren|filter(child => not child.fieldType.deleted) %}
-                    {% set tabsLocalePreferredFirst = dataField.fieldType.displayOptions.localePreferredFirst|default(false) %}
-            {% if tabsLocalePreferredFirst and app.user.language in tabs|keys %}
-                {% set tabs = tabs|sort((a, b) => a.fieldType.name == app.user.language ? -1 : b.fieldType.name == app.user.language ? 1 : 0) %}
-            {% endif %}
+                {% set tabsLocalePreferredFirst = dataField.fieldType.displayOptions.localePreferredFirst|default(false) %}
+                {% if tabsLocalePreferredFirst and app.user.language in tabs|keys %}
+                    {% set tabs = tabs|sort((a, b) => a.fieldType.name == app.user.language ? -1 : b.fieldType.name == app.user.language ? 1 : 0) %}
+                {% endif %}
 
-            {% for child in tabs %}
-                {%if 'EMS\\CoreBundle\\Form\\DataField\\MultiplexedTabContainerFieldType' == child.fieldType.type|default(null) %}
-                        {% set labels = child.fieldType.displayOptions.labels|default('')|replace({"\r":''})|split('\n') %}
-                        {% set values = child.fieldType.displayOptions.values|default('')|replace({"\r":''})|split('\n')%}
-                        {% set choices = [] %}
-                        {% for value in values %}
-                            {% set choices = choices|merge({(value): attribute(labels, loop.index0)|default(value)}) %}
-                        {% endfor %}
-                        {% if child.fieldType.displayOptions.localePreferredFirst|default(false) and app.user.language in values %}
-                            {% set values = values|sort((a, b) => a == app.user.language ? -1 : b == app.user.language ? 1 : 0) %}
-                        {% endif %}
-
-                        {% for value in values %}
+                {% for child in tabs %}
+                    {%if 'EMS\\CoreBundle\\Form\\DataField\\MultiplexedTabContainerFieldType' == child.fieldType.type|default(null) %}
+                        {% for key, item in  child.getChildren %}
                             {% with {
-                                'child': child.getChildren[value],
+                                'child': item,
                                 'counter': counter,
-                                'label': attribute(choices, value),
+                                'label': item.formLabel ?? key,
                                 'path': path|merge([counter]),
                             }
                             %}
@@ -530,8 +505,7 @@
                             {% with {
                                 'child': item,
                                 'counter': counter,
-                            }
-                            %}
+                            } %}
                                 <div class="tab-pane fade{% if counter == 1%} active show{% endif %}" id="item_{{ path|join('_')~'_'~counter }}__tab" role="tabpanel" aria-labelledby="{{ path|join('_') }}-tab">
                                     {% set childData = source[key]|default([]) %}
                                     {% set childCompareData = compareRawData[key]|default([]) %}

--- a/EMS/admin-ui-bundle/templates/bootstrap5/macros/data-field-type.html.twig
+++ b/EMS/admin-ui-bundle/templates/bootstrap5/macros/data-field-type.html.twig
@@ -430,32 +430,32 @@
                 {% for value in values|default([]) %}
                     <li class="nav-item {% if loop.index == 1%}active{% endif %}">
                         <a href="#item_{{ path|join('_')~'_'~loop.index0 }}__tab" data-bs-toggle="pill" class="nav-link{% if loop.index == 1%} active{% endif %}" id="{{ path|join('_')~'_'~loop.index0 }}-tab"  data-bs-target="#item_{{ path|join('_')~'_'~loop.index0 }}__tab" role="tab" aria-selected="{% if loop.index == 1%}true{%else%}false{% endif %}">
-            {{ attribute(choices, value) }}
-        </a>
-    </li>
-{% endfor %}
-</ul>
-</div>
-<div class="card-body">
-    <div class="tab-content">
-        {% for value in values|default([]) %}
-            <div class="tab-pane{% if loop.index == 1%} active{% endif %}" id="item_{{ path|join('_')~'_'~loop.index0 }}__tab">
-                {% set childData = source[value]|default([]) %}
-                {% set childCompareData = compareRawData[value]|default([]) %}
-                <div class="row">
-                        {% for grandchild in dataField.getChildren.get(value).getChildren|default([]) %}
-                            <div class="{% if grandchild.fieldType.displayOptions.class is defined and grandchild.fieldType.displayOptions.class  %}{{ grandchild.fieldType.displayOptions.class }}{%else%}col-md-12{% endif %}">
-                    {{ _self.renderDataFieldBlock(grandchild, childData, compare, childCompareData, '', path|merge([loop.index0]), locale) }}
-                </div>
-                            {% if grandchild.fieldType.displayOptions.lastOfRow is defined and grandchild.fieldType.displayOptions.lastOfRow %}
-                                <div class="clearfix"></div>
-                            {% endif %}
-                        {% endfor %}
-                    </div>
-            </div>
-        {% endfor %}
+                            {{ attribute(choices, value) }}
+                        </a>
+                    </li>
+                {% endfor %}
+            </ul>
     </div>
-</div>
+    <div class="card-body">
+        <div class="tab-content">
+            {% for value in values|default([]) %}
+                <div class="tab-pane{% if loop.index == 1%} active{% endif %}" id="item_{{ path|join('_')~'_'~loop.index0 }}__tab">
+                    {% set childData = source[value]|default([]) %}
+                    {% set childCompareData = compareRawData[value]|default([]) %}
+                    <div class="row">
+                            {% for grandchild in dataField.getChildren.get(value).getChildren|default([]) %}
+                                <div class="{% if grandchild.fieldType.displayOptions.class is defined and grandchild.fieldType.displayOptions.class  %}{{ grandchild.fieldType.displayOptions.class }}{%else%}col-md-12{% endif %}">
+                        {{ _self.renderDataFieldBlock(grandchild, childData, compare, childCompareData, '', path|merge([loop.index0]), locale) }}
+                    </div>
+                                {% if grandchild.fieldType.displayOptions.lastOfRow is defined and grandchild.fieldType.displayOptions.lastOfRow %}
+                                    <div class="clearfix"></div>
+                                {% endif %}
+                            {% endfor %}
+                        </div>
+                </div>
+            {% endfor %}
+        </div>
+    </div>
 </div>
 {% endblock %}
 
@@ -538,8 +538,8 @@
                                     <div class="row">
                                     {% for grandchild in child.getChildren|default([]) %}
                                         <div class="{% if grandchild.fieldType.displayOptions.class is defined and grandchild.fieldType.displayOptions.class  %}{{ grandchild.fieldType.displayOptions.class }}{%else%}col-md-12{% endif %}">
-                                        {{ _self.renderDataFieldBlock(grandchild, childData, compare, childCompareData, '', path|merge([counter]), locale) }}
-                                    </div>
+                                            {{ _self.renderDataFieldBlock(grandchild, childData, compare, childCompareData, '', path|merge([counter]), locale) }}
+                                        </div>
                                         {% if grandchild.fieldType.displayOptions.lastOfRow is defined and grandchild.fieldType.displayOptions.lastOfRow %}
                                             <div class="clearfix"></div>
                                         {% endif %}

--- a/EMS/core-bundle/config/form.xml
+++ b/EMS/core-bundle/config/form.xml
@@ -178,6 +178,7 @@
             <argument type="service" id="form.registry" />
             <argument type="service" id="ems.service.elasticsearch" />
             <argument type="service" id="emsco.manager.user" />
+            <argument>%emsch.locales%</argument>
             <tag name="ems.form.datafieldtype" alias="multiplexed_tab_container" />
             <tag name="form.type"/>
         </service>

--- a/EMS/core-bundle/src/Core/Revision/RawDataTransformer.php
+++ b/EMS/core-bundle/src/Core/Revision/RawDataTransformer.php
@@ -32,13 +32,13 @@ final class RawDataTransformer
                     if (0 === \count($jsonNames)) {
                         $out[$child->getName()] = self::transform($child, $data);
                     } else {
-                        $colectedData = [];
+                        $collectedData = [];
                         foreach ($jsonNames as $name) {
                             if (isset($data[$name])) {
-                                $colectedData[$name] = self::transform($child, $data[$name]);
+                                $collectedData[$name] = self::transform($child, $data[$name]);
                             }
                         }
-                        $out[$child->getName()] = $colectedData;
+                        $out[$child->getName()] = $collectedData;
                     }
                 } else {
                     $out[$child->getName()] = $type::filterSubField($data, $child->getOptions());

--- a/EMS/core-bundle/src/Entity/DataField.php
+++ b/EMS/core-bundle/src/Entity/DataField.php
@@ -48,6 +48,7 @@ class DataField implements \ArrayAccess, \IteratorAggregate, \Stringable
     private bool $marked = false;
 
     private ?DataFieldFormOptions $formOptions = null;
+    private ?string $formLabel = null;
 
     public function setChildrenFieldType(FieldType $fieldType): void
     {
@@ -726,5 +727,15 @@ class DataField implements \ArrayAccess, \IteratorAggregate, \Stringable
     public function setFormOptions(?DataFieldFormOptions $formOptions): void
     {
         $this->formOptions = $formOptions;
+    }
+
+    public function setFormLabel(string $label): void
+    {
+        $this->formLabel = $label;
+    }
+
+    public function getFormLabel(): ?string
+    {
+        return $this->formLabel;
     }
 }

--- a/EMS/core-bundle/src/Entity/FieldType.php
+++ b/EMS/core-bundle/src/Entity/FieldType.php
@@ -222,6 +222,14 @@ class FieldType extends JsonDeserializer implements \JsonSerializable
     }
 
     /**
+     * @param array<mixed> $displayOptions
+     */
+    public function setDisplayOptions(array $displayOptions): void
+    {
+        $this->options[self::DISPLAY_OPTIONS] = $displayOptions;
+    }
+
+    /**
      * @param ?mixed $default
      *
      * @return mixed

--- a/EMS/core-bundle/src/Entity/Revision.php
+++ b/EMS/core-bundle/src/Entity/Revision.php
@@ -97,7 +97,7 @@ class Revision implements EntityInterface, \Stringable
     }
 
     /**
-     * Remove virtual fields ans save the raw data.
+     * Remove virtual fields and save the raw data.
      *
      * @param array<mixed> $data
      */

--- a/EMS/core-bundle/src/Form/DataField/MultiplexedTabContainerFieldType.php
+++ b/EMS/core-bundle/src/Form/DataField/MultiplexedTabContainerFieldType.php
@@ -209,11 +209,10 @@ final class MultiplexedTabContainerFieldType extends DataFieldType
             }
         }
 
-        $labels = $fieldType->getDisplayOption(self::LABELS_DISPLAY_OPTION) ?? '';
         $values = $fieldType->getDisplayOption(self::VALUES_DISPLAY_OPTION);
         if (null !== $values) {
             $values = self::textAreaToArray($values);
-            $labels = self::textAreaToArray($labels);
+            $labels = self::textAreaToArray($fieldType->getDisplayOption(self::LABELS_DISPLAY_OPTION));
             $counter = 0;
             foreach ($values as $value) {
                 $choices[$value] = $labels[$counter++] ?? $value;

--- a/EMS/core-bundle/src/Form/DataField/MultiplexedTabContainerFieldType.php
+++ b/EMS/core-bundle/src/Form/DataField/MultiplexedTabContainerFieldType.php
@@ -15,21 +15,27 @@ use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormRegistryInterface;
+use Symfony\Component\Intl\Locales;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 final class MultiplexedTabContainerFieldType extends DataFieldType
 {
     private const string LOCALE_PREFERRED_FIRST_DISPLAY_OPTION = 'localePreferredFirst';
+    private const string WITH_LOCALES_VARIABLE_DISPLAY_OPTION = 'withLocalesVariable';
     private const string LABELS_DISPLAY_OPTION = 'labels';
     private const string VALUES_DISPLAY_OPTION = 'values';
     private const string ICON_DISPLAY_OPTION = 'icon';
 
+    /**
+     * @param string[] $locales
+     */
     public function __construct(
         AuthorizationCheckerInterface $authorizationChecker,
         FormRegistryInterface $formRegistry,
         ElasticsearchService $elasticsearchService,
-        private readonly UserManager $userManager
+        private readonly UserManager $userManager,
+        private readonly array $locales
     ) {
         parent::__construct($authorizationChecker, $formRegistry, $elasticsearchService);
     }
@@ -66,6 +72,9 @@ final class MultiplexedTabContainerFieldType extends DataFieldType
         ->add(self::LOCALE_PREFERRED_FIRST_DISPLAY_OPTION, CheckboxType::class, [
             'required' => false,
         ])
+        ->add(self::WITH_LOCALES_VARIABLE_DISPLAY_OPTION, CheckboxType::class, [
+            'required' => false,
+        ])
         ->add(self::ICON_DISPLAY_OPTION, IconPickerType::class, [
             'required' => false,
         ]);
@@ -90,6 +99,7 @@ final class MultiplexedTabContainerFieldType extends DataFieldType
         $resolver->setDefault(self::VALUES_DISPLAY_OPTION, '');
         $resolver->setDefault(self::LABELS_DISPLAY_OPTION, '');
         $resolver->setDefault(self::LOCALE_PREFERRED_FIRST_DISPLAY_OPTION, false);
+        $resolver->setDefault(self::WITH_LOCALES_VARIABLE_DISPLAY_OPTION, false);
         $resolver->setDefault(self::ICON_DISPLAY_OPTION, null);
     }
 
@@ -138,8 +148,8 @@ final class MultiplexedTabContainerFieldType extends DataFieldType
         if (!$fieldType instanceof FieldType) {
             throw new \RuntimeException('Unexpected FieldType type');
         }
-
-        foreach ($this->getChoices($fieldType, $options['locale']) as $label => $value) {
+        $choices = $this->getChoices($fieldType, $options['locale']);
+        foreach ($choices as $label => $value) {
             $builder->add($value, ContainerFieldType::class, [
                 'metadata' => $fieldType,
                 'label' => $label,
@@ -192,6 +202,13 @@ final class MultiplexedTabContainerFieldType extends DataFieldType
     private function getChoices(FieldType $fieldType, ?string $locale = null): array
     {
         $choices = [];
+
+        if (true === $fieldType->getDisplayOption(self::WITH_LOCALES_VARIABLE_DISPLAY_OPTION)) {
+            foreach ($this->locales as $locale) {
+                $choices[$locale] = Locales::getName($locale);
+            }
+        }
+
         $labels = $fieldType->getDisplayOption(self::LABELS_DISPLAY_OPTION) ?? '';
         $values = $fieldType->getDisplayOption(self::VALUES_DISPLAY_OPTION);
         if (null !== $values) {

--- a/EMS/core-bundle/src/Form/DataField/MultiplexedTabContainerFieldType.php
+++ b/EMS/core-bundle/src/Form/DataField/MultiplexedTabContainerFieldType.php
@@ -226,7 +226,13 @@ final class MultiplexedTabContainerFieldType extends DataFieldType
 
         $choices = \array_flip($choices);
 
-        $localePreferredFirst = $fieldType->getDisplayBoolOption(self::LOCALE_PREFERRED_FIRST_DISPLAY_OPTION, false);
+        if (true === $fieldType->getDisplayOption(self::WITH_LOCALES_VARIABLE_DISPLAY_OPTION)) {
+            $options = $fieldType->getDisplayOptions();
+            $options[self::LABELS_DISPLAY_OPTION] = \implode(PHP_EOL, \array_keys($choices));
+            $options[self::VALUES_DISPLAY_OPTION] = \implode(PHP_EOL, $choices);
+            $fieldType->setDisplayOptions($options);
+        }
+
         if (!$localePreferredFirst) {
             return $choices;
         }

--- a/EMS/core-bundle/src/Form/DataField/MultiplexedTabContainerFieldType.php
+++ b/EMS/core-bundle/src/Form/DataField/MultiplexedTabContainerFieldType.php
@@ -219,7 +219,8 @@ final class MultiplexedTabContainerFieldType extends DataFieldType
             }
         }
 
-        if ($locale && isset($choices[$locale])) {
+        $localePreferredFirst = $fieldType->getDisplayBoolOption(self::LOCALE_PREFERRED_FIRST_DISPLAY_OPTION, false);
+        if (!$localePreferredFirst && $locale && isset($choices[$locale])) {
             $choices = [...[$locale => $choices[$locale]], ...\array_filter($choices, static fn ($l) => $l !== $locale)];
         }
 

--- a/EMS/core-bundle/src/Form/DataField/MultiplexedTabContainerFieldType.php
+++ b/EMS/core-bundle/src/Form/DataField/MultiplexedTabContainerFieldType.php
@@ -203,7 +203,8 @@ final class MultiplexedTabContainerFieldType extends DataFieldType
     {
         $choices = [];
 
-        if (true === $fieldType->getDisplayOption(self::WITH_LOCALES_VARIABLE_DISPLAY_OPTION)) {
+        $withLocalesVariable = true === $fieldType->getDisplayOption(self::WITH_LOCALES_VARIABLE_DISPLAY_OPTION, false);
+        if ($withLocalesVariable) {
             foreach ($this->locales as $locale) {
                 $choices[$locale] = Locales::getName($locale);
             }
@@ -226,7 +227,7 @@ final class MultiplexedTabContainerFieldType extends DataFieldType
 
         $choices = \array_flip($choices);
 
-        if (true === $fieldType->getDisplayOption(self::WITH_LOCALES_VARIABLE_DISPLAY_OPTION)) {
+        if ($withLocalesVariable) {
             $options = $fieldType->getDisplayOptions();
             $options[self::LABELS_DISPLAY_OPTION] = \implode(PHP_EOL, \array_keys($choices));
             $options[self::VALUES_DISPLAY_OPTION] = \implode(PHP_EOL, $choices);

--- a/EMS/core-bundle/src/Service/DataService.php
+++ b/EMS/core-bundle/src/Service/DataService.php
@@ -1703,8 +1703,11 @@ class DataService
         /** @var DataField $out */
         $out = $form->getNormData();
         foreach ($form as $key => $item) {
-            if ($item->getNormData() instanceof DataField) {
+            $data = $item->getNormData();
+            if ($data instanceof DataField) {
                 $out->addChild($item->getNormData(), $key);
+                $options = $item->getConfig()->getOptions();
+                $data->setFormLabel(isset($options['label']) && \is_string($options['label']) ? $options['label'] : $key);
                 $this->getDataFieldsStructure($item);
             }
         }

--- a/EMS/core-bundle/templates/macros/data-field-type.html.twig
+++ b/EMS/core-bundle/templates/macros/data-field-type.html.twig
@@ -409,41 +409,26 @@
 {% endblock %}
 
 {% block EMS_CoreBundle_Form_DataField_MultiplexedTabContainerFieldType %}
-	{% set labels = dataField.fieldType.displayOptions.labels|default('')|replace({"\r":''})|split('\n') %}
-	{% set values = dataField.fieldType.displayOptions.values|default('')|replace({"\r":''})|split('\n') %}
-	{% set choices = [] %}
-	{% for value in values %}
-		{% set choices = choices|merge({(value): attribute(labels, loop.index0)|default(value)}) %}
-	{% endfor %}
-
-    {% if locale != null and locale in values %}
-        {% set values = [locale]|merge(values|filter(v => v != locale))  %}
-    {% endif %}
-
-	{% if dataField.fieldType.displayOptions.localePreferredFirst|default(false) and app.user.language in values %}
-		{% set values = values|sort((a, b) => a == app.user.language ? -1 : b == app.user.language ? 1 : 0) %}
-	{% endif %}
-
 	<div class="nav-tabs-custom">
 		<ul class="nav nav-tabs">
-			{% for value in values|default([]) %}
-				<li class="{% if loop.index == 1%}active{% endif %}">
-					<a href="#item_{{ path|join('_')~'_'~loop.index0 }}__tab" data-toggle="tab" aria-expanded="{% if loop.index == 1%}true{% else %}false{% endif %}">
-						{{ attribute(choices, value) }}
-					</a>
-				</li>
-			{% endfor %}
+            {% for key, item in  dataField.getChildren %}
+                <li class="{% if loop.index == 1%}active{% endif %}">
+                    <a href="#item_{{ path|join('_')~'_'~loop.index0 }}__tab" data-toggle="tab" aria-expanded="{% if loop.index == 1%}true{% else %}false{% endif %}">
+                        {{ item.formLabel ?? key }}
+                    </a>
+                </li>
+            {% endfor %}
 		</ul>
 		<div class="tab-content">
-			{% for value in values|default([]) %}
-				<div class="tab-pane{% if loop.index == 1%} active{% endif %}" id="item_{{ path|join('_')~'_'~loop.index0 }}__tab">
-					{% set childData = source[value]|default([]) %}
-					{% set childCompareData = compareRawData[value]|default([]) %}
-					<div class="row">
-						{% for grandchild in dataField.getChildren.get(value).getChildren|default([]) %}
+            {% for key, item in  dataField.getChildren %}
+                <div class="tab-pane{% if loop.index == 1%} active{% endif %}" id="item_{{ path|join('_')~'_'~loop.index0 }}__tab">
+                    {% set childData = source[key]|default([]) %}
+                    {% set childCompareData = compareRawData[key]|default([]) %}
+                    <div class="row">
+                        {% for grandchild in item.getChildren|default([]) %}
 							<div class="{% if grandchild.fieldType.displayOptions.class is defined and grandchild.fieldType.displayOptions.class  %}{{ grandchild.fieldType.displayOptions.class }}{%else%}col-md-12{% endif %}">
-								{{ _self.renderDataFieldBlock(grandchild, childData, compare, childCompareData, '', path|merge([loop.index0]), locale) }}
-							</div>
+                                {{ _self.renderDataFieldBlock(grandchild, childData, compare, childCompareData, '', path|merge([loop.index0]), locale) }}
+                            </div>
 							{% if grandchild.fieldType.displayOptions.lastOfRow is defined and grandchild.fieldType.displayOptions.lastOfRow %}
 								<div class="clearfix"></div>
 							{% endif %}
@@ -480,21 +465,11 @@
 
             {% for child in tabs %}
 				{% if 'EMS\\CoreBundle\\Form\\DataField\\MultiplexedTabContainerFieldType' == child.fieldType.type|default(null) %}
-					{% set labels = child.fieldType.displayOptions.labels|default('')|replace({"\r":''})|split('\n') %}
-					{% set values = child.fieldType.displayOptions.values|default('')|replace({"\r":''})|split('\n')%}
-					{% set choices = [] %}
-					{% for value in values %}
-						{% set choices = choices|merge({(value): attribute(labels, loop.index0)|default(value)}) %}
-					{% endfor %}
-					{% if child.fieldType.displayOptions.localePreferredFirst|default(false) and app.user.language in values %}
-						{% set values = values|sort((a, b) => a == app.user.language ? -1 : b == app.user.language ? 1 : 0) %}
-					{% endif %}
-
-					{% for value in values %}
+                    {% for key, item in  child.getChildren %}
 						{% with {
-							'child': child.getChildren[value],
+							'child': item,
 							'counter': counter,
-							'label': attribute(choices, value),
+							'label': item.formLabel ?? key,
 							'path': path|merge([counter]),
 							}
 						%}

--- a/demo/configs/admin/content-type/category.json
+++ b/demo/configs/admin/content-type/category.json
@@ -86,10 +86,11 @@
                                     "class": "col-md-12",
                                     "lastOfRow": false,
                                     "helptext": null,
-                                    "values": "fr\r\nnl",
-                                    "labels": "French\r\nDutch",
+                                    "values": null,
+                                    "labels": null,
                                     "localePreferredFirst": true,
-                                    "icon": null
+                                    "icon": null,
+                                    "withLocalesVariable": true
                                 },
                                 "mappingOptions": [],
                                 "restrictionOptions": [],
@@ -144,7 +145,7 @@
                                                 "protected": false
                                             }
                                         },
-                                        "orderKey": 1,
+                                        "orderKey": 0,
                                         "children": []
                                     },
                                     "replaced": []
@@ -187,7 +188,7 @@
                                                 "protected": false
                                             }
                                         },
-                                        "orderKey": 2,
+                                        "orderKey": 1,
                                         "children": []
                                     },
                                     "replaced": []

--- a/demo/configs/admin/content-type/form_instance.json
+++ b/demo/configs/admin/content-type/form_instance.json
@@ -615,10 +615,11 @@
                                                                                     "class": "col-md-12",
                                                                                     "lastOfRow": false,
                                                                                     "helptext": null,
-                                                                                    "values": "en\r\nfr\r\nnl\r\nde",
-                                                                                    "labels": "English\r\nFrench\r\nDutch\r\nGerman",
+                                                                                    "values": null,
+                                                                                    "labels": null,
                                                                                     "icon": "fa fa-language",
-                                                                                    "localePreferredFirst": true
+                                                                                    "localePreferredFirst": true,
+                                                                                    "withLocalesVariable": true
                                                                                 },
                                                                                 "mappingOptions": [],
                                                                                 "restrictionOptions": [],
@@ -669,7 +670,7 @@
                                                                                                 "protected": false
                                                                                             }
                                                                                         },
-                                                                                        "orderKey": 1,
+                                                                                        "orderKey": 0,
                                                                                         "children": []
                                                                                     },
                                                                                     "replaced": []
@@ -712,7 +713,7 @@
                                                                                                 "protected": false
                                                                                             }
                                                                                         },
-                                                                                        "orderKey": 2,
+                                                                                        "orderKey": 1,
                                                                                         "children": []
                                                                                     },
                                                                                     "replaced": []
@@ -751,7 +752,7 @@
                                                                                                 "protected": false
                                                                                             }
                                                                                         },
-                                                                                        "orderKey": 3,
+                                                                                        "orderKey": 2,
                                                                                         "children": []
                                                                                     },
                                                                                     "replaced": []
@@ -1422,10 +1423,11 @@
                                                             "class": "col-md-12",
                                                             "lastOfRow": false,
                                                             "helptext": null,
-                                                            "values": "en\r\nfr\r\nnl\r\nde",
-                                                            "labels": "English\r\nFrench\r\nDutch\r\nGerman",
+                                                            "values": null,
+                                                            "labels": null,
                                                             "icon": null,
-                                                            "localePreferredFirst": true
+                                                            "localePreferredFirst": true,
+                                                            "withLocalesVariable": true
                                                         },
                                                         "mappingOptions": [],
                                                         "restrictionOptions": [],
@@ -1475,7 +1477,7 @@
                                                                         "protected": false
                                                                     }
                                                                 },
-                                                                "orderKey": 1,
+                                                                "orderKey": 0,
                                                                 "children": []
                                                             },
                                                             "replaced": []
@@ -1607,10 +1609,11 @@
                                                                         "class": "col-md-12",
                                                                         "lastOfRow": false,
                                                                         "helptext": null,
-                                                                        "values": "en\r\nfr\r\nnl\r\nde",
-                                                                        "labels": "English\r\nFrench\r\nDutch\r\nGerman",
+                                                                        "values": null,
+                                                                        "labels": null,
                                                                         "icon": null,
-                                                                        "localePreferredFirst": true
+                                                                        "localePreferredFirst": true,
+                                                                        "withLocalesVariable": true
                                                                     },
                                                                     "mappingOptions": [],
                                                                     "restrictionOptions": [],
@@ -1662,7 +1665,7 @@
                                                                                     "transformers": []
                                                                                 }
                                                                             },
-                                                                            "orderKey": 1,
+                                                                            "orderKey": 0,
                                                                             "children": []
                                                                         },
                                                                         "replaced": []

--- a/demo/configs/admin/content-type/link.json
+++ b/demo/configs/admin/content-type/link.json
@@ -166,10 +166,11 @@
                                                 "class": "col-md-12",
                                                 "lastOfRow": false,
                                                 "helptext": null,
-                                                "values": "nl\r\nfr",
-                                                "labels": "Dutch\r\nFrench",
+                                                "values": null,
+                                                "labels": null,
                                                 "localePreferredFirst": true,
-                                                "icon": "fa fa-language"
+                                                "icon": "fa fa-language",
+                                                "withLocalesVariable": true
                                             },
                                             "mappingOptions": [],
                                             "restrictionOptions": [],

--- a/demo/configs/admin/content-type/page.json
+++ b/demo/configs/admin/content-type/page.json
@@ -164,10 +164,11 @@
                                                 "class": "col-md-12",
                                                 "lastOfRow": false,
                                                 "helptext": null,
-                                                "values": "nl\r\nfr",
-                                                "labels": "Dutch\r\nFrench",
+                                                "values": null,
+                                                "labels": null,
                                                 "localePreferredFirst": true,
-                                                "icon": "fa fa-language"
+                                                "icon": "fa fa-language",
+                                                "withLocalesVariable": true
                                             },
                                             "mappingOptions": [],
                                             "restrictionOptions": [],
@@ -222,7 +223,7 @@
                                                             "protected": false
                                                         }
                                                     },
-                                                    "orderKey": 1,
+                                                    "orderKey": 0,
                                                     "children": []
                                                 },
                                                 "replaced": []
@@ -258,7 +259,7 @@
                                                         },
                                                         "raw_data": []
                                                     },
-                                                    "orderKey": 2,
+                                                    "orderKey": 1,
                                                     "children": []
                                                 },
                                                 "replaced": []
@@ -305,7 +306,7 @@
                                                             "protected": false
                                                         }
                                                     },
-                                                    "orderKey": 3,
+                                                    "orderKey": 2,
                                                     "children": []
                                                 },
                                                 "replaced": []
@@ -353,7 +354,7 @@
                                                             "transformers": []
                                                         }
                                                     },
-                                                    "orderKey": 4,
+                                                    "orderKey": 3,
                                                     "children": []
                                                 },
                                                 "replaced": []
@@ -396,7 +397,7 @@
                                                             "protected": false
                                                         }
                                                     },
-                                                    "orderKey": 5,
+                                                    "orderKey": 4,
                                                     "children": [
                                                         {
                                                             "class": "EMS\\CoreBundle\\Entity\\FieldType",
@@ -428,7 +429,7 @@
                                                                     },
                                                                     "raw_data": []
                                                                 },
-                                                                "orderKey": 1,
+                                                                "orderKey": 0,
                                                                 "children": [
                                                                     {
                                                                         "class": "EMS\\CoreBundle\\Entity\\FieldType",
@@ -469,7 +470,7 @@
                                                                                     "transformers": []
                                                                                 }
                                                                             },
-                                                                            "orderKey": 1,
+                                                                            "orderKey": 0,
                                                                             "children": []
                                                                         },
                                                                         "replaced": []
@@ -509,7 +510,7 @@
                                                                                     "protected": false
                                                                                 }
                                                                             },
-                                                                            "orderKey": 2,
+                                                                            "orderKey": 1,
                                                                             "children": []
                                                                         },
                                                                         "replaced": []
@@ -551,7 +552,7 @@
                                                                     },
                                                                     "raw_data": []
                                                                 },
-                                                                "orderKey": 2,
+                                                                "orderKey": 1,
                                                                 "children": [
                                                                     {
                                                                         "class": "EMS\\CoreBundle\\Entity\\FieldType",
@@ -591,7 +592,7 @@
                                                                                     "protected": false
                                                                                 }
                                                                             },
-                                                                            "orderKey": 1,
+                                                                            "orderKey": 0,
                                                                             "children": []
                                                                         },
                                                                         "replaced": []
@@ -638,7 +639,7 @@
                                                                                     "protected": false
                                                                                 }
                                                                             },
-                                                                            "orderKey": 2,
+                                                                            "orderKey": 1,
                                                                             "children": []
                                                                         },
                                                                         "replaced": []
@@ -671,7 +672,7 @@
                                                                                 },
                                                                                 "raw_data": []
                                                                             },
-                                                                            "orderKey": 3,
+                                                                            "orderKey": 2,
                                                                             "children": [
                                                                                 {
                                                                                     "class": "EMS\\CoreBundle\\Entity\\FieldType",
@@ -715,7 +716,7 @@
                                                                                                 "protected": false
                                                                                             }
                                                                                         },
-                                                                                        "orderKey": 1,
+                                                                                        "orderKey": 0,
                                                                                         "children": []
                                                                                     },
                                                                                     "replaced": []
@@ -758,7 +759,7 @@
                                                                                                 "protected": false
                                                                                             }
                                                                                         },
-                                                                                        "orderKey": 2,
+                                                                                        "orderKey": 1,
                                                                                         "children": []
                                                                                     },
                                                                                     "replaced": []
@@ -801,7 +802,7 @@
                                                                     },
                                                                     "raw_data": []
                                                                 },
-                                                                "orderKey": 3,
+                                                                "orderKey": 2,
                                                                 "children": [
                                                                     {
                                                                         "class": "EMS\\CoreBundle\\Entity\\FieldType",
@@ -845,7 +846,7 @@
                                                                                     "protected": false
                                                                                 }
                                                                             },
-                                                                            "orderKey": 1,
+                                                                            "orderKey": 0,
                                                                             "children": []
                                                                         },
                                                                         "replaced": []
@@ -884,7 +885,7 @@
                                                                     },
                                                                     "raw_data": []
                                                                 },
-                                                                "orderKey": 4,
+                                                                "orderKey": 3,
                                                                 "children": [
                                                                     {
                                                                         "class": "EMS\\CoreBundle\\Entity\\FieldType",
@@ -928,7 +929,7 @@
                                                                                     "protected": false
                                                                                 }
                                                                             },
-                                                                            "orderKey": 1,
+                                                                            "orderKey": 0,
                                                                             "children": []
                                                                         },
                                                                         "replaced": []
@@ -967,7 +968,7 @@
                                                                     },
                                                                     "raw_data": []
                                                                 },
-                                                                "orderKey": 5,
+                                                                "orderKey": 4,
                                                                 "children": [
                                                                     {
                                                                         "class": "EMS\\CoreBundle\\Entity\\FieldType",
@@ -1011,7 +1012,7 @@
                                                                                     "protected": false
                                                                                 }
                                                                             },
-                                                                            "orderKey": 1,
+                                                                            "orderKey": 0,
                                                                             "children": []
                                                                         },
                                                                         "replaced": []
@@ -1067,7 +1068,7 @@
                                                             "transformers": []
                                                         }
                                                     },
-                                                    "orderKey": 6,
+                                                    "orderKey": 5,
                                                     "children": []
                                                 },
                                                 "replaced": []
@@ -1100,7 +1101,7 @@
                                                         },
                                                         "raw_data": []
                                                     },
-                                                    "orderKey": 7,
+                                                    "orderKey": 6,
                                                     "children": [
                                                         {
                                                             "class": "EMS\\CoreBundle\\Entity\\FieldType",
@@ -1144,7 +1145,7 @@
                                                                         "protected": false
                                                                     }
                                                                 },
-                                                                "orderKey": 1,
+                                                                "orderKey": 0,
                                                                 "children": []
                                                             },
                                                             "replaced": []
@@ -1192,7 +1193,7 @@
                                                                         "transformers": []
                                                                     }
                                                                 },
-                                                                "orderKey": 2,
+                                                                "orderKey": 1,
                                                                 "children": []
                                                             },
                                                             "replaced": []
@@ -1230,7 +1231,7 @@
                                                                         "protected": false
                                                                     }
                                                                 },
-                                                                "orderKey": 3,
+                                                                "orderKey": 2,
                                                                 "children": []
                                                             },
                                                             "replaced": []


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | y  |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Allow to use the locales defined in the EMSCH_LOCALES variable as tabs in the multiplex tabs field