### PR TITLE
chore(make): upgrade to base-php:8.4-cli-dev for npm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ RUN_ADMIN				= php ${PWD}/elasticms-admin/bin/console --no-debug
 RUN_WEB					= php ${PWD}/elasticms-web/bin/console --no-debug
 RUN_POSTGRES		= docker exec -i -u ${DOCKER_USER}:0 -e PGUSER=postgres -e PGPASSWORD=adminpg ems-mono-postgres
 NPM_CMD         = "${NPM_EXTRA_CMD} npm $*"
-RUN_DEMO_NPM		= docker run -u ${DOCKER_USER}:0 --rm -it -v ${PWD}/demo:/opt/src --workdir /opt/src elasticms/base-php:8.1-cli-dev sh -c ${NPM_CMD}
+RUN_DEMO_NPM		= docker run -u ${DOCKER_USER}:0 --rm -it -v ${PWD}/demo:/opt/src --workdir /opt/src elasticms/base-php:8.4-cli-dev sh -c ${NPM_CMD}
 
 .DEFAULT_GOAL := help
 .PHONY: help demo docs


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  n |
| New feature?   |  n|
| BC breaks?     |n  |
| Deprecations?  | y  |
| Fixed tickets? | n  |
| Documentation? |  n |

Upgrade to elasticms/base-php:8.4-cli-dev (in the make file)
