### PR TITLE
fix(admin/ui): action are not filtered on envs is role is not defined

### DIFF
--- a/EMS/admin-ui-bundle/templates/bootstrap5/elements/object-views-button.html.twig
+++ b/EMS/admin-ui-bundle/templates/bootstrap5/elements/object-views-button.html.twig
@@ -6,7 +6,7 @@
 
     {% for template in contentType.templates %}
         {% if currentTemplate is not defined or template != currentTemplate %}
-            {% if template.role == "not-defined" or is_granted(template.role) and (template.environments is empty or environment in template.environments or template.isEnvironmentExist(environment.name)) %}
+            {% if (template.role == "not-defined" or is_granted(template.role)) and (template.environments is empty or environment in template.environments or template.isEnvironmentExist(environment.name)) %}
                 {% if template.renderOption is constant('EMS\\CoreBundle\\Form\\Field\\RenderOptionType::EXTERNALLINK') %}
                     {% set link = template.body|emsco_generate_from_template({
                         environment: environment,


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  |  n |
| Fixed tickets? |  n |
| Documentation? | n  |

 same fix as #1205 for bs5
