### PR TITLE
fix(admin/field): reverse entity name modal transformer nullable

### DIFF
--- a/EMS/core-bundle/src/Form/DataTransformer/EntityNameModelTransformer.php
+++ b/EMS/core-bundle/src/Form/DataTransformer/EntityNameModelTransformer.php
@@ -32,6 +32,10 @@ readonly class EntityNameModelTransformer implements DataTransformerInterface
     #[\Override]
     public function reverseTransform(mixed $value)
     {
+        if (null === $value) {
+            return null;
+        }
+
         return $this->multiple ? $this->reverseTransformMultiple($value) : $this->reverseTransformSingle($value);
     }
 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

We can not create dataLinks without defining a querySearch, this will throw an error because the entityNameModalTransformer wants to transform the null value.

The transform method is already checking for null values, but the reverse was not.

This transformer was introduced in the 6.x with https://github.com/ems-project/elasticms/pull/775/files#diff-bfe1861dc62408d063a120f273a1616f38c5171d265f5eef6259baa2b146afc7
