### PR TITLE
fix(admin/cli): backup fieldType ignore displayExtraOptions

### DIFF
--- a/EMS/core-bundle/src/Entity/FieldType.php
+++ b/EMS/core-bundle/src/Entity/FieldType.php
@@ -674,6 +674,7 @@ class FieldType extends JsonDeserializer implements \JsonSerializable
         $json->removeProperty('created');
         $json->removeProperty('modified');
         $json->removeProperty('parent');
+        $json->removeProperty('displayExtraOptions');
         $json->updateProperty('children', $this->getValidChildren());
 
         return $json;


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   |  n |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

The displayExtraOptions was added in https://github.com/ems-project/elasticms/pull/1203
But should be ignored when create a backup with 'ems:admin:backup --configs'
