### PR TITLE
feat(admin/post-processing): add document revision in context

### DIFF
--- a/EMS/core-bundle/src/Service/Revision/PostProcessingService.php
+++ b/EMS/core-bundle/src/Service/Revision/PostProcessingService.php
@@ -10,6 +10,7 @@ use EMS\CoreBundle\Core\Revision\RawDataTransformer;
 use EMS\CoreBundle\Entity\ContentType;
 use EMS\CoreBundle\Entity\DataField;
 use EMS\CoreBundle\Entity\FieldType;
+use EMS\CoreBundle\Entity\Revision;
 use EMS\CoreBundle\Exception\CantBeFinalizedException;
 use EMS\CoreBundle\Form\DataField\CollectionFieldType;
 use EMS\CoreBundle\Form\DataField\ComputedFieldType;
@@ -50,6 +51,9 @@ final readonly class PostProcessingService
     public function postProcessing(FormInterface $form, ContentType $contentType, array &$objectArray, array $context = [], ?array &$parent = [], string $path = ''): bool
     {
         $migration = isset($context['migration']) && $context['migration'];
+        $rootData = $form->getRoot()->getData();
+        $revision = $rootData instanceof Revision ? $rootData : null;
+
         $context = \array_merge($context, [
             '_source' => &$objectArray, // if update also update the context
             '_type' => $contentType->getName(),
@@ -58,6 +62,7 @@ final readonly class PostProcessingService
             'parent' => $parent,
             'path' => $path,
             'form' => $form,
+            'revisionId' => $revision?->getId(),
         ]);
 
         $found = false;


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  n  |
| New feature?   |  y |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? |  n |
| Documentation? | n  |

Expose the revisionId of the document in the post processing context;
Did not want to expose the full revision object.
