### PR TITLE
fix(admin): optional use of deprecated EMSCH_BACKEND_URL env

### DIFF
--- a/EMS/client-helper-bundle/src/Helper/UserApi/ClientFactory.php
+++ b/EMS/client-helper-bundle/src/Helper/UserApi/ClientFactory.php
@@ -11,7 +11,7 @@ use GuzzleHttp\Client;
  */
 final readonly class ClientFactory
 {
-    public function __construct(private string $baseUrl)
+    public function __construct(private ?string $baseUrl)
     {
     }
 
@@ -20,6 +20,10 @@ final readonly class ClientFactory
      */
     public function createClient(array $headers = []): Client
     {
+        if (null === $this->baseUrl) {
+            throw new \RuntimeException('base url not set (EMSCH_BACKEND_URL)');
+        }
+        
         return new Client([
             'base_uri' => $this->baseUrl,
             'headers' => $headers,

--- a/EMS/client-helper-bundle/src/Helper/UserApi/ClientFactory.php
+++ b/EMS/client-helper-bundle/src/Helper/UserApi/ClientFactory.php
@@ -23,7 +23,7 @@ final readonly class ClientFactory
         if (null === $this->baseUrl) {
             throw new \RuntimeException('base url not set (EMSCH_BACKEND_URL)');
         }
-        
+
         return new Client([
             'base_uri' => $this->baseUrl,
             'headers' => $headers,

--- a/EMS/common-bundle/src/Common/Bridge/Core/CoreBridgeResponse.php
+++ b/EMS/common-bundle/src/Common/Bridge/Core/CoreBridgeResponse.php
@@ -9,8 +9,8 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 class CoreBridgeResponse
 {
     private function __construct(
-        private mixed $data = null,
-        private ?HttpException $exception = null
+        private readonly mixed $data = null,
+        private readonly ?HttpException $exception = null
     ) {
     }
 

--- a/EMS/core-bundle/src/Form/Field/ColorPickerType.php
+++ b/EMS/core-bundle/src/Form/Field/ColorPickerType.php
@@ -12,7 +12,7 @@ use function Symfony\Component\Translation\t;
 class ColorPickerType extends Select2Type
 {
     /** @var array<string, ?string> */
-    private array $choices;
+    private readonly array $choices;
 
     public function __construct()
     {


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | n  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

The lint:container of the admin will fail if we do not define the deprecated %EMSCH_BACKEND_URL% variable.
Use the bridge of better implementation

