### PR TITLE
feat(web/form): add emsch_form_view view variable

### DIFF
--- a/EMS/client-helper-bundle/config/services.xml
+++ b/EMS/client-helper-bundle/config/services.xml
@@ -65,6 +65,10 @@
             <argument type="service" id="security.csrf.token_manager" />
         </service>
 
+        <service id="emsch.form.extension.view" class="EMS\ClientHelperBundle\Helper\Form\Extension\EmschFormViewExtension">
+            <tag name="form.type_extension" priority="1"/>
+        </service>
+
         <!-- event listeners -->
         <service id="emsch.event_listener.security" class="EMS\ClientHelperBundle\EventListener\SecurityListener">
             <argument type="service" id="security.authorization_checker" />

--- a/EMS/client-helper-bundle/src/Helper/Form/EmschFormType.php
+++ b/EMS/client-helper-bundle/src/Helper/Form/EmschFormType.php
@@ -9,6 +9,7 @@ use EMS\CommonBundle\Contracts\Twig\TemplateInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -19,10 +20,11 @@ use Symfony\Component\Validator\Constraints as Assert;
 class EmschFormType extends AbstractType
 {
     private const string BLOCK_FROM_CONFIG = 'emschFormConfig';
+    private const string BLOCK_FROM_VIEW = 'emschFormView';
 
     /**
      * @param FormBuilderInterface<mixed>            $builder
-     * @param array{ 'template': TemplateInterface } $options
+     * @param array{ 'template': TemplateInterface, 'emsch_form_view': array<mixed> } $options
      */
     #[\Override]
     public function buildForm(FormBuilderInterface $builder, array $options): void
@@ -34,6 +36,7 @@ class EmschFormType extends AbstractType
             $elementType = $this->getElementType($element['type'] ?? 'text');
             $elementOptions = $element['options'] ?? [];
             $elementOptions['constraints'] = $this->resolveConstraints($elementOptions['constraints'] ?? []);
+            $elementOptions['emsch_form_view'] = $options['emsch_form_view'];
 
             $builder->add(child: $element['name'], type: $elementType, options: $elementOptions);
         }
@@ -44,7 +47,13 @@ class EmschFormType extends AbstractType
     {
         $resolver
             ->setRequired(['template'])
-            ->setAllowedTypes('template', TemplateInterface::class);
+            ->setAllowedTypes('template', TemplateInterface::class)
+            ->setDefault('emsch_form_view', function (Options $options): array {
+                /** @var TemplateInterface $template */
+                $template = $options['template'];
+
+                return $template->jsonBlock(self::BLOCK_FROM_VIEW);
+            });
     }
 
     #[\Override]

--- a/EMS/client-helper-bundle/src/Helper/Form/EmschFormType.php
+++ b/EMS/client-helper-bundle/src/Helper/Form/EmschFormType.php
@@ -23,8 +23,11 @@ class EmschFormType extends AbstractType
     private const string BLOCK_FROM_VIEW = 'emschFormView';
 
     /**
-     * @param FormBuilderInterface<mixed>            $builder
-     * @param array{ 'template': TemplateInterface, 'emsch_form_view': array<mixed> } $options
+     * @param FormBuilderInterface<mixed> $builder
+     * @param array{
+     *     'template': TemplateInterface,
+     *     'emsch_form_view': array<mixed>
+     * } $options
      */
     #[\Override]
     public function buildForm(FormBuilderInterface $builder, array $options): void

--- a/EMS/client-helper-bundle/src/Helper/Form/Extension/EmschFormViewExtension.php
+++ b/EMS/client-helper-bundle/src/Helper/Form/Extension/EmschFormViewExtension.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\ClientHelperBundle\Helper\Form\Extension;
+
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class EmschFormViewExtension extends AbstractTypeExtension
+{
+    public function buildView(FormView $view, FormInterface $form, array $options): void
+    {
+        parent::buildView($view, $form, $options);
+
+        if (isset($options['emsch_form_view'])) {
+            $view->vars['emsch_form_view'] = $options['emsch_form_view'];
+        }
+    }
+
+    #[\Override]
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        parent::configureOptions($resolver);
+        $resolver->setDefaults(['emsch_form_view' => null]);
+    }
+
+    #[\Override]
+    public static function getExtendedTypes(): iterable
+    {
+        return [FormType::class];
+    }
+}


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  n |
| New feature?   |  y |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

The emsch form will now try to render `emschFormView` and pass the result to all elements.

```twig 
{%- block emschFormView -%}
    {{- {'test': 'test'}|json_encode|raw -}}
{%- endblock emschFormView -%}
```

This way inside the form theme we can do 
```twig 
{% set test= form.vars.emsch_form_view.test %}
```
