### PR TITLE
fix(admin/publish): only create new version if tags are defined

### DIFF
--- a/EMS/core-bundle/src/Service/PublishService.php
+++ b/EMS/core-bundle/src/Service/PublishService.php
@@ -382,7 +382,7 @@ class PublishService
         $contentType = $revision->giveContentType();
         $versioning = $contentType->getVersioning();
 
-        if (!$versioning->enabled()) {
+        if (!$versioning->enabled() || 0 === \count($versioning->getTags())) {
             return;
         }
 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   |  n |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

When the contentType has versioning enabled, but no tags defined we should not create a new version on publication.
