### PR TITLE
fix(web/form): add range and regex assert

### DIFF
--- a/EMS/client-helper-bundle/src/Helper/Form/EmschFormType.php
+++ b/EMS/client-helper-bundle/src/Helper/Form/EmschFormType.php
@@ -103,6 +103,15 @@ class EmschFormType extends AbstractType
                 minMessage: $value['minMessage'] ?? null,
                 maxMessage: $value['maxMessage'] ?? null,
             ),
+            'range' => new Assert\Range(
+                notInRangeMessage: $value['message'] ?? null,
+                min: isset($value['min']) ? (int) $value['min'] : null,
+                max: isset($value['max']) ? (int) $value['max'] : null,
+            ),
+            'regex' => new Assert\Regex(
+                pattern: $value['pattern'],
+                message: $value['message'] ?? null,
+            ),
             default => throw new \RuntimeException(\sprintf('Invalid constraint type "%s"', $value['type'])),
         }, $constraints);
     }


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | y  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Currently we are not able to validate decimals or numbers correctly. Added a range and regex assert.
