### PR TITLE
fix(cli/file-import): use correct mimetype of import file

### DIFF
--- a/EMS/common-bundle/src/Common/File/FileReader.php
+++ b/EMS/common-bundle/src/Common/File/FileReader.php
@@ -33,9 +33,10 @@ final class FileReader implements FileReaderInterface
     #[\Override]
     public function readCells(string $filename, array $options = []): \Generator
     {
-        $isCsv = 0 === \strcasecmp(\pathinfo($filename, PATHINFO_EXTENSION), 'csv');
+        $mimeType = $options['mime_type'] ?? null;
+        $csvExtension = 0 === \strcasecmp(\pathinfo($filename, PATHINFO_EXTENSION), 'csv');
 
-        if ($isCsv) {
+        if ($csvExtension || 'text/csv' === $mimeType) {
             $csv = new CsvFile(
                 filename: $filename,
                 delimiter: ($options['delimiter'] ?? CsvFile::DEFAULT_DELIMITER),

--- a/EMS/common-bundle/src/Contracts/File/FileReaderInterface.php
+++ b/EMS/common-bundle/src/Contracts/File/FileReaderInterface.php
@@ -18,6 +18,7 @@ interface FileReaderInterface
 
     /**
      * @param array{
+     *      mime_type?: ?string,
      *      delimiter?: ?string,
      *      encoding?: ?string,
      *      exclude_rows?: int[],

--- a/elasticms-cli/src/Command/FileReader/FileReaderImportCommand.php
+++ b/elasticms-cli/src/Command/FileReader/FileReaderImportCommand.php
@@ -10,6 +10,7 @@ use EMS\CommonBundle\Common\Admin\AdminHelper;
 use EMS\CommonBundle\Common\Command\AbstractCommand;
 use EMS\CommonBundle\Contracts\CoreApi\Endpoint\Data\DataInterface;
 use EMS\CommonBundle\Contracts\File\FileReaderInterface;
+use EMS\CommonBundle\Helper\MimeTypeHelper;
 use EMS\CommonBundle\Search\Search;
 use EMS\CommonBundle\Storage\File\FileInterface;
 use EMS\CommonBundle\Storage\NotFoundException;
@@ -97,7 +98,11 @@ final class FileReaderImportCommand extends AbstractCommand
 
             $config = $this->createConfig(...$this->getOptionStringArray(self::OPTION_CONFIG, false));
 
-            $cells = $this->fileReader->readCells($this->getFile($this->file)->getFilename(), [
+            $file = $this->getFile($this->file);
+            $mimeType = MimeTypeHelper::getInstance()->guessMimeType($file->getFilename());
+
+            $cells = $this->fileReader->readCells($file->getFilename(), [
+                'mime_type' => $mimeType,
                 'delimiter' => $config->delimiter,
                 'encoding' => $config->encoding,
                 'exclude_rows' => $config->excludeRows,


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

The cli will ask the coreApi for the file, but the coreApi is returning a stream. We create a tempFile without the orginal mimeType. 
The file reader will also use excel parsing because he is not aware that the file is a csv content. Add a new optional mime_type option for the FileReader.
