### PR TITLE
feat(cli/import): add command for database import

### DIFF
--- a/docs/elasticms-cli/commands.md
+++ b/docs/elasticms-cli/commands.md
@@ -50,9 +50,9 @@ Example:
 php bin/console ems:admin:command 'ems:env:rebuild preview'
 ```
 
-## File Reader
+## Import
 
-### Import
+### File
 
 With this command you can upload a folder to a content-type.
 If the merge options is set to `false`, the rawData will be replaced.
@@ -60,14 +60,40 @@ It will send async index requests, the responses are parsed when the flush-size 
 
 ```bash
 Description:
-  Import an Excel file or a CSV file, one document per row
+  Import an Excel file or a CSV file, one document per row.
 
 Usage:
-  emscli:file-reader:import [options] [--] <file> <content-type>
+  emscli:import:file [options] [--] <file> <content-type>
+  emscli:file-reader:import
 
 Arguments:
-  file                  File path (xlsx or csv)
-  content-type          Content type target
+  file                         File path (xlsx or csv)
+  content-type                 Content type target
+
+Options:
+      --config=CONFIG          Config(s) json, file path or hash (multiple values allowed)
+      --dry-run                Just do a dry run
+      --merge=MERGE            Perform a merge or replace [default: true]
+      --flush-size=FLUSH-SIZE  Flush size for the queue [default: 100]
+      --limit=LIMIT            Limit the rows
+```
+
+### Database
+
+With this command you can upload a database table to a content-type.
+If the merge options is set to `false`, the rawData will be replaced.
+It will send async index requests, the responses are parsed when the flush-size is reached (default 100).
+
+```bash
+Description:
+  Import an database table, one document per row.
+
+Usage:
+  emscli:import:database [options] [--] <table> <content-type>
+
+Arguments:
+  table                        Database table name.
+  content-type                 Content type target
 
 Options:
       --config=CONFIG          Config(s) json, file path or hash (multiple values allowed)

--- a/docs/elasticms-cli/parameters.md
+++ b/docs/elasticms-cli/parameters.md
@@ -20,17 +20,53 @@ Define the max connections to the API client, when using async calls. By default
 
 ## Doctrine variables
 
-### DATABASE_URL
+Default values (sqlite):
+```dotenv
+DB_DRIVER='pgsql'
+DB_USER='user'
+DB_PASSWORD='pass'
+DB_PORT='5432'
+DB_NAME='elasticms'
+```
 
-Format described at https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url
+### DB_HOST
 
-IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml
+DB's host.
+- Default value: `127.0.0.1`
+- Example: `DB_DRIVER='db-server.tl'`
 
-Examples: 
-- `DATABASE_URL="sqlite:///%kernel.project_dir%/var/data.db"`
-- `DATABASE_URL="mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=5.7&charset=utf8mb4"`
-- `DATABASE_URL="postgresql://symfony:ChangeMe@127.0.0.1:5432/app?serverVersion=13&charset=utf8"`
+### DB_DRIVER
 
+Driver (Type of the DB server). Accepted values are `mysql`, `pgsql` and `sqlite`
+- Default value: `pgsql`
+- Example: `DB_DRIVER='pgsql'`
+
+### DB_USER
+
+- Default value `user`
+- Example: `DB_USER='demo'`
+
+### DB_PASSWORD
+
+- Default value `pass`
+- Example: `DB_PASSWORD='password'`
+
+### DB_PORT
+
+For information the default mysql/mariadb port is 3306 and 5432 for Postgres
+- Default value `5432`
+- Example: `DB_PORT='5432'`
+
+### DB_NAME
+
+- Default value `elasticms`
+- Example: `DB_NAME='demo'`
+
+### DB_SCHEMA
+
+This variable is not used by Doctrine but by the dump script with postgres in the docker image of elasticms.
+- Default value: not defined
+- Example: `DB_SCEMA='schema_demo_adm'`
 
 ## Elasticms Common Bundle variables
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -1,7 +1,20 @@
 # Upgrade
 
-  * [Switch to CK Editor 5](#switch-to-ck-editor-5)
+<!-- TOC -->
+* [Upgrade](#upgrade)
+  * [General remarks](#general-remarks)
+  * [version 6.1.1](#version-611)
+  * [Switch to CK Editor 5 (still in beta)](#switch-to-ck-editor-5-still-in-beta)
   * [version 6.0.x](#version-60x)
+    * [Postgres 17](#postgres-17)
+    * [Symfony request inputBag](#symfony-request-inputbag)
+    * [Renamed embed methods in web/skeleton templates](#renamed-embed-methods-in-webskeleton-templates)
+    * [Routes removed](#routes-removed)
+    * [Deprecated twig filters](#deprecated-twig-filters)
+    * [Deprecated twig function](#deprecated-twig-function)
+    * [New dynamic mapping config which change the elasticsearch indexes](#new-dynamic-mapping-config-which-change-the-elasticsearch-indexes)
+  * [version 5.25.x](#version-525x)
+  * [version 5.24.x](#version-524x)
   * [version 5.23.x](#version-523x)
   * [version 5.22.x](#version-522x)
   * [version 5.21.x](#version-521x)
@@ -11,13 +24,27 @@
   * [version 5.14.x](#version-514x)
   * [version 5.7.x](#version-57x)
   * [version 5.3.x](#version-53x)
+    * [Deprecated emsch_add_environment](#deprecated-emsch_add_environment-)
   * [version 4.2.x](#version-42x)
+    * [Content type roles in twig](#content-type-roles-in-twig)
   * [version 4.x](#version-4x)
+    * [Deprecated twig functions](#deprecated-twig-functions)
+    * [Asset custom twig functions](#asset-custom-twig-functions)
+    * [Email custom twig functions](#email-custom-twig-functions)
+    * [Misc](#misc)
   * [Tips and tricks](#tips-and-tricks)
+    * [Backward compatibility route to old school assets path](#backward-compatibility-route-to-old-school-assets-path)
+    * [Create an old school "Corresponding revision" in the action menu](#create-an-old-school-corresponding-revision-in-the-action-menu)
+<!-- TOC -->
 
 ## General remarks
 
  * It's always a good idea to rebuild indexes on upgrade: `emsco:environment:rebuild --all`
+
+## version 6.1.1
+
+We added a new cli command `emscli:import:database`.
+Good practice to replace `emscli:file-reader:import` now alias for `emscli:file:import`
 
 ## Switch to CK Editor 5 (still in beta)
 

--- a/elasticms-cli/.env
+++ b/elasticms-cli/.env
@@ -19,13 +19,15 @@ APP_SECRET='$ecretbyd3fault'
 ###< symfony/framework-bundle ###
 
 ###> doctrine/doctrine-bundle ###
-# Format described at https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url
-# IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml
-#
-# DATABASE_URL="sqlite:///%kernel.project_dir%/var/data.db"
-# DATABASE_URL="mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=5.7&charset=utf8mb4"
-# DATABASE_URL="postgresql://symfony:ChangeMe@127.0.0.1:5432/app?serverVersion=13&charset=utf8"
-DATABASE_URL='sqlite:///%kernel.project_dir%/var/data.db'
+#DB_CONNECTION_TIMEOUT=30
+#DB_DRIVER=pgsql
+#DB_HOST=127.0.0.1
+#DB_NAME=elasticms
+#DB_PASSWORD=pass
+#DB_PORT=5432
+#DB_URL=
+#DB_USER=user
+#DB_VERSION=12
 ###< doctrine/doctrine-bundle ###
 
 ###> EMSCommonBundle ###

--- a/elasticms-cli/config/packages/doctrine.yaml
+++ b/elasticms-cli/config/packages/doctrine.yaml
@@ -1,11 +1,20 @@
 parameters:
-  env(DATABASE_URL): 'sqlite:///%kernel.project_dir%/var/data.db'
-  env(DB_SERVER_VERSION): '5.7'
+    env(DB_HOST): '127.0.0.1'
+    env(DB_DRIVER): 'pgsql'
+    env(DB_USER): 'user'
+    env(DB_PASSWORD): 'pass'
+    env(DB_PORT): '5432'
+    env(DB_NAME): 'elasticms'
+    env(DB_CONNECTION_TIMEOUT): 30
+    env(DB_VERSION): '12'
+    env(DB_URL): '%env(string:DB_DRIVER)%://%env(string:DB_USER)%:%%env(urlencode:DB_PASSWORD)%%@%env(string:DB_HOST)%:%env(string:DB_PORT)%/%env(string:DB_NAME)%'
 
 doctrine:
     dbal:
-        url: '%env(resolve:DATABASE_URL)%'
-        server_version: '%env(resolve:DB_SERVER_VERSION)%'
+        url: '%env(resolve:DB_URL)%'
+        server_version: '%env(string:DB_VERSION)%'
+        options:
+            2: '%env(int:DB_CONNECTION_TIMEOUT)%' #const PDO:ATTR_TIMEOUT = 2 , minimum value is 2 https://pracucci.com/php-pdo-pgsql-connection-timeout.html
     orm:
         auto_generate_proxy_classes: true
         auto_mapping: true

--- a/elasticms-cli/src/Client/File/ImportConfig.php
+++ b/elasticms-cli/src/Client/File/ImportConfig.php
@@ -6,7 +6,7 @@ namespace App\CLI\Client\File;
 
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class FileReaderImportConfig
+class ImportConfig
 {
     /**
      * @param array<string, mixed> $defaultData

--- a/elasticms-cli/src/Command/Import/AbstractImportCommand.php
+++ b/elasticms-cli/src/Command/Import/AbstractImportCommand.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\CLI\Command\Import;
+
+use App\CLI\Client\File\ImportConfig;
+use EMS\CommonBundle\Common\Admin\AdminHelper;
+use EMS\CommonBundle\Common\Command\AbstractCommand;
+use EMS\CommonBundle\Contracts\CoreApi\Endpoint\Data\DataInterface;
+use EMS\CommonBundle\Search\Search;
+use EMS\CommonBundle\Storage\File\FileInterface;
+use EMS\CommonBundle\Storage\NotFoundException;
+use EMS\CommonBundle\Storage\StorageManager;
+use EMS\Helpers\Standard\Hash;
+use EMS\Helpers\Standard\Json;
+use EMS\Helpers\Standard\UuidGenerator;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+
+abstract class AbstractImportCommand extends AbstractCommand
+{
+    private const string ARGUMENT_CONTENT_TYPE = 'content-type';
+    private const string OPTION_CONFIG = 'config';
+    private const string OPTION_DRY_RUN = 'dry-run';
+    private const string OPTION_LIMIT = 'limit';
+    private const string OPTION_FLUSH_SIZE = 'flush-size';
+    private const string OPTION_MERGE = 'merge';
+
+    protected string $contentType;
+    protected bool $dryRun;
+    protected bool $merge;
+    protected int $flushSize;
+    protected ?int $limit = null;
+    private ExpressionLanguage $expressionLanguage;
+
+    public function __construct(
+        private readonly AdminHelper $adminHelper,
+        private readonly StorageManager $storageManager,
+    ) {
+        parent::__construct();
+    }
+
+    #[\Override]
+    protected function configure(): void
+    {
+        $this
+            ->addArgument(self::ARGUMENT_CONTENT_TYPE, InputArgument::REQUIRED, 'Content type target')
+            ->addOption(self::OPTION_CONFIG, null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Config(s) json, file path or hash', [])
+            ->addOption(self::OPTION_DRY_RUN, null, InputOption::VALUE_NONE, 'Just do a dry run')
+            ->addOption(self::OPTION_MERGE, null, InputOption::VALUE_REQUIRED, 'Perform a merge or replace', true)
+            ->addOption(self::OPTION_FLUSH_SIZE, null, InputOption::VALUE_REQUIRED, 'Flush size for the queue', 100)
+            ->addOption(self::OPTION_LIMIT, null, InputOption::VALUE_REQUIRED, 'Limit the rows')
+        ;
+    }
+
+    #[\Override]
+    protected function initialize(InputInterface $input, OutputInterface $output): void
+    {
+        parent::initialize($input, $output);
+        $this->contentType = $this->getArgumentString(self::ARGUMENT_CONTENT_TYPE);
+        $this->dryRun = $this->getOptionBool(self::OPTION_DRY_RUN);
+        $this->merge = $this->getOptionBool(self::OPTION_MERGE);
+        $this->flushSize = $this->getOptionInt(self::OPTION_FLUSH_SIZE);
+        $this->limit = $this->getOptionIntNull(self::OPTION_LIMIT);
+
+        $this->expressionLanguage = new ExpressionLanguage();
+    }
+
+    public function import(ImportConfig $config, \Generator $records): void
+    {
+        $coreApi = $this->adminHelper->getCoreApi();
+        $contentTypeApi = $coreApi->data($this->contentType);
+        if (!$coreApi->isAuthenticated()) {
+            throw new \RuntimeException(\sprintf('Not authenticated for %s, run ems:admin:login', $this->adminHelper->getCoreApi()->getBaseUrl()));
+        }
+        $ouuids = $config->deleteMissingDocuments ? $this->searchExistingOuuids() : [];
+
+        $progressBar = $this->io->createProgressBar();
+        $count = 0;
+        $queue = $coreApi->queue($this->flushSize)->addFlushCallback(fn () => $progressBar->advance());
+
+        foreach ($records as $row) {
+            $ouuid = $this->createOuuid($config, $row);
+
+            $rawData = $config->defaultData;
+            $rawData['_sync_metadata'] = $row;
+
+            if (null !== $ouuidVersionExpression = $config->ouuidVersionExpression) {
+                $rawData['_version_uuid'] = UuidGenerator::fromValue(
+                    value: $this->expressionLanguage->evaluate($ouuidVersionExpression, ['row' => $row])
+                );
+            }
+
+            if ($ouuid) {
+                unset($ouuids[$ouuid]);
+            }
+
+            if (!$this->dryRun) {
+                $queue->add($contentTypeApi->indexAsync(ouuid: $ouuid, rawData: $rawData, merge: $this->merge));
+            }
+
+            ++$count;
+        }
+
+        $queue->flush();
+        $progressBar->finish();
+        $this->io->newLine();
+
+        $notReadable = \count($records->getReturn());
+        if ($notReadable > 0) {
+            $this->io->warning(\sprintf('Could not read %d records', $notReadable));
+        }
+
+        if (!$this->dryRun && $config->deleteMissingDocuments && \count($ouuids) > 0) {
+            $this->deleteMissingDocuments($contentTypeApi, ...\array_keys($ouuids));
+        }
+
+        $this->io->definitionList(
+            'Summary',
+            ['Index' => $count],
+            ['Delete' => \count($ouuids)]
+        );
+    }
+
+    protected function getImportConfig(): ImportConfig
+    {
+        $inputs = $this->getOptionStringArray(self::OPTION_CONFIG, false);
+
+        $configs = \array_map(fn (string $input) => match (true) {
+            Json::isJson($input) => Json::decode($input),
+            default => Json::decode($this->getFile($input)->getContent()),
+        }, $inputs);
+
+        return ImportConfig::createFromArray(
+            config: \array_merge(...$configs)
+        );
+    }
+
+    protected function getFile(string $fileIdentifier): FileInterface
+    {
+        try {
+            return $this->storageManager->getFile($fileIdentifier);
+        } catch (NotFoundException) {
+            return $this->adminHelper->getCoreApi()->file()->getFile($fileIdentifier);
+        }
+    }
+
+    /**
+     * @param array<int, array<mixed>> $row
+     */
+    private function createOuuid(ImportConfig $config, array $row): ?string
+    {
+        if (null === $config->ouuidExpression) {
+            return null;
+        }
+
+        $ouuid = $this->expressionLanguage->evaluate($config->ouuidExpression, ['row' => $row]);
+        $prefix = $config->ouuidPrefix;
+
+        return match (true) {
+            $config->generateOuuid => (string) UuidGenerator::fromValue(($prefix ?? '').$ouuid),
+            null !== $prefix => Hash::string($prefix.$ouuid),
+            $config->generateHash => Hash::string(\sprintf('FileReaderImport:%s:%s', $this->contentType, $ouuid)),
+            default => $ouuid,
+        };
+    }
+
+    private function deleteMissingDocuments(DataInterface $api, string ...$ouuids): void
+    {
+        $this->io->newLine(2);
+        $this->io->section(\sprintf('%d documents have not been updated and will be deleted', \count($ouuids)));
+        $progressBar = $this->io->createProgressBar(\count($ouuids));
+        foreach ($ouuids as $ouuid) {
+            $api->delete($ouuid);
+            $progressBar->advance();
+        }
+        $progressBar->finish();
+        $this->io->newLine();
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function searchExistingOuuids(): array
+    {
+        $ouuids = [];
+        $search = new Search([
+            $this->adminHelper->getCoreApi()->meta()->getDefaultContentTypeEnvironmentAlias($this->contentType),
+        ]);
+        $search->setSources(['_id']);
+        $search->setContentTypes([$this->contentType]);
+
+        foreach ($this->adminHelper->getCoreApi()->search()->scroll($search) as $hit) {
+            $ouuids[$hit->getOuuid()] = true;
+        }
+
+        return $ouuids;
+    }
+}

--- a/elasticms-cli/src/Command/Import/AbstractImportCommand.php
+++ b/elasticms-cli/src/Command/Import/AbstractImportCommand.php
@@ -161,8 +161,8 @@ abstract class AbstractImportCommand extends AbstractCommand
         $ouuid = $this->expressionLanguage->evaluate($config->ouuidExpression, ['row' => $row]);
         $prefix = $config->ouuidPrefix;
 
-        return match (true) {
-            $config->generateOuuid => (string) UuidGenerator::fromValue(($prefix ?? '').$ouuid),
+        return (string) match (true) {
+            $config->generateOuuid => UuidGenerator::fromValue(($prefix ?? '').$ouuid),
             null !== $prefix => Hash::string($prefix.$ouuid),
             $config->generateHash => Hash::string(\sprintf('FileReaderImport:%s:%s', $this->contentType, $ouuid)),
             default => $ouuid,

--- a/elasticms-cli/src/Command/Import/DatabaseImportCommand.php
+++ b/elasticms-cli/src/Command/Import/DatabaseImportCommand.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace App\CLI\Command\Import;
 
 use App\CLI\Commands;
+use Doctrine\DBAL\Connection;
+use EMS\CommonBundle\Common\Admin\AdminHelper;
+use EMS\CommonBundle\Storage\StorageManager;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -21,12 +24,20 @@ final class DatabaseImportCommand extends AbstractImportCommand
 
     private string $table;
 
+    public function __construct(
+        private readonly Connection $connection,
+        AdminHelper $adminHelper,
+        StorageManager $storageManager
+    ) {
+        parent::__construct($adminHelper, $storageManager);
+    }
+
     #[\Override]
     protected function configure(): void
     {
-        parent::configure();
-
         $this->addArgument(self::ARGUMENT_TABLE, InputArgument::REQUIRED, 'Database table name.');
+
+        parent::configure();
     }
 
     #[\Override]
@@ -43,11 +54,28 @@ final class DatabaseImportCommand extends AbstractImportCommand
         try {
             $this->io->title('EMS CLI - Import - Database');
 
+            $config = $this->getImportConfig();
+            $records = $this->getRecords($this->table);
+
+            $this->import($config, $records);
+
             return self::EXECUTE_SUCCESS;
         } catch (\Throwable $e) {
             $this->io->error($e->getMessage());
 
             return self::EXECUTE_ERROR;
         }
+    }
+
+    private function getRecords(string $table): \Generator
+    {
+        $sql = \sprintf('SELECT * FROM %s;', $table);
+        $stmt = $this->connection->executeQuery($sql);
+
+        while ($row = $stmt->fetchAssociative()) {
+            yield $row;
+        }
+
+        return [];
     }
 }

--- a/elasticms-cli/src/Command/Import/DatabaseImportCommand.php
+++ b/elasticms-cli/src/Command/Import/DatabaseImportCommand.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\CLI\Command\Import;
+
+use App\CLI\Commands;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: Commands::IMPORT_DATABASE,
+    description: 'Import an database table, one document per row.',
+    hidden: false
+)]
+final class DatabaseImportCommand extends AbstractImportCommand
+{
+    private const string ARGUMENT_TABLE = 'table';
+
+    private string $table;
+
+    #[\Override]
+    protected function configure(): void
+    {
+        parent::configure();
+
+        $this->addArgument(self::ARGUMENT_TABLE, InputArgument::REQUIRED, 'Database table name.');
+    }
+
+    #[\Override]
+    protected function initialize(InputInterface $input, OutputInterface $output): void
+    {
+        parent::initialize($input, $output);
+
+        $this->table = $this->getArgumentString(self::ARGUMENT_TABLE);
+    }
+
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        try {
+            $this->io->title('EMS CLI - Import - Database');
+
+            return self::EXECUTE_SUCCESS;
+        } catch (\Throwable $e) {
+            $this->io->error($e->getMessage());
+
+            return self::EXECUTE_ERROR;
+        }
+    }
+}

--- a/elasticms-cli/src/Command/Import/FileImportCommand.php
+++ b/elasticms-cli/src/Command/Import/FileImportCommand.php
@@ -27,9 +27,9 @@ final class FileImportCommand extends AbstractImportCommand
     private string $file;
 
     public function __construct(
+        private readonly FileReaderInterface $fileReader,
         AdminHelper $adminHelper,
         StorageManager $storageManager,
-        private readonly FileReaderInterface $fileReader,
     ) {
         parent::__construct($adminHelper, $storageManager);
     }

--- a/elasticms-cli/src/Command/Import/FileImportCommand.php
+++ b/elasticms-cli/src/Command/Import/FileImportCommand.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Output\OutputInterface;
     aliases: ['emscli:file-reader:import'],
     hidden: false
 )]
-final class FileReaderImportCommand extends AbstractImportCommand
+final class FileImportCommand extends AbstractImportCommand
 {
     private const string ARGUMENT_FILE = 'file';
 

--- a/elasticms-cli/src/Command/Import/FileReaderImportCommand.php
+++ b/elasticms-cli/src/Command/Import/FileReaderImportCommand.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\CLI\Command\FileReader;
+namespace App\CLI\Command\Import;
 
 use App\CLI\Client\File\FileReaderImportConfig;
 use App\CLI\Commands;

--- a/elasticms-cli/src/Command/Import/FileReaderImportCommand.php
+++ b/elasticms-cli/src/Command/Import/FileReaderImportCommand.php
@@ -4,101 +4,58 @@ declare(strict_types=1);
 
 namespace App\CLI\Command\Import;
 
-use App\CLI\Client\File\FileReaderImportConfig;
 use App\CLI\Commands;
 use EMS\CommonBundle\Common\Admin\AdminHelper;
-use EMS\CommonBundle\Common\Command\AbstractCommand;
-use EMS\CommonBundle\Contracts\CoreApi\Endpoint\Data\DataInterface;
 use EMS\CommonBundle\Contracts\File\FileReaderInterface;
 use EMS\CommonBundle\Helper\MimeTypeHelper;
-use EMS\CommonBundle\Search\Search;
-use EMS\CommonBundle\Storage\File\FileInterface;
-use EMS\CommonBundle\Storage\NotFoundException;
 use EMS\CommonBundle\Storage\StorageManager;
-use EMS\Helpers\Standard\Hash;
-use EMS\Helpers\Standard\Json;
-use EMS\Helpers\Standard\UuidGenerator;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
 #[AsCommand(
     name: Commands::IMPORT_FILE,
     description: 'Import an Excel file or a CSV file, one document per row.',
     aliases: ['emscli:file-reader:import'],
-    hidden: false 
+    hidden: false
 )]
-final class FileReaderImportCommand extends AbstractCommand
+final class FileReaderImportCommand extends AbstractImportCommand
 {
     private const string ARGUMENT_FILE = 'file';
-    private const string ARGUMENT_CONTENT_TYPE = 'content-type';
-    private const string OPTION_CONFIG = 'config';
-    private const string OPTION_DRY_RUN = 'dry-run';
-    private const string OPTION_LIMIT = 'limit';
-    private const string OPTION_FLUSH_SIZE = 'flush-size';
-    private const string OPTION_MERGE = 'merge';
 
     private string $file;
-    private string $contentType;
-    private bool $dryRun;
-    private bool $merge;
-    private int $flushSize;
-    private ?int $limit = null;
-    private ExpressionLanguage $expressionLanguage;
 
     public function __construct(
-        private readonly AdminHelper $adminHelper,
-        private readonly StorageManager $storageManager,
+        AdminHelper $adminHelper,
+        StorageManager $storageManager,
         private readonly FileReaderInterface $fileReader,
     ) {
-        parent::__construct();
+        parent::__construct($adminHelper, $storageManager);
     }
 
     #[\Override]
     protected function configure(): void
     {
-        $this
-            ->addArgument(self::ARGUMENT_FILE, InputArgument::REQUIRED, 'File path (xlsx or csv)')
-            ->addArgument(self::ARGUMENT_CONTENT_TYPE, InputArgument::REQUIRED, 'Content type target')
-            ->addOption(self::OPTION_CONFIG, null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Config(s) json, file path or hash', [])
-            ->addOption(self::OPTION_DRY_RUN, null, InputOption::VALUE_NONE, 'Just do a dry run')
-            ->addOption(self::OPTION_MERGE, null, InputOption::VALUE_REQUIRED, 'Perform a merge or replace', true)
-            ->addOption(self::OPTION_FLUSH_SIZE, null, InputOption::VALUE_REQUIRED, 'Flush size for the queue', 100)
-            ->addOption(self::OPTION_LIMIT, null, InputOption::VALUE_REQUIRED, 'Limit the rows')
-        ;
+        $this->addArgument(self::ARGUMENT_FILE, InputArgument::REQUIRED, 'File path (xlsx or csv)');
+        parent::configure();
     }
 
     #[\Override]
     protected function initialize(InputInterface $input, OutputInterface $output): void
     {
         parent::initialize($input, $output);
-        $this->file = $this->getArgumentString(self::ARGUMENT_FILE);
-        $this->contentType = $this->getArgumentString(self::ARGUMENT_CONTENT_TYPE);
-        $this->dryRun = $this->getOptionBool(self::OPTION_DRY_RUN);
-        $this->merge = $this->getOptionBool(self::OPTION_MERGE);
-        $this->flushSize = $this->getOptionInt(self::OPTION_FLUSH_SIZE);
-        $this->limit = $this->getOptionIntNull(self::OPTION_LIMIT);
 
-        $this->expressionLanguage = new ExpressionLanguage();
+        $this->file = $this->getArgumentString(self::ARGUMENT_FILE);
     }
 
     #[\Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         try {
-            $this->io->title('EMS CLI - File reader - Import');
+            $this->io->title('EMS CLI - Import - File');
 
-            $coreApi = $this->adminHelper->getCoreApi();
-            $contentTypeApi = $coreApi->data($this->contentType);
-            if (!$coreApi->isAuthenticated()) {
-                throw new \RuntimeException(\sprintf('Not authenticated for %s, run ems:admin:login', $this->adminHelper->getCoreApi()->getBaseUrl()));
-            }
-
-            $config = $this->createConfig(...$this->getOptionStringArray(self::OPTION_CONFIG, false));
-
+            $config = $this->getImportConfig();
             $file = $this->getFile($this->file);
             $mimeType = MimeTypeHelper::getInstance()->guessMimeType($file->getFilename());
 
@@ -110,132 +67,13 @@ final class FileReaderImportCommand extends AbstractCommand
                 'limit' => $this->limit,
             ]);
 
-            $ouuids = $config->deleteMissingDocuments ? $this->searchExistingOuuids() : [];
-
-            $progressBar = $this->io->createProgressBar();
-            $count = 0;
-            $queue = $coreApi->queue($this->flushSize)->addFlushCallback(fn () => $progressBar->advance());
-
-            foreach ($cells as $row) {
-                $ouuid = $this->createOuuid($config, $row);
-
-                $rawData = $config->defaultData;
-                $rawData['_sync_metadata'] = $row;
-
-                if (null !== $ouuidVersionExpression = $config->ouuidVersionExpression) {
-                    $rawData['_version_uuid'] = UuidGenerator::fromValue(
-                        value: $this->expressionLanguage->evaluate($ouuidVersionExpression, ['row' => $row])
-                    );
-                }
-
-                if ($ouuid) {
-                    unset($ouuids[$ouuid]);
-                }
-
-                if (!$this->dryRun) {
-                    $queue->add($contentTypeApi->indexAsync(ouuid: $ouuid, rawData: $rawData, merge: $this->merge));
-                }
-
-                ++$count;
-            }
-
-            $queue->flush();
-            $progressBar->finish();
-            $this->io->newLine();
-
-            $notReadable = \count($cells->getReturn());
-            if ($notReadable > 0) {
-                $this->io->warning(\sprintf('Could not read %d records', $notReadable));
-            }
-
-            if (!$this->dryRun && $config->deleteMissingDocuments && \count($ouuids) > 0) {
-                $this->deleteMissingDocuments($contentTypeApi, ...\array_keys($ouuids));
-            }
-
-            $this->io->definitionList(
-                'Summary',
-                ['Index' => $count],
-                ['Delete' => \count($ouuids)]
-            );
+            $this->import($config, $cells);
 
             return self::EXECUTE_SUCCESS;
         } catch (\Throwable $e) {
             $this->io->error($e->getMessage());
 
             return self::EXECUTE_ERROR;
-        }
-    }
-
-    private function createConfig(string ...$inputs): FileReaderImportConfig
-    {
-        $configs = \array_map(fn (string $input) => match (true) {
-            Json::isJson($input) => Json::decode($input),
-            default => Json::decode($this->getFile($input)->getContent()),
-        }, $inputs);
-
-        return FileReaderImportConfig::createFromArray(
-            config: \array_merge(...$configs)
-        );
-    }
-
-    /**
-     * @param array<int, array<mixed>> $syncMetaData
-     */
-    private function createOuuid(FileReaderImportConfig $config, array $syncMetaData): ?string
-    {
-        if (null === $config->ouuidExpression) {
-            return null;
-        }
-
-        $ouuid = $this->expressionLanguage->evaluate($config->ouuidExpression, ['row' => $syncMetaData]);
-        $prefix = $config->ouuidPrefix;
-
-        return match (true) {
-            $config->generateOuuid => (string) UuidGenerator::fromValue(($prefix ?? '').$ouuid),
-            null !== $prefix => Hash::string($prefix.$ouuid),
-            $config->generateHash => Hash::string(\sprintf('FileReaderImport:%s:%s', $this->contentType, $ouuid)),
-            default => $ouuid,
-        };
-    }
-
-    private function deleteMissingDocuments(DataInterface $api, string ...$ouuids): void
-    {
-        $this->io->newLine(2);
-        $this->io->section(\sprintf('%d documents have not been updated and will be deleted', \count($ouuids)));
-        $progressBar = $this->io->createProgressBar(\count($ouuids));
-        foreach ($ouuids as $ouuid) {
-            $api->delete($ouuid);
-            $progressBar->advance();
-        }
-        $progressBar->finish();
-        $this->io->newLine();
-    }
-
-    /**
-     * @return array<string, bool>
-     */
-    private function searchExistingOuuids(): array
-    {
-        $ouuids = [];
-        $search = new Search([
-            $this->adminHelper->getCoreApi()->meta()->getDefaultContentTypeEnvironmentAlias($this->contentType),
-        ]);
-        $search->setSources(['_id']);
-        $search->setContentTypes([$this->contentType]);
-
-        foreach ($this->adminHelper->getCoreApi()->search()->scroll($search) as $hit) {
-            $ouuids[$hit->getOuuid()] = true;
-        }
-
-        return $ouuids;
-    }
-
-    private function getFile(string $fileIdentifier): FileInterface
-    {
-        try {
-            return $this->storageManager->getFile($fileIdentifier);
-        } catch (NotFoundException) {
-            return $this->adminHelper->getCoreApi()->file()->getFile($fileIdentifier);
         }
     }
 }

--- a/elasticms-cli/src/Command/Import/FileReaderImportCommand.php
+++ b/elasticms-cli/src/Command/Import/FileReaderImportCommand.php
@@ -26,9 +26,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
 #[AsCommand(
-    name: Commands::FILE_READER_IMPORT,
+    name: Commands::IMPORT_FILE,
     description: 'Import an Excel file or a CSV file, one document per row.',
-    hidden: false
+    aliases: ['emscli:file-reader:import'],
+    hidden: false 
 )]
 final class FileReaderImportCommand extends AbstractCommand
 {

--- a/elasticms-cli/src/Commands.php
+++ b/elasticms-cli/src/Commands.php
@@ -13,6 +13,7 @@ class Commands
     final public const string DOCUMENTS_UPDATE = 'emscli:documents:update';
     final public const string MEDIA_LIBRARY_SYNC = 'emscli:media-library:synchronize';
     final public const string MEDIA_LIBRARY_TIKA_CACHE = 'emscli:media-library:load-tika-cache';
-    
+
     final public const string IMPORT_FILE = 'emscli:import:file';
+    final public const string IMPORT_DATABASE = 'emscli:import:database';
 }

--- a/elasticms-cli/src/Commands.php
+++ b/elasticms-cli/src/Commands.php
@@ -13,5 +13,6 @@ class Commands
     final public const string DOCUMENTS_UPDATE = 'emscli:documents:update';
     final public const string MEDIA_LIBRARY_SYNC = 'emscli:media-library:synchronize';
     final public const string MEDIA_LIBRARY_TIKA_CACHE = 'emscli:media-library:load-tika-cache';
-    final public const string FILE_READER_IMPORT = 'emscli:file-reader:import';
+    
+    final public const string IMPORT_FILE = 'emscli:import:file';
 }


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  n |
| New feature?   | y  |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | y  |

The command `emscli:file-reader:import` still works like before, but is now an alias for: `emscli:import:file`.
Because in this pr we added a new `emscli:import:database`.

- The import code is moved to a new AbstractImportCommand
- FileImportConfig renamed to ImportConfig, because now we have File and Database.

The abstractCommand has an import method which expects the config object and a Generator.

> This would normally be in a Major release, but we can not wait and it will not break anything.

```bash
php bin/console emscli:import:database tbl_users demo_users -config='{"ouuid_expression":"row[\"id\"]","ouuid_prefix":"user"}'
```

Still todo
- [ ] add documentation
