### PR TITLE
chore(docker): update deprecated minio env variables

### DIFF
--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -90,8 +90,8 @@ services:
     volumes:
       - s3:/data
     environment:
-      MINIO_ACCESS_KEY: accesskey
-      MINIO_SECRET_KEY: secretkey
+      MINIO_ROOT_USER: accesskey
+      MINIO_ROOT_PASSWORD: secretkey
     command: server /data --console-address ":9001"
     healthcheck:
       test: [ "CMD", "mc", "ready", "local" ]

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -90,6 +90,8 @@ services:
     volumes:
       - s3:/data
     environment:
+      MINIO_ACCESS_KEY: accesskey
+      MINIO_SECRET_KEY: secretkey
       MINIO_ROOT_USER: accesskey
       MINIO_ROOT_PASSWORD: secretkey
     command: server /data --console-address ":9001"


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  n |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? |  n |
| Documentation? | n  |

Updating deprecated environment variables for minio
