### PR TITLE
feat(admin/api): add support for lazy indexing

### DIFF
--- a/EMS/common-bundle/src/Common/CoreApi/Endpoint/Data/Data.php
+++ b/EMS/common-bundle/src/Common/CoreApi/Endpoint/Data/Data.php
@@ -148,13 +148,10 @@ final readonly class Data implements DataInterface
     }
 
     #[\Override]
-    public function indexAsync(?string $ouuid, array $rawData, bool $merge = false, bool $refresh = false): ResponseInterface
+    public function indexAsync(?string $ouuid, array $rawData, bool $merge = false, bool $refresh = false, bool $lazy = false): ResponseInterface
     {
         $resource = $this->makeResource($merge && $ouuid ? 'update' : 'index', $ouuid);
-
-        if ($refresh) {
-            $resource .= '?refresh=true';
-        }
+        $resource .= '?'.\http_build_query(['refresh' => $refresh, 'lazy' => $lazy]);
 
         return $this->client->asyncRequest(Request::METHOD_POST, $resource, ['json' => $rawData]);
     }

--- a/EMS/common-bundle/src/Contracts/CoreApi/Endpoint/Data/DataInterface.php
+++ b/EMS/common-bundle/src/Contracts/CoreApi/Endpoint/Data/DataInterface.php
@@ -55,7 +55,7 @@ interface DataInterface
     /**
      * @param array<string, mixed> $rawData
      */
-    public function indexAsync(?string $ouuid, array $rawData, bool $merge = false, bool $refresh = false): ResponseInterface;
+    public function indexAsync(?string $ouuid, array $rawData, bool $merge = false, bool $refresh = false, bool $lazy = false): ResponseInterface;
 
     /**
      * @throws CoreApiExceptionInterface

--- a/EMS/core-bundle/src/Controller/ContentManagement/CrudController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/CrudController.php
@@ -385,10 +385,12 @@ class CrudController extends AbstractController
 
     public function index(Request $request, string $name, ?string $ouuid = null, string $replaceOrMerge = 'replace'): JsonResponse
     {
+        $lazyIndex = $request->query->getBoolean('lazy');
         $revision = null;
         if (null !== $ouuid) {
             try {
                 $revision = $this->dataService->getNewestRevision($name, $ouuid);
+                $revision->setLazyIndex($lazyIndex);
             } catch (NotFoundHttpException) {
             }
         }
@@ -397,6 +399,7 @@ class CrudController extends AbstractController
         if (null === $revision) {
             $contentType = $this->contentTypeService->giveByName($name);
             $revision = $this->dataService->createData($ouuid, $rawData, $contentType);
+            $revision->setLazyIndex($lazyIndex);
         } else {
             $revision = $this->dataService->replaceData($revision, $rawData, $replaceOrMerge);
         }

--- a/EMS/core-bundle/src/Entity/Revision.php
+++ b/EMS/core-bundle/src/Entity/Revision.php
@@ -66,6 +66,7 @@ class Revision implements EntityInterface, \Stringable
     private bool $selfUpdate = false;
 
     public const VERSION_BLANK = 'silent';
+    private bool $lazyIndex = false;
 
     public function enableSelfUpdate(): void
     {
@@ -94,7 +95,21 @@ class Revision implements EntityInterface, \Stringable
      */
     public function getData(): array
     {
+        if ($this->isLazyIndex()) {
+            return [];
+        }
+
         return RawDataTransformer::transform($this->giveContentType()->getFieldType(), $this->rawData ?? []);
+    }
+
+    public function setLazyIndex(bool $lazyIndex): void
+    {
+        $this->lazyIndex = $lazyIndex;
+    }
+
+    public function isLazyIndex(): bool
+    {
+        return $this->lazyIndex;
     }
 
     /**
@@ -146,6 +161,7 @@ class Revision implements EntityInterface, \Stringable
                 $this->taskCurrent = $ancestor->taskCurrent;
                 $this->taskPlannedIds = $ancestor->taskPlannedIds;
                 $this->taskApprovedIds = $ancestor->taskApprovedIds;
+                $this->lazyIndex = $ancestor->lazyIndex;
 
                 if (null !== $versionUuid = $ancestor->getVersionUuid()) {
                     $this->setVersionId($versionUuid);
@@ -822,6 +838,10 @@ class Revision implements EntityInterface, \Stringable
         if (null === $this->getVersionUuid()) {
             $versionId = isset($this->rawData['_version_uuid']) ? Uuid::fromString($this->rawData['_version_uuid']) : Uuid::uuid4();
             $this->setVersionId($versionId);
+        }
+
+        if ($this->isLazyIndex()) {
+            return;
         }
 
         if (\count($versioning->getTags()) > 0) {

--- a/EMS/core-bundle/src/Form/DataField/ContainerFieldType.php
+++ b/EMS/core-bundle/src/Form/DataField/ContainerFieldType.php
@@ -62,6 +62,10 @@ class ContainerFieldType extends DataFieldType
             throw new \RuntimeException('Unexpected non-FieldType entity');
         }
 
+        if (true === $options['lazy_index']) {
+            return;
+        }
+
         foreach ($fieldType->getChildren() as $child) {
             $this->buildChildForm($child, $options, $builder);
         }
@@ -82,8 +86,11 @@ class ContainerFieldType extends DataFieldType
     public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
-        $resolver->setDefault('icon', null);
-        $resolver->setDefault('language', null);
+        $resolver->setDefaults([
+            'icon' => null,
+            'language' => null,
+            'lazy_index' => false,
+        ]);
     }
 
     #[\Override]

--- a/EMS/core-bundle/src/Form/DataField/HolderFieldType.php
+++ b/EMS/core-bundle/src/Form/DataField/HolderFieldType.php
@@ -67,6 +67,7 @@ class HolderFieldType extends DataFieldType
     {
         parent::configureOptions($resolver);
         $resolver->setDefault('is_visible', false);
+        $resolver->setDefault('lazy_index', false);
     }
 
     #[\Override]

--- a/EMS/core-bundle/src/Form/Form/RevisionType.php
+++ b/EMS/core-bundle/src/Form/Form/RevisionType.php
@@ -53,6 +53,7 @@ class RevisionType extends AbstractType
             'migration' => $options['migration'],
             'with_warning' => $options['with_warning'],
             'raw_data' => $options['raw_data'],
+            'lazy_index' => $revision && $revision->isLazyIndex(),
             'disabled_fields' => $contentType->getDisabledDataFields(),
             'referrer-ems-id' => $revision && $revision->hasOuuid() ? $revision->getEmsId() : null,
         ]);

--- a/EMS/core-bundle/src/Service/DataService.php
+++ b/EMS/core-bundle/src/Service/DataService.php
@@ -151,8 +151,9 @@ class DataService
             }
         }
 
-        /** @var Notification $notification */
-        foreach ($revision->getNotifications() as $notification) {
+        /** @var Notification[] $revisionNotifications */
+        $revisionNotifications = $revision->isLazyIndex() ? [] : $revision->getNotifications();
+        foreach ($revisionNotifications as $notification) {
             if (Notification::PENDING === $notification->getStatus() && !$this->authorizationChecker->isGranted($notification->getTemplate()->getRole())) {
                 throw new PrivilegeException($revision, 'A pending "'.$notification->getTemplate()->getName().'" notification is locking this content');
             }
@@ -175,7 +176,7 @@ class DataService
 
         $twigExtension = $this->container->get('app.twig_extension');
 
-        if (!$username && $twigExtension instanceof AppExtension && !$twigExtension->oneGranted($revision->giveContentType()->getFieldType()->getFieldsRoles(), $super)) {
+        if (!$username && !$revision->isLazyIndex() && $twigExtension instanceof AppExtension && !$twigExtension->oneGranted($revision->giveContentType()->getFieldType()->getFieldsRoles(), $super)) {
             throw new PrivilegeException($revision);
         }
         // TODO: test circles
@@ -738,7 +739,9 @@ class DataService
 
         $objectArray = $revision->getRawData();
 
-        $this->updateDataStructure($revision->giveContentType()->getFieldType(), $form->get('data')->getNormData());
+        if (!$revision->isLazyIndex()) {
+            $this->updateDataStructure($revision->giveContentType()->getFieldType(), $form->get('data')->getNormData());
+        }
         if ($computeFields && $this->propagateDataToComputedField($form->get('data'), $objectArray, $revision->giveContentType(), $revision->giveContentType()->getName(), $revision->getOuuid())) {
             $revision->setRawData($objectArray);
         }
@@ -1370,6 +1373,11 @@ class DataService
         $data->setOrderKey($revision->giveContentType()->getFieldType()->getOrderKey());
         $data->setRawData($revision->getRawData());
         $revision->setDataField($data);
+
+        if ($revision->isLazyIndex()) {
+            return;
+        }
+
         $this->updateDataStructure($revision->giveContentType()->getFieldType(), $data);
         $object = $revision->getRawData();
         $this->updateDataValue($data, $object);

--- a/EMS/core-bundle/src/Service/ReleaseRevisionService.php
+++ b/EMS/core-bundle/src/Service/ReleaseRevisionService.php
@@ -90,6 +90,11 @@ final readonly class ReleaseRevisionService implements QueryServiceInterface, En
     public function finalizeDraftEvent(RevisionFinalizeDraftEvent $event): void
     {
         $revision = $event->getRevision();
+
+        if ($revision->isLazyIndex()) {
+            return;
+        }
+
         $releaseRevisions = $this->releaseRevisionRepository->getRevisionsLinkedToReleasesByOuuid($revision->giveOuuid(), $revision->giveContentType());
         foreach ($releaseRevisions as $releaseRevision) {
             $this->logger->warning('log.service.release_revision.preceding.revision.in.release', [

--- a/elasticms-cli/src/Command/Import/AbstractImportCommand.php
+++ b/elasticms-cli/src/Command/Import/AbstractImportCommand.php
@@ -29,10 +29,12 @@ abstract class AbstractImportCommand extends AbstractCommand
     private const string OPTION_LIMIT = 'limit';
     private const string OPTION_FLUSH_SIZE = 'flush-size';
     private const string OPTION_MERGE = 'merge';
+    private const string OPTION_LAZY = 'lazy';
 
     protected string $contentType;
     protected bool $dryRun;
     protected bool $merge;
+    protected bool $lazy;
     protected int $flushSize;
     protected ?int $limit = null;
     private ExpressionLanguage $expressionLanguage;
@@ -54,6 +56,7 @@ abstract class AbstractImportCommand extends AbstractCommand
             ->addOption(self::OPTION_MERGE, null, InputOption::VALUE_REQUIRED, 'Perform a merge or replace', true)
             ->addOption(self::OPTION_FLUSH_SIZE, null, InputOption::VALUE_REQUIRED, 'Flush size for the queue', 100)
             ->addOption(self::OPTION_LIMIT, null, InputOption::VALUE_REQUIRED, 'Limit the rows')
+            ->addOption(self::OPTION_LAZY, null, InputOption::VALUE_NONE, 'Lazy index will only call post-processing on source element')
         ;
     }
 
@@ -66,6 +69,7 @@ abstract class AbstractImportCommand extends AbstractCommand
         $this->merge = $this->getOptionBool(self::OPTION_MERGE);
         $this->flushSize = $this->getOptionInt(self::OPTION_FLUSH_SIZE);
         $this->limit = $this->getOptionIntNull(self::OPTION_LIMIT);
+        $this->lazy = $this->getOptionBool(self::OPTION_LAZY);
 
         $this->expressionLanguage = new ExpressionLanguage();
     }
@@ -100,7 +104,12 @@ abstract class AbstractImportCommand extends AbstractCommand
             }
 
             if (!$this->dryRun) {
-                $queue->add($contentTypeApi->indexAsync(ouuid: $ouuid, rawData: $rawData, merge: $this->merge));
+                $queue->add($contentTypeApi->indexAsync(
+                    ouuid: $ouuid,
+                    rawData: $rawData,
+                    merge: $this->merge,
+                    lazy: $this->lazy
+                ));
             }
 
             ++$count;


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  n |
| New feature?   | y  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Problem: indexing a lot of document with `emscli:import:file` gets really slow if the contentType has a lot of fields. 

Solution: added a lazy option, this will only create the root `source` element and skip all others. Also it will not set the version from & to fields, you should do it yourself in the source post processing. Because getting the versionFromField will loop over all fields, and we do not want this.
