### PR TITLE
fix(admin/contentType): datetime field type correct default display format

### DIFF
--- a/EMS/admin-ui-bundle/assets/src/core/plugins/datetime.js
+++ b/EMS/admin-ui-bundle/assets/src/core/plugins/datetime.js
@@ -34,10 +34,10 @@ class Datetime {
 
   loadDatetime(target) {
     const options = this.defaultOptions()
-    this.loadPicker(target, '.datetime-picker', options)
+    this.loadPicker(target, '.datetime-picker', options, true)
   }
 
-  loadPicker(target, query, options) {
+  loadPicker(target, query, options, momentJSFormat = false) {
     const pickers = target.querySelectorAll(query)
     for (let i = 0; i < pickers.length; i++) {
       if (pickers[i].dataset.multidate) {
@@ -47,7 +47,11 @@ class Datetime {
         options.localization.startOfTheWeek = pickers[i].dataset.weekStart
       }
       if (pickers[i].dataset.dateFormat) {
-        options.localization.format = pickers[i].dataset.dateFormat
+        let dateFormat = pickers[i].dataset.dateFormat
+        if (momentJSFormat) {
+          dateFormat = this.convertMomentToTempusFormat(dateFormat)
+        }
+        options.localization.format = dateFormat
       }
       if (pickers[i].dataset.daysOfWeekDisabled) {
         options.restrictions.daysOfWeekDisabled = JSON.parse(pickers[i].dataset.daysOfWeekDisabled)
@@ -133,6 +137,34 @@ class Datetime {
       },
       restrictions: {}
     }
+  }
+
+  convertMomentToTempusFormat(momentFormat) {
+    const map = {
+      'YYYY': 'yyyy',
+      'YY': 'yy',
+      'MMMM': 'MMMM',
+      'MMM': 'MMM',
+      'MM': 'MM',
+      'M': 'M',
+      'DD': 'dd',
+      'D': 'd',
+      'dddd': 'EEEE',
+      'ddd': 'EEE',
+      'HH': 'HH',
+      'H': 'H',
+      'hh': 'hh',
+      'h': 'h',
+      'mm': 'mm',
+      'm': 'm',
+      'ss': 'ss',
+      's': 's',
+      'A': 'a'
+    };
+    const sortedKeys = Object.keys(map).sort((a, b) => b.length - a.length);
+    const regex = new RegExp(sortedKeys.join('|'), 'g');
+
+    return momentFormat.replace(regex, match => map[match] || match);
   }
 }
 

--- a/EMS/core-bundle/src/Form/DataField/DateTimeFieldType.php
+++ b/EMS/core-bundle/src/Form/DataField/DateTimeFieldType.php
@@ -13,7 +13,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class DateTimeFieldType extends DataFieldType
 {
     public const string DEFAULT_PARSE_FORMAT = 'd/m/Y H:i:s';
-    public const string DEFAULT_DISPLAY_FORMAT = 'dd/MM/yyyy HH:mm:ss';
+    public const string DEFAULT_DISPLAY_FORMAT = 'D/MM/YYYY HH:mm:ss';
 
     #[\Override]
     public function getLabel(): string


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? |  y |
| Documentation? | n  |

DateTimeFieldType supports MomentJS date format ! #1266