### PR TITLE
fix(admin/revision): set version revision on publish

### DIFF
--- a/EMS/core-bundle/src/Entity/Revision.php
+++ b/EMS/core-bundle/src/Entity/Revision.php
@@ -922,7 +922,10 @@ class Revision implements EntityInterface, \Stringable
             $this->setVersionId($versionId);
         }
 
-        $this->setVersionTag($this->rawData[Mapping::VERSION_TAG] ?? $this->getVersionTagDefault());
+        if (null === $this->getVersionTag()) {
+            $this->setVersionTag($this->rawData[Mapping::VERSION_TAG] ?? $this->getVersionTagDefault());
+        }
+
         $this->updateVersionNextTag();
 
         if (null === $this->getVersionDate('from') && null === $this->getVersionDate('to')) {

--- a/EMS/core-bundle/src/Service/PublishService.php
+++ b/EMS/core-bundle/src/Service/PublishService.php
@@ -388,8 +388,6 @@ class PublishService
         $selectedVersionTag = $revision->getVersionNextTag();
 
         if (\in_array($selectedVersionTag, [null, Revision::VERSION_BLANK], true)) {
-            $revision->removeFromRawData($contentType->getVersionTagField());
-
             return;
         }
 

--- a/EMS/core-bundle/src/Service/PublishService.php
+++ b/EMS/core-bundle/src/Service/PublishService.php
@@ -388,6 +388,8 @@ class PublishService
         $selectedVersionTag = $revision->getVersionNextTag();
 
         if (\in_array($selectedVersionTag, [null, Revision::VERSION_BLANK], true)) {
+            $revision->removeFromRawData($contentType->getVersionTagField());
+
             return;
         }
 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  Y  |
| New feature?   | N  |
| BC breaks?     |  N |
| Deprecations?  |  N |
| Fixed tickets? | N  |
| Documentation? | N  |

It was not possible to create a Minor version. During live publish, the version was always replaced by Major (default).
