### PR TITLE
fix(core/revision): autoSave without merge

### DIFF
--- a/EMS/core-bundle/src/Entity/Revision.php
+++ b/EMS/core-bundle/src/Entity/Revision.php
@@ -673,7 +673,7 @@ class Revision implements EntityInterface, \Stringable
     public function autoSaveToRawData(): self
     {
         if (null !== $this->autoSave) {
-            $this->rawData = [...$this->getRawData(), ...$this->autoSave];
+            $this->rawData = $this->autoSave;
             $this->autoSaveClear();
         }
 

--- a/EMS/core-bundle/src/Service/Revision/RevisionService.php
+++ b/EMS/core-bundle/src/Service/Revision/RevisionService.php
@@ -334,7 +334,6 @@ class RevisionService implements RevisionServiceInterface
         $originalRawData = $revision->getRawData();
         $this->lock($revision, $user);
 
-        $rootFieldType = $revision->giveContentType()->getFieldType();
         $data = [...$revision->getRawData(), ...$autoSave];
 
         $revision->setRawData($data);


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

We should just replace the rawData with the autoSave. Because the autoSave is fully validated and contains all fieds, this was not the case in first version of the bridge/api.

Without this pr we can not clear any fields, because they will stay. The editController does exactly the same, so the api should also do it like this.
