### PR TITLE
fix(core/revision): api finalize autoSave check for _version_uuid

### DIFF
--- a/EMS/core-bundle/src/Entity/Revision.php
+++ b/EMS/core-bundle/src/Entity/Revision.php
@@ -836,7 +836,7 @@ class Revision implements EntityInterface, \Stringable
         }
 
         if (null === $this->getVersionUuid()) {
-            $versionId = isset($this->rawData['_version_uuid']) ? Uuid::fromString($this->rawData['_version_uuid']) : Uuid::uuid4();
+            $versionId = isset($this->rawData[Mapping::VERSION_UUID]) ? Uuid::fromString($this->rawData[Mapping::VERSION_UUID]) : Uuid::uuid4();
             $this->setVersionId($versionId);
         }
 

--- a/EMS/core-bundle/src/Service/Revision/RevisionService.php
+++ b/EMS/core-bundle/src/Service/Revision/RevisionService.php
@@ -26,8 +26,10 @@ use EMS\CoreBundle\Repository\RevisionRepository;
 use EMS\CoreBundle\Service\ContentTypeService;
 use EMS\CoreBundle\Service\DataService;
 use EMS\CoreBundle\Service\EnvironmentService;
+use EMS\CoreBundle\Service\Mapping;
 use EMS\CoreBundle\Service\PublishService;
 use Psr\Log\LoggerInterface;
+use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\Form\FormFactory;
 use Symfony\Component\Form\FormInterface;
@@ -349,6 +351,10 @@ class RevisionService implements RevisionServiceInterface
             ->setAutoSaveAt($now)
             ->setAutoSaveBy($user->getUsername())
             ->setAutoSave($validatedAutoSaveData);
+
+        if (isset($autoSave[Mapping::VERSION_UUID])) {
+            $revision->setVersionId(Uuid::fromString($autoSave[Mapping::VERSION_UUID]));
+        }
 
         $this->revisionRepository->save($revision);
     }


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

From the bridge we want to create a new version, this means we need to 'autoSave' the _version_uuid.
Extra use Mapping constant also in setVersionMetaFields
