### PR TITLE
feat(client/emschForm): support validate block

### DIFF
--- a/EMS/client-helper-bundle/src/Controller/FormController.php
+++ b/EMS/client-helper-bundle/src/Controller/FormController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EMS\ClientHelperBundle\Controller;
 
+use EMS\ClientHelperBundle\Helper\Form\EmschFormBlock;
 use EMS\ClientHelperBundle\Helper\Form\EmschFormType;
 use EMS\ClientHelperBundle\Helper\Request\Handler;
 use Symfony\Component\Form\FormFactoryInterface;
@@ -13,9 +14,6 @@ use Symfony\Component\HttpFoundation\Response;
 
 readonly class FormController
 {
-    public const string BLOCK_SUCCESS_REDIRECT = 'emschFormSuccessRedirect';
-    public const string BLOCK_DATA = 'emschFormData';
-
     public function __construct(
         private Handler $handler,
         private FormFactoryInterface $formFactory,
@@ -26,7 +24,7 @@ readonly class FormController
     {
         $template = $this->handler->handle($request);
 
-        $data = $template->jsonBlock(self::BLOCK_DATA);
+        $data = $template->jsonBlock(EmschFormBlock::DATA->value);
 
         $form = $this->formFactory->create(EmschFormType::class, $data, ['template' => $template]);
         $form->handleRequest($request);
@@ -34,7 +32,7 @@ readonly class FormController
         if ($form->isSubmitted() && $form->isValid()) {
             $template->context()->append(['emschFormData' => $form->getData()]);
 
-            if ($redirect = $template->renderBlock(self::BLOCK_SUCCESS_REDIRECT)) {
+            if ($redirect = $template->renderBlock(EmschFormBlock::SUCCESS_REDIRECT->value)) {
                 return new RedirectResponse($redirect);
             }
         }

--- a/EMS/client-helper-bundle/src/Helper/Form/EmschFormBlock.php
+++ b/EMS/client-helper-bundle/src/Helper/Form/EmschFormBlock.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\ClientHelperBundle\Helper\Form;
+
+enum EmschFormBlock: string
+{
+    case SUCCESS_REDIRECT = 'emschFormSuccessRedirect';
+    case DATA = 'emschFormData';
+    case CONFIG = 'emschFormConfig';
+    case VALIDATE = 'emschFormValidate';
+    case VIEW = 'emschFormView';
+}

--- a/EMS/client-helper-bundle/src/Helper/Form/EmschFormType.php
+++ b/EMS/client-helper-bundle/src/Helper/Form/EmschFormType.php
@@ -13,15 +13,13 @@ use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 /**
  * @extends AbstractType<mixed>
  */
 class EmschFormType extends AbstractType
 {
-    private const string BLOCK_FROM_CONFIG = 'emschFormConfig';
-    private const string BLOCK_FROM_VIEW = 'emschFormView';
-
     /**
      * @param FormBuilderInterface<mixed> $builder
      * @param array{
@@ -33,7 +31,7 @@ class EmschFormType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         /** @var list<array{ 'name': string, 'type'?: 'string', 'options': array<string, mixed> }> $elements */
-        $elements = $options['template']->jsonBlock(self::BLOCK_FROM_CONFIG);
+        $elements = $options['template']->jsonBlock(EmschFormBlock::CONFIG->value);
 
         foreach ($elements as $element) {
             $elementType = $this->getElementType($element['type'] ?? 'text');
@@ -45,24 +43,52 @@ class EmschFormType extends AbstractType
         }
     }
 
+    /** @param array<string, mixed> $data */
+    public function validateForm(array $data, ExecutionContextInterface $context, TemplateInterface $template): void
+    {
+        $template->context()->append(['submitData' => $data]);
+
+        /** @var array<int, array{ 'path'?: string, 'message': string }> $errors */
+        $errors = $template->jsonBlock(EmschFormBlock::VALIDATE->value);
+
+        foreach ($errors as $error) {
+            $violation = $context->buildViolation($error['message']);
+            if (isset($error['path'])) {
+                $violation->atPath($error['path']);
+            }
+            $violation->addViolation();
+        }
+    }
+
     #[\Override]
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setRequired(['template'])
             ->setAllowedTypes('template', TemplateInterface::class)
-            ->setDefault('emsch_form_view', function (Options $options): array {
-                /** @var TemplateInterface $template */
-                $template = $options['template'];
+            ->setDefaults([
+                'constraints' => function (Options $options) {
+                    /** @var TemplateInterface $template */
+                    $template = $options['template'];
 
-                return $template->jsonBlock(self::BLOCK_FROM_VIEW);
-            });
+                    return [new Assert\Callback(function ($data, ExecutionContextInterface $context) use ($template) {
+                        $this->validateForm($data, $context, $template);
+                    })];
+                },
+                'emsch_form_view' => function (Options $options): array {
+                    /** @var TemplateInterface $template */
+                    $template = $options['template'];
+
+                    return $template->jsonBlock(EmschFormBlock::VIEW->value);
+                },
+            ])
+        ;
     }
 
     #[\Override]
     public function getBlockPrefix(): string
     {
-        return '';
+        return 'emsch_form';
     }
 
     private function getElementType(string $type): string


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | n  |
| New feature?   | y  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Add support for a 'emschFormValidate' block. In this block you have access to the submitData and you can return and array of errors. Each error has a message and a path. If you leave the path empty the error will be added at the root level of the form.

Extra moved block constants to a dedicated enum called EmschFormBlock.
