### PR TITLE
feat(web/twig): add 'ems_search_config_execute' twig function

### DIFF
--- a/EMS/client-helper-bundle/config/services.xml
+++ b/EMS/client-helper-bundle/config/services.xml
@@ -121,6 +121,7 @@
             <argument type="service" id="request_stack" />
             <argument type="service" id="logger" />
             <argument type="service" id="ems_common.service.elastica" />
+            <argument type="service" id="emsch.search.manager" />
             <tag name="monolog.logger" channel="emsch_request"/>
             <tag name="twig.runtime" />
         </service>

--- a/EMS/client-helper-bundle/src/Controller/SearchController.php
+++ b/EMS/client-helper-bundle/src/Controller/SearchController.php
@@ -23,7 +23,7 @@ final readonly class SearchController
     {
         $template = $this->handler->handle($request);
 
-        $search = $this->manager->search($request);
+        $search = $this->manager->searchFromRequest($request);
         $template->context()->append($search);
 
         $response = new Response($template->render());

--- a/EMS/client-helper-bundle/src/Helper/Elasticsearch/ClientRequestRuntime.php
+++ b/EMS/client-helper-bundle/src/Helper/Elasticsearch/ClientRequestRuntime.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace EMS\ClientHelperBundle\Helper\Elasticsearch;
 
 use EMS\ClientHelperBundle\Exception\SingleResultException;
+use EMS\ClientHelperBundle\Helper\Search\Manager;
 use EMS\ClientHelperBundle\Helper\Search\Search;
 use EMS\CommonBundle\Common\EMSLink;
 use EMS\CommonBundle\Elasticsearch\Document\Document;
@@ -30,6 +31,7 @@ final class ClientRequestRuntime implements RuntimeExtensionInterface
         private readonly RequestStack $requestStack,
         private readonly LoggerInterface $logger,
         private readonly ElasticaService $elasticaService,
+        private readonly Manager $searchManager,
     ) {
     }
 
@@ -71,14 +73,25 @@ final class ClientRequestRuntime implements RuntimeExtensionInterface
         throw new HttpException($statusCode, $message, null, $headers, $code);
     }
 
-    public function searchConfig(): Search
+    /**
+     * @param array<mixed> $options
+     */
+    public function searchConfig(array $options): Search
     {
         $currentRequest = $this->requestStack->getCurrentRequest();
         if (null === $currentRequest) {
             throw new \RuntimeException('Unexpected null request');
         }
 
-        return new Search($currentRequest, $this->manager->getDefault());
+        return new Search($currentRequest, $this->manager->getDefault(), $options);
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public function searchConfigExecute(Search $searchConfig): array
+    {
+        return $this->searchManager->search($searchConfig);
     }
 
     /**

--- a/EMS/client-helper-bundle/src/Helper/Search/Manager.php
+++ b/EMS/client-helper-bundle/src/Helper/Search/Manager.php
@@ -26,33 +26,41 @@ final readonly class Manager
     /**
      * @return array<mixed>
      */
-    public function search(Request $request): array
+    public function searchFromRequest(Request $request): array
     {
-        $requestSearch = new Search($request, $this->clientRequest);
+        return $this->search(new Search($request, $this->clientRequest));
+    }
 
-        $qbService = new QueryBuilder($this->clientRequest, $requestSearch);
-        $search = $qbService->buildSearch($requestSearch->getTypes());
-        $search->setSourceExcludes($requestSearch->getFieldsExclude());
-        $search->setFrom($requestSearch->getFrom());
-        $search->setSize($requestSearch->getSize());
-        $search->setRegex($requestSearch->getIndexRegex());
+    /**
+     * @return array<mixed>
+     */
+    public function search(Search $searchConfig): array
+    {
+        $qbService = new QueryBuilder($this->clientRequest, $searchConfig);
+
+        $search = $qbService->buildSearch($searchConfig->getTypes());
+        $search->setSourceExcludes($searchConfig->getFieldsExclude());
+        $search->setFrom($searchConfig->getFrom());
+        $search->setSize($searchConfig->getSize());
+        $search->setRegex($searchConfig->getIndexRegex());
 
         $commonSearch = $this->clientRequest->commonSearch($search);
+        /** @var array{ 'hits': array<mixed> } $results */
         $results = $commonSearch->getResponse()->getData();
         $results['hits']['total'] = $results['hits']['total']['value'] ?? $results['hits']['total'] ?? 0;
 
         $response = Response::fromResultSet($commonSearch);
-        $requestSearch->bindAggregations($response, $qbService->getQueryFilters());
+        $searchConfig->bindAggregations($response, $qbService->getQueryFilters());
 
         return [
             'results' => $results,
             'response' => $response,
-            'search' => $requestSearch,
-            'query' => $requestSearch->getQueryString(),
-            'sort' => $requestSearch->getSortBy(),
-            'facets' => $requestSearch->getQueryFacets(),
-            'page' => $requestSearch->getPage(),
-            'size' => $requestSearch->getSize(),
+            'search' => $searchConfig,
+            'query' => $searchConfig->getQueryString(),
+            'sort' => $searchConfig->getSortBy(),
+            'facets' => $searchConfig->getQueryFacets(),
+            'page' => $searchConfig->getPage(),
+            'size' => $searchConfig->getSize(),
         ];
     }
 }

--- a/EMS/client-helper-bundle/src/Helper/Search/Search.php
+++ b/EMS/client-helper-bundle/src/Helper/Search/Search.php
@@ -55,9 +55,12 @@ final class Search
     private string $sortOrder = 'asc';
     private readonly ?string $minimumShouldMatch;
 
-    public function __construct(private readonly Request $request, ClientRequest $clientRequest)
+    /**
+     * @param array<mixed> $options
+     */
+    public function __construct(private readonly Request $request, ClientRequest $clientRequest, ?array $options = null)
     {
-        $options = $this->getOptions($request, $clientRequest);
+        $options ??= $this->getOptions($request, $clientRequest);
 
         if (isset($options['facets'])) {
             @\trigger_error('Deprecated facets, please use filters setting', E_USER_DEPRECATED);

--- a/EMS/client-helper-bundle/src/Twig/HelperExtension.php
+++ b/EMS/client-helper-bundle/src/Twig/HelperExtension.php
@@ -37,6 +37,7 @@ final class HelperExtension extends AbstractExtension
             new TwigFunction('emsch_search_one', [ClientRequestRuntime::class, 'searchOne']),
             new TwigFunction('emsch_add_environment', [ClientRequestRuntime::class, 'addEnvironment']),
             new TwigFunction('emsch_search_config', [ClientRequestRuntime::class, 'searchConfig']),
+            new TwigFunction('emsch_search_config_execute', [ClientRequestRuntime::class, 'searchConfigExecute']),
             new TwigFunction('emsch_http_error', [ClientRequestRuntime::class, 'httpException']),
             new TwigFunction('emsch_asset', [AssetHelperRuntime::class, 'asset'], ['is_safe' => ['html']]),
             new TwigFunction('emsch_asset_redirect', [AssetHelperRuntime::class, 'assetRedirect']),

--- a/docs/dev/client-helper-bundle/twig.md
+++ b/docs/dev/client-helper-bundle/twig.md
@@ -66,6 +66,18 @@ Sorting example
 {% endif %}
 ````
 
+## ems_search_config_execute
+
+Execute a search configuration and retrieve the results, allowing the
+configuration to be defined directly within Twig templates instead of in the
+route or environment variables
+
+````twig
+{% set searchConfig = emsch_search_config() %}
+
+{% set results = emsch_search_config_execute(searchConfig %}
+````
+
 # Twig embed
 
 ## render hierarchy


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  n |
| New feature?   | y  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | y  |

Now we can define the search config inside twig, instead of the route or environment variable.
