### PR TITLE
feat(demo/wysiwyg): add wysiwyg crawler macro

### DIFF
--- a/demo/skeleton/template/macros/wysiwyg.twig
+++ b/demo/skeleton/template/macros/wysiwyg.twig
@@ -1,0 +1,38 @@
+{% macro transform(content, transformers = ['table', 'img', 'external_links']) %}
+    {% set crawler = content|ems_dom_crawler %}
+
+    {% for transformer in transformers %}
+        {{ block('_' ~ transformer) }}
+    {% endfor %}
+
+    {{ crawler.html()|raw }}
+{% endmacro %}
+
+{% block _table %}
+    {% for table in crawler.filter('table:not([class])') %}
+        {% set wrapper = table.ownerDocument.createElement('div') %}
+        {% do wrapper.setAttribute('class', 'table-responsive') %}
+
+        {% do table.setAttribute('class', 'table table-bordered table-striped') %}
+
+        {% do table.replaceWith(wrapper) %}
+        {% do wrapper.append(table) %}
+    {% endfor %}
+{% endblock _table %}
+
+{% block _img %}
+    {% for img in crawler.filter('img:not([class*="img-fluid"])') %}
+        {% do img.setAttribute('class', 'img-fluid') %}
+    {% endfor %}
+{% endblock _img %}
+
+{% block _external_links %}
+    {% set new_window = 'key.new_window'|trans %}
+    {% for a in crawler.filter('a[href^="http"]') %}
+        {% set span = a.ownerDocument.createElement('span') %}
+        {% do span.setAttribute('class', 'sr-only') %}
+        {% do span.append(new_window) %}
+        {% do a.append(span) %}
+        {% do a.setAttribute('target', '_blank') %}
+    {% endfor %}
+{% endblock _external_links %}

--- a/demo/skeleton/template/news/details.html.twig
+++ b/demo/skeleton/template/news/details.html.twig
@@ -1,6 +1,8 @@
 {% extends '@EMSCH/template/view/abstract.html.twig' %}
 {% trans_default_domain trans_default_domain %}
 
+{% import '@EMSCH/template/macros/wysiwyg.twig' as wysiwyg %}
+
 {% block title %}
     {%- if attribute(source, locale).meta_title|default(false) -%}
         {{- attribute(source, locale).meta_title -}}
@@ -43,7 +45,9 @@
         <section class="py-5 py-lg-8">
             <div class="row">
                 <div class="col-12 col-lg-10 offset-lg-1 col-xl-8 offset-xl-2">
-                    {{ attribute(source, locale).body|emsch_routing }}
+                    {%- if attribute(source, locale).body is defined -%}
+                        {{ wysiwyg.transform(attribute(source, locale).body|emsch_routing) }}
+                    {%- endif -%}
                 </div>
                 <div class="col-12 col-lg-10 offset-lg-1 col-xl-8 offset-xl-2">
                     {%  set target = {

--- a/demo/skeleton/template/page/default.html.twig
+++ b/demo/skeleton/template/page/default.html.twig
@@ -1,6 +1,8 @@
 {% extends '@EMSCH/template/base/bootstrap.html.twig' %}
 {% trans_default_domain trans_default_domain %}
 
+{% import '@EMSCH/template/macros/wysiwyg.twig' as wysiwyg %}
+
 {% block title %}{{ attribute(source, locale).title|default('') }}{% endblock %}
 
 {% block metatitle -%}
@@ -38,7 +40,7 @@
             <section class="py-5 py-lg-8">
                 <div class="row">
                     <div class="col-12 col-lg-10 offset-lg-1 col-xl-8 offset-xl-2">
-                        {{ attribute(source, locale).body|emsch_routing }}
+                        {{ wysiwyg.transform(attribute(source, locale).body|emsch_routing) }}
                     </div>
                 </div>
             </section>

--- a/demo/skeleton/template/page/with_banner.html.twig
+++ b/demo/skeleton/template/page/with_banner.html.twig
@@ -1,6 +1,8 @@
 {% extends '@EMSCH/template/page/default.html.twig' %}
 {% trans_default_domain trans_default_domain %}
 
+{% import '@EMSCH/template/macros/wysiwyg.twig' as wysiwyg %}
+
 {% block body_class %}with-banner{% endblock %}
 {% block main -%}
     <div class="jumbotron py-8 px-0 rounded-0 mb-0">
@@ -13,7 +15,9 @@
                     <h1 {{ emsch_admin_menu(target.getEmsLink|default(emsLink|default(''))) }}>
                         {{ block('title') }}
                     </h1>
-                    {{ attribute(source, locale).body|default('')|emsch_routing|raw }}
+                    {%- if attribute(source, locale).body is defined -%}
+                        {{ wysiwyg.transform(attribute(source, locale).body|default('')|emsch_routing) }}
+                    {%- endif -%}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | x  |
| New feature?   |  y |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? |  n |

Added a macro for wysiwyg content rendering:
* automatically add "img-fluid" class to images
* automatically add "target=_blank" attribute to external links
* automatically add "new window" SR only text to external links
* automatically add bootstrap table styling to <table>s
