### PR TITLE
fix(web/form): pass submitted data to template

### DIFF
--- a/EMS/client-helper-bundle/src/Controller/FormController.php
+++ b/EMS/client-helper-bundle/src/Controller/FormController.php
@@ -23,18 +23,15 @@ readonly class FormController
     public function __invoke(Request $request): Response
     {
         $template = $this->handler->handle($request);
-
         $data = $template->jsonBlock(EmschFormBlock::DATA->value);
 
         $form = $this->formFactory->create(EmschFormType::class, $data, ['template' => $template]);
         $form->handleRequest($request);
 
-        if ($form->isSubmitted() && $form->isValid()) {
-            $template->context()->append(['emschFormData' => $form->getData()]);
-
-            if ($redirect = $template->renderBlock(EmschFormBlock::SUCCESS_REDIRECT->value)) {
-                return new RedirectResponse($redirect);
-            }
+        if ($form->isSubmitted()
+            && $form->isValid()
+            && $redirect = $template->renderBlock(EmschFormBlock::SUCCESS_REDIRECT->value)) {
+            return new RedirectResponse($redirect);
         }
 
         $template->context()->append(['emschForm' => $form->createView()]);

--- a/EMS/client-helper-bundle/src/Helper/Form/EmschFormType.php
+++ b/EMS/client-helper-bundle/src/Helper/Form/EmschFormType.php
@@ -9,6 +9,10 @@ use EMS\CommonBundle\Contracts\Twig\TemplateInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type as SymfonyType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraint;
@@ -24,22 +28,44 @@ class EmschFormType extends AbstractType
      * @param FormBuilderInterface<mixed> $builder
      * @param array{
      *     'template': TemplateInterface,
-     *     'emsch_form_view': array<mixed>
+     *     'elements': list<array{ 'name': string, 'type'?: 'string', 'options': array<string, mixed> }>
      * } $options
      */
     #[\Override]
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        /** @var list<array{ 'name': string, 'type'?: 'string', 'options': array<string, mixed> }> $elements */
-        $elements = $options['template']->jsonBlock(EmschFormBlock::CONFIG->value);
-
-        foreach ($elements as $element) {
+        foreach ($options['elements'] as $element) {
             $elementType = $this->getElementType($element['type'] ?? 'text');
             $elementOptions = $element['options'] ?? [];
             $elementOptions['constraints'] = $this->resolveConstraints($elementOptions['constraints'] ?? []);
-            $elementOptions['emsch_form_view'] = $options['emsch_form_view'];
 
             $builder->add(child: $element['name'], type: $elementType, options: $elementOptions);
+        }
+
+        $template = $options['template'];
+        $builder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) use ($template) {
+            $template->context()->append(['submitData' => $event->getData()]);
+        });
+    }
+
+    /**
+     * @param array{
+     *     'template': TemplateInterface,
+     *     'elements': list<array{ 'name': string, 'type'?: 'string', 'options': array<string, mixed> }>
+     * } $options
+     */
+    #[\Override]
+    public function finishView(FormView $view, FormInterface $form, array $options): void
+    {
+        $template = $options['template'];
+        $emschView = $template->jsonBlock(EmschFormBlock::VIEW->value);
+
+        foreach ($options['elements'] as $element) {
+            if (!isset($view->children[$element['name']])) {
+                continue;
+            }
+
+            $view->children[$element['name']]->vars['emsch_form_view'] = $emschView;
         }
     }
 
@@ -50,6 +76,12 @@ class EmschFormType extends AbstractType
             ->setRequired(['template'])
             ->setAllowedTypes('template', TemplateInterface::class)
             ->setDefaults([
+                'elements' => function (Options $options) {
+                    /** @var TemplateInterface $template */
+                    $template = $options['template'];
+
+                    return $template->jsonBlock(EmschFormBlock::CONFIG->value);
+                },
                 'constraints' => function (Options $options) {
                     /** @var TemplateInterface $template */
                     $template = $options['template'];
@@ -57,12 +89,6 @@ class EmschFormType extends AbstractType
                     return [new Assert\Callback(function ($data, ExecutionContextInterface $context) use ($template) {
                         $this->validateForm($data, $context, $template);
                     })];
-                },
-                'emsch_form_view' => function (Options $options): array {
-                    /** @var TemplateInterface $template */
-                    $template = $options['template'];
-
-                    return $template->jsonBlock(EmschFormBlock::VIEW->value);
                 },
             ])
         ;

--- a/EMS/client-helper-bundle/src/Helper/Form/EmschFormType.php
+++ b/EMS/client-helper-bundle/src/Helper/Form/EmschFormType.php
@@ -43,9 +43,13 @@ class EmschFormType extends AbstractType
         }
 
         $template = $options['template'];
-        $builder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) use ($template) {
-            $template->context()->append(['submitData' => $event->getData()]);
-        });
+        $appendEmschFormData = function (FormEvent $event) use ($template) {
+            $template->context()->append(['emschFormData' => $event->getData()]);
+        };
+
+        $builder
+            ->addEventListener(FormEvents::POST_SET_DATA, $appendEmschFormData)
+            ->addEventListener(FormEvents::POST_SUBMIT, $appendEmschFormData);
     }
 
     /**
@@ -87,7 +91,7 @@ class EmschFormType extends AbstractType
                     $template = $options['template'];
 
                     return [new Assert\Callback(function ($data, ExecutionContextInterface $context) use ($template) {
-                        $this->validateForm($data, $context, $template);
+                        $this->validateForm($context, $template);
                     })];
                 },
             ])
@@ -122,11 +126,8 @@ class EmschFormType extends AbstractType
         };
     }
 
-    /** @param array<string, mixed> $data */
-    private function validateForm(array $data, ExecutionContextInterface $context, TemplateInterface $template): void
+    private function validateForm(ExecutionContextInterface $context, TemplateInterface $template): void
     {
-        $template->context()->append(['submitData' => $data]);
-
         /** @var array<int, array{ 'path'?: string, 'message': string }> $errors */
         $errors = $template->jsonBlock(EmschFormBlock::VALIDATE->value);
 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Problem: 
We can not access the submitted data in the twig blocks for customizing the form rendering.
For example on load we check the draft data for ems link and resolve these with one query. But on resubmit the submitted data could be different from the draft data.

Now emschFormData variable is available in the blocks: `emschFormView` , `emschFormValidate`, `emschFormSuccessRedirect`.


