### PR TITLE
fix(admin/revision): lock exception on restore from trash

### DIFF
--- a/EMS/core-bundle/src/Entity/Revision.php
+++ b/EMS/core-bundle/src/Entity/Revision.php
@@ -390,6 +390,22 @@ class Revision implements EntityInterface, \Stringable
         return $this;
     }
 
+    public function delete(string $username): self
+    {
+        $this->deletedBy = $username;
+        $this->deleted = true;
+
+        return $this;
+    }
+
+    public function restore(): self
+    {
+        $this->deletedBy = null;
+        $this->deleted = false;
+
+        return $this;
+    }
+
     public function setDeleted(bool $deleted): self
     {
         $this->deleted = $deleted;
@@ -541,13 +557,6 @@ class Revision implements EntityInterface, \Stringable
     public function setArchivedBy(?string $archivedBy): void
     {
         $this->archivedBy = $archivedBy;
-    }
-
-    public function setDeletedBy(?string $deletedBy): self
-    {
-        $this->deletedBy = $deletedBy;
-
-        return $this;
     }
 
     public function getDeletedBy(): ?string

--- a/EMS/core-bundle/src/Service/DataService.php
+++ b/EMS/core-bundle/src/Service/DataService.php
@@ -1219,14 +1219,14 @@ class DataService
                 }
                 $revision->removeEnvironment($environment);
             }
-            $revision->setDeleted(true);
-            $revision->setDeletedBy($username);
+            $revision->delete($username);
 
             if (null === $revision->getEndTime()) {
                 $this->auditLogger->notice('log.revision.deleted', LogRevisionContext::delete($revision));
             }
 
             $em->persist($revision);
+            $this->unlockRevision($revision, $username);
         }
         $em->flush();
 
@@ -1249,16 +1249,14 @@ class DataService
         $revisions = $this->revRepository->findTrashRevisions($contentType, ...$ouuids);
 
         foreach ($revisions as $revision) {
-            $revision->setDeleted(false);
-            $revision->setDeletedBy(null);
+            $this->lockRevision($revision);
+            $revision->restore();
             if (null === $revision->getEndTime()) {
-                $this->lockRevision($revision);
                 $revision->setDraft(true);
                 $this->auditLogger->notice('log.revision.restored', LogRevisionContext::update($revision));
-            } else {
-                $revision->enableSelfUpdate();
             }
             $this->em->persist($revision);
+            $this->unlockRevision($revision);
         }
         $this->em->flush();
 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

The previous fix was not correct: https://github.com/ems-project/elasticms/pull/1087 We should just correctly unlock the revision.
Also added 2 new methods 'delete' & 'restore' on the revision entity.
