### PR TITLE
fix(admin/revision): save display value in label on delete

### DIFF
--- a/EMS/core-bundle/config/controllers.xml
+++ b/EMS/core-bundle/config/controllers.xml
@@ -151,6 +151,7 @@
         <service id="EMS\CoreBundle\Controller\ContentManagement\DataController" public="true">
             <argument type="service" id="logger" />
             <argument type="service" id="ems.service.data" />
+            <argument type="service" id="ems.service.revision" />
             <argument type="service" id="ems.service.search" />
             <argument type="service" id="ems.service.contenttype" />
             <argument type="service" id="ems.service.environment" />

--- a/EMS/core-bundle/config/services.xml
+++ b/EMS/core-bundle/config/services.xml
@@ -234,6 +234,7 @@
             <argument type="service" id="ems_core.core_mail.mailer_service" />
             <argument type="service" id="ems.repository.user" />
             <argument type="service" id="security.user_password_hasher" />
+            <argument type="service" id="security.authorization_checker" />
             <argument>%ems_core.template_namespace%</argument>
         </service>
 
@@ -283,6 +284,7 @@
             <argument type="service" id="form.factory" />
             <argument type="service" id="logger" />
             <argument type="service" id="emsco.logger.audit" />
+            <argument type="service" id="Doctrine\ORM\EntityManagerInterface" />
             <argument type="service" id="EMS\CoreBundle\Repository\RevisionRepository" />
             <argument type="service" id="ems.service.publish" />
             <argument type="service" id="EMS\CoreBundle\Service\ContentTypeService"/>

--- a/EMS/core-bundle/src/Controller/ContentManagement/CrudController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/CrudController.php
@@ -219,7 +219,7 @@ class CrudController extends AbstractController
         $isDeleted = false;
 
         try {
-            $this->dataService->delete($name, $ouuid);
+            $this->revisionService->delete($name, $ouuid);
             $this->logger->notice('log.crud.deleted', [
                 EmsFields::LOG_CONTENTTYPE_FIELD => $name,
                 EmsFields::LOG_OUUID_FIELD => $ouuid,

--- a/EMS/core-bundle/src/Controller/ContentManagement/DataController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/DataController.php
@@ -37,6 +37,7 @@ use EMS\CoreBundle\Service\EnvironmentService;
 use EMS\CoreBundle\Service\IndexService;
 use EMS\CoreBundle\Service\JobService;
 use EMS\CoreBundle\Service\PublishService;
+use EMS\CoreBundle\Service\Revision\RevisionService;
 use EMS\CoreBundle\Service\SearchService;
 use EMS\CoreBundle\Twig\AppExtension;
 use EMS\Helpers\Standard\Json;
@@ -60,6 +61,7 @@ class DataController extends AbstractController
     public function __construct(
         private readonly LoggerInterface $logger,
         private readonly DataService $dataService,
+        private readonly RevisionService $revisionService,
         private readonly SearchService $searchService,
         private readonly ContentTypeService $contentTypeService,
         private readonly EnvironmentService $environmentService,
@@ -353,7 +355,7 @@ class DataController extends AbstractController
             ]);
         }
 
-        $this->dataService->delete($type, $ouuid);
+        $this->revisionService->delete($type, $ouuid);
 
         return $this->contentTypeService->redirectOverview($contentType);
     }

--- a/EMS/core-bundle/src/Core/Bridge/Core/CoreDataServiceBridge.php
+++ b/EMS/core-bundle/src/Core/Bridge/Core/CoreDataServiceBridge.php
@@ -52,7 +52,7 @@ readonly class CoreDataServiceBridge implements CoreDataBridgeInterface
     #[\Override]
     public function delete(string $uuid): CoreBridgeResponse
     {
-        return $this->response(fn () => $this->dataService->delete($this->contentType->validate(), $uuid));
+        return $this->response(fn () => $this->revisionService->delete($this->contentType->validate(), $uuid));
     }
 
     #[\Override]

--- a/EMS/core-bundle/src/Core/Component/MediaLibrary/MediaLibraryService.php
+++ b/EMS/core-bundle/src/Core/Component/MediaLibrary/MediaLibraryService.php
@@ -85,7 +85,7 @@ class MediaLibraryService
     public function deleteDocument(MediaLibraryDocument $mediaDocument, ?string $username = null): void
     {
         $document = $mediaDocument->document;
-        $this->dataService->delete($document->getContentType(), $document->getOuuid(), $username);
+        $this->revisionService->delete($document->getContentType(), $document->getOuuid(), $username);
     }
 
     public function exists(MediaLibraryFile|MediaLibraryFolder $document): bool

--- a/EMS/core-bundle/src/Core/User/UserManager.php
+++ b/EMS/core-bundle/src/Core/User/UserManager.php
@@ -13,6 +13,7 @@ use EMS\CoreBundle\Repository\UserRepository;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 class UserManager
 {
@@ -25,6 +26,7 @@ class UserManager
         private readonly MailerService $mailerService,
         private readonly UserRepository $userRepository,
         private readonly UserPasswordHasherInterface $userPasswordHasher,
+        private readonly AuthorizationCheckerInterface $authorizationChecker,
         private readonly string $templateNamespace,
     ) {
     }
@@ -89,6 +91,11 @@ class UserManager
     public function getUserByConfirmationToken(string $token): ?User
     {
         return $this->userRepository->findOneBy(['confirmationToken' => $token]);
+    }
+
+    public function isGranted(string $role): bool
+    {
+        return $this->authorizationChecker->isGranted($role);
     }
 
     public function requestResetPassword(string $usernameOrEmail): ?User

--- a/EMS/core-bundle/src/Service/DataService.php
+++ b/EMS/core-bundle/src/Service/DataService.php
@@ -11,7 +11,6 @@ use Doctrine\ORM\OptimisticLockException;
 use EMS\CommonBundle\Common\EMSLink;
 use EMS\CommonBundle\Elasticsearch\Document\Document;
 use EMS\CommonBundle\Elasticsearch\Document\DocumentInterface;
-use EMS\CommonBundle\Elasticsearch\Exception\NotFoundException;
 use EMS\CommonBundle\Helper\EmsFields;
 use EMS\CommonBundle\Service\ElasticaService;
 use EMS\CommonBundle\Storage\StorageManager;
@@ -54,7 +53,6 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
-use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Twig\Environment as TwigEnvironment;
 use Twig\Error\Error;
@@ -1191,64 +1189,6 @@ class DataService
         $this->auditLogger->info('log.revision.draft.deleted', LogRevisionContext::update($revision));
 
         return $hasPreviousRevision;
-    }
-
-    public function delete(ContentType|string $contentType, string $ouuid, ?string $username = null): void
-    {
-        $contentType = (\is_string($contentType)) ? $this->contentTypeService->giveByName($contentType) : $contentType;
-        $contentType->validate();
-
-        if (!$this->authorizationChecker->isGranted($contentType->role(ContentTypeRoles::DELETE))) {
-            throw new AccessDeniedException('Delete role not granted!');
-        }
-
-        /** @var EntityManager $em */
-        $em = $this->doctrine->getManager();
-        /** @var RevisionRepository $repository */
-        $repository = $em->getRepository(Revision::class);
-
-        $revisions = $repository->findBy([
-            'ouuid' => $ouuid,
-            'contentType' => $contentType]);
-
-        $username ??= $this->userService->getCurrentUser()->getUsername();
-
-        /** @var Revision $revision */
-        foreach ($revisions as $revision) {
-            $this->lockRevision(revision: $revision, username: $username);
-
-            /** @var Environment $environment */
-            foreach ($revision->getEnvironments() as $environment) {
-                try {
-                    $this->indexService->delete($revision, $environment);
-                    $this->auditLogger->notice('log.unpublished.success', LogRevisionContext::unpublish($revision, $environment));
-                } catch (NotFoundException $e) {
-                    if (!$revision->getDeleted()) {
-                        $this->logger->warning('service.data.already_unpublished', [
-                            'label' => $revision->getLabel(),
-                            EmsFields::LOG_CONTENTTYPE_FIELD => $revision->giveContentType()->getName(),
-                            EmsFields::LOG_OUUID_FIELD => $revision->getOuuid(),
-                            EmsFields::LOG_REVISION_ID_FIELD => $revision->getId(),
-                            EmsFields::LOG_OPERATION_FIELD => EmsFields::LOG_OPERATION_DELETE,
-                            EmsFields::LOG_ENVIRONMENT_FIELD => $environment->getLabel(),
-                        ]);
-                    }
-                    throw $e;
-                }
-                $revision->removeEnvironment($environment);
-            }
-            $revision->delete($username);
-
-            if (null === $revision->getEndTime()) {
-                $this->auditLogger->notice('log.revision.deleted', LogRevisionContext::delete($revision));
-            }
-
-            $em->persist($revision);
-            $this->unlockRevision($revision, $username);
-        }
-        $em->flush();
-
-        $this->elasticaService->refresh($contentType->giveEnvironment()->getAlias());
     }
 
     public function trashEmpty(ContentType $contentType, string ...$ouuids): void

--- a/EMS/core-bundle/src/Service/PublishService.php
+++ b/EMS/core-bundle/src/Service/PublishService.php
@@ -267,7 +267,7 @@ class PublishService
     /**
      * @throws DBALException
      */
-    public function unpublish(Revision $revision, Environment $environment, bool $command = false): void
+    public function unpublish(Revision $revision, Environment $environment, bool $command = false, bool $defaultProtected = true): void
     {
         if (!$command) {
             $user = $this->userService->getCurrentUser();
@@ -293,7 +293,7 @@ class PublishService
             }
         }
 
-        if ($revision->giveContentType()->giveEnvironment() === $environment) {
+        if ($defaultProtected && $revision->giveContentType()->giveEnvironment() === $environment) {
             $this->logger->warning('service.publish.not_in_default_environment', [
                 EmsFields::LOG_CONTENTTYPE_FIELD => $revision->giveContentType()->getName(),
                 EmsFields::LOG_OUUID_FIELD => $revision->getOuuid(),

--- a/EMS/core-bundle/src/Service/Revision/RevisionService.php
+++ b/EMS/core-bundle/src/Service/Revision/RevisionService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EMS\CoreBundle\Service\Revision;
 
+use Doctrine\ORM\EntityManagerInterface;
 use EMS\CommonBundle\Common\EMSLink;
 use EMS\CommonBundle\Common\EMSLinkCollection;
 use EMS\CommonBundle\Contracts\ExpressionServiceInterface;
@@ -14,6 +15,7 @@ use EMS\CommonBundle\Service\ElasticaService;
 use EMS\CoreBundle\Common\DocumentInfo;
 use EMS\CoreBundle\Contracts\Revision\RevisionServiceInterface;
 use EMS\CoreBundle\Core\ContentType\ContentTypeFields;
+use EMS\CoreBundle\Core\ContentType\ContentTypeRoles;
 use EMS\CoreBundle\Core\Log\LogRevisionContext;
 use EMS\CoreBundle\Core\Revision\Revisions;
 use EMS\CoreBundle\Core\User\UserManager;
@@ -33,6 +35,7 @@ use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\Form\FormFactory;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -45,6 +48,7 @@ class RevisionService implements RevisionServiceInterface
         private readonly FormFactory $formFactory,
         private readonly LoggerInterface $logger,
         private readonly LoggerInterface $auditLogger,
+        private readonly EntityManagerInterface $em,
         private readonly RevisionRepository $revisionRepository,
         private readonly PublishService $publishService,
         private readonly ContentTypeService $contentTypeService,
@@ -121,6 +125,40 @@ class RevisionService implements RevisionServiceInterface
         return $this->formFactory->createBuilder(RevisionType::class, $revision, [
             'raw_data' => $revision->getRawData(),
         ])->getForm();
+    }
+
+    public function delete(ContentType|string $contentType, string $ouuid, ?string $username = null): void
+    {
+        $contentType = (\is_string($contentType)) ? $this->contentTypeService->giveByName($contentType) : $contentType;
+        $contentType->validate();
+
+        if (!$this->userManager->isGranted($contentType->role(ContentTypeRoles::DELETE))) {
+            throw new AccessDeniedException('Delete role not granted!');
+        }
+
+        $revisions = $this->revisionRepository->findBy(['ouuid' => $ouuid, 'contentType' => $contentType]);
+        $username ??= $this->userManager->getAuthenticatedUser()->getUsername();
+
+        /** @var Revision $revision */
+        foreach ($revisions as $revision) {
+            $this->dataService->lockRevision(revision: $revision, username: $username);
+
+            /** @var Environment $environment */
+            foreach ($revision->getEnvironments() as $environment) {
+                $this->publishService->unpublish(revision: $revision, environment: $environment, defaultProtected: false);
+            }
+            $revision->delete($username);
+
+            if (null === $revision->getEndTime()) {
+                $this->auditLogger->notice('log.revision.deleted', LogRevisionContext::delete($revision));
+            }
+
+            $this->em->persist($revision);
+            $this->dataService->unlockRevision($revision, $username);
+        }
+        $this->em->flush();
+
+        $this->elasticaService->refresh($contentType->giveEnvironment()->getAlias());
     }
 
     public function deleteByContentType(ContentType $contentType): int


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n |

On delete we should save the display value in the label field. We can use the display method which has a fallback to label_field (old way). But to make this work we had to move the delete method from dataService to RevisionService, otherwise we got a circular reference error.


