### PR TITLE
fix(admin/revision): use revision display column in trash overview

### DIFF
--- a/EMS/core-bundle/src/DataTable/Type/Revision/RevisionTrashDataTableType.php
+++ b/EMS/core-bundle/src/DataTable/Type/Revision/RevisionTrashDataTableType.php
@@ -48,7 +48,7 @@ class RevisionTrashDataTableType extends AbstractTableType implements QueryServi
             ->setLabelAttribute('label')
             ->setDefaultOrder('modified', 'desc');
 
-        $table->addColumnDefinition(new RevisionDisplayTableColumn(t('field.label', [], 'emsco-core'), 'label'))->setOrderField('labelField');;
+        $table->addColumnDefinition(new RevisionDisplayTableColumn(t('field.label', [], 'emsco-core'), 'label'))->setOrderField('labelField');
         if ($this->userService->isSuper()) {
             $table->addColumn(t('revision.field.ouuid', [], 'emsco-core'), 'ouuid');
         }


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Did a correct commit on 5.25, but phpcs was not valide show I made this pr.
Just like in drafts overview, we should use the RevisionDisplayTableColumn
