### PR TITLE
fix(admin/api): ldap authenticator use provider

### DIFF
--- a/EMS/core-bundle/src/Resources/config/security/ldap.xml
+++ b/EMS/core-bundle/src/Resources/config/security/ldap.xml
@@ -24,6 +24,7 @@
 
         <service id="emsco.security.authenticator.auth_token_ldap" class="EMS\CoreBundle\Security\Ldap\LdapAuthTokenLoginAuthenticator">
             <argument type="service" id="ems_core.security.ldap.config" />
+            <argument type="service" id="emsco.security.provider.user_ldap" />
             <argument type="service" id="ems.repository.auth_token" />
         </service>
 

--- a/EMS/core-bundle/src/Security/Ldap/LdapAuthTokenLoginAuthenticator.php
+++ b/EMS/core-bundle/src/Security/Ldap/LdapAuthTokenLoginAuthenticator.php
@@ -23,11 +23,16 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 class LdapAuthTokenLoginAuthenticator extends AbstractAuthenticator
 {
     private AuthTokenRepository $authTokenRepository;
+    private LdapUserProvider $ldapUserProvider;
     private LdapConfig $ldapConfig;
 
-    public function __construct(LdapConfig $ldapConfig, AuthTokenRepository $authTokenRepository)
-    {
+    public function __construct(
+        LdapConfig $ldapConfig,
+        LdapUserProvider $ldapUserProvider,
+        AuthTokenRepository $authTokenRepository
+    ) {
         $this->authTokenRepository = $authTokenRepository;
+        $this->ldapUserProvider = $ldapUserProvider;
         $this->ldapConfig = $ldapConfig;
     }
 
@@ -49,7 +54,7 @@ class LdapAuthTokenLoginAuthenticator extends AbstractAuthenticator
         }
 
         return new Passport(
-            new UserBadge($username),
+            new UserBadge($username, fn ($userIdentifier) => $this->ldapUserProvider->loadUserByIdentifier($userIdentifier)),
             new PasswordCredentials($password),
             [
                 new LdapBadge(


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

The ldap api authenticator was not calling the UserProvider
