### PR TITLE
feat(admin/cli): add report option for emsco:asset:extract

### DIFF
--- a/EMS/common-bundle/src/EventListener/CommandListener.php
+++ b/EMS/common-bundle/src/EventListener/CommandListener.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace EMS\CommonBundle\EventListener;
 
 use EMS\CommonBundle\Command\CommandInterface;
-use EMS\CommonBundle\Common\Converter;
+use EMS\Helpers\Standard\Number;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\Console\Event\ConsoleTerminateEvent;
@@ -58,7 +58,7 @@ class CommandListener implements EventSubscriberInterface
         $io = new SymfonyStyle($event->getInput(), $event->getOutput());
         $io->listing([
             \sprintf('Duration: %d s', $stopwatch->getDuration() / 1000),
-            \sprintf('Memory: %s', Converter::formatBytes($stopwatch->getMemory())),
+            \sprintf('Memory: %s', Number::formatBytes($stopwatch->getMemory())),
         ]);
     }
 }

--- a/EMS/common-bundle/src/Twig/CommonExtension.php
+++ b/EMS/common-bundle/src/Twig/CommonExtension.php
@@ -10,6 +10,7 @@ use EMS\CommonBundle\Helper\Text\Encoder;
 use EMS\Helpers\Standard\Base64;
 use EMS\Helpers\Standard\Color;
 use EMS\Helpers\Standard\DateTime;
+use EMS\Helpers\Standard\Number;
 use EMS\Helpers\Standard\UuidGenerator;
 use Twig\DeprecatedCallableInfo;
 use Twig\Extension\AbstractExtension;
@@ -55,7 +56,7 @@ class CommonExtension extends AbstractExtension
         return [
             new TwigFilter('ems_array_key', $this->arrayKey(...)),
             new TwigFilter('ems_file_exists', $this->fileExists(...)),
-            new TwigFilter('ems_format_bytes', Converter::formatBytes(...)),
+            new TwigFilter('ems_format_bytes', Number::formatBytes(...)),
             new TwigFilter('ems_ouuid', $this->getOuuid(...)),
             new TwigFilter('ems_locale_attr', [RequestRuntime::class, 'localeAttribute']),
             new TwigFilter('ems_html_encode', [TextRuntime::class, 'htmlEncode'], ['is_safe' => ['html']]),
@@ -96,7 +97,7 @@ class CommonExtension extends AbstractExtension
             new TwigFilter('array_key', $this->arrayKey(...), [
                 'deprecation_info' => new DeprecatedCallableInfo('elasticms/common-bundle', '6.0.0', 'ems_array_key'),
             ]),
-            new TwigFilter('format_bytes', Converter::formatBytes(...), [
+            new TwigFilter('format_bytes', Number::formatBytes(...), [
                 'deprecation_info' => new DeprecatedCallableInfo('elasticms/common-bundle', '6.0.0', 'ems_format_bytes'),
             ]),
             new TwigFilter('locale_attr', [RequestRuntime::class, 'localeAttribute'], [

--- a/EMS/common-bundle/tests/Unit/Common/ConverterAiTest.php
+++ b/EMS/common-bundle/tests/Unit/Common/ConverterAiTest.php
@@ -16,13 +16,6 @@ class ConverterAiTest extends TestCase
         $this->assertEquals('a-e-i-o-u', Converter::toAscii('À É Í Ó Ú'));
     }
 
-    public function testFormatBytes(): void
-    {
-        $this->assertEquals('1 B', Converter::formatBytes(1));
-        $this->assertEquals('1 KB', Converter::formatBytes(1024));
-        $this->assertEquals('1 MB', Converter::formatBytes(1024 * 1024));
-    }
-
     public function testStringify(): void
     {
         $this->assertEquals('hello', Converter::stringify('hello'));

--- a/EMS/common-bundle/tests/Unit/Common/ConverterTest.php
+++ b/EMS/common-bundle/tests/Unit/Common/ConverterTest.php
@@ -40,28 +40,4 @@ class ConverterTest extends TestCase
     {
         self::assertSame($expected, $this->converter->toAscii($str));
     }
-
-    /**
-     * format: [int,text].
-     *
-     * @return array<array<int|string>>
-     */
-    public static function byteProvider(): array
-    {
-        return [
-            [243, '243 B', '243 B', '243 B'],
-            [2496, '2.44 KB', '2 KB', '2.4375 KB'],
-            [24_962_496, '23.81 MB', '24 MB', '23.8061 MB'],
-            [249_624_962_496, '232.48 GB', '232 GB', '232.4814 GB'],
-            [2_496_249_624_962_496, '2270.33 TB', '2270 TB', '2270.3258 TB'],
-        ];
-    }
-
-    #[DataProvider('byteProvider')]
-    public function testBytes(int $byte, string $expected, string $expected2, string $expected3): void
-    {
-        self::assertSame($expected, $this->converter->formatBytes($byte));
-        self::assertSame($expected2, $this->converter->formatBytes($byte, 0));
-        self::assertSame($expected3, $this->converter->formatBytes($byte, 4));
-    }
 }

--- a/EMS/core-bundle/src/Command/ExtractAssetCommand.php
+++ b/EMS/core-bundle/src/Command/ExtractAssetCommand.php
@@ -130,9 +130,9 @@ class ExtractAssetCommand extends AbstractCommand
             return \is_array($row) ? [
                 $row['name'],
                 Number::formatBytes($row['size']),
-                \number_format($row['length'], 0, ',', '.'),
-                \number_format($row['words'], 0, ',', '.'),
-                \number_format($row['tokens'], 0, ',', '.'),
+                Number::format($row['length']),
+                Number::format($row['words']),
+                Number::format($row['tokens']),
             ] : $row;
         }, $rows));
     }

--- a/EMS/core-bundle/src/Command/ExtractAssetCommand.php
+++ b/EMS/core-bundle/src/Command/ExtractAssetCommand.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace EMS\CoreBundle\Command;
 
 use EMS\CommonBundle\Common\Command\AbstractCommand;
-use EMS\CommonBundle\Common\Converter;
 use EMS\CommonBundle\Storage\Service\StorageInterface;
 use EMS\CommonBundle\Storage\StorageManager;
 use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Service\AssetExtractorService;
+use EMS\Helpers\Standard\Number;
 use EMS\Helpers\Standard\Type;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -129,7 +129,7 @@ class ExtractAssetCommand extends AbstractCommand
         $this->io->table(['name', 'size', 'length', 'words', 'tokens'], \array_map(static function ($row) {
             return \is_array($row) ? [
                 $row['name'],
-                Converter::formatBytes($row['size']),
+                Number::formatBytes($row['size']),
                 \number_format($row['length'], 0, ',', '.'),
                 \number_format($row['words'], 0, ',', '.'),
                 \number_format($row['tokens'], 0, ',', '.'),

--- a/EMS/core-bundle/src/Command/ExtractAssetCommand.php
+++ b/EMS/core-bundle/src/Command/ExtractAssetCommand.php
@@ -5,13 +5,18 @@ declare(strict_types=1);
 namespace EMS\CoreBundle\Command;
 
 use EMS\CommonBundle\Common\Command\AbstractCommand;
+use EMS\CommonBundle\Common\Converter;
+use EMS\CommonBundle\Storage\Service\StorageInterface;
 use EMS\CommonBundle\Storage\StorageManager;
 use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Service\AssetExtractorService;
+use EMS\Helpers\Standard\Type;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Finder\Finder;
 
@@ -25,6 +30,7 @@ class ExtractAssetCommand extends AbstractCommand
 {
     private const string ARG_PATH = 'path';
     private const string ARG_NAME = 'name';
+    private const string OPTION_REPORT = 'report';
 
     public function __construct(
         protected LoggerInterface $logger,
@@ -40,33 +46,91 @@ class ExtractAssetCommand extends AbstractCommand
         $this
             ->addArgument(self::ARG_PATH, InputArgument::REQUIRED, 'Path to the files to extract data from')
             ->addArgument(self::ARG_NAME, InputArgument::OPTIONAL, 'File pattern or file name i.e. *.pdf', '*.*')
+            ->addOption(self::OPTION_REPORT, null, InputOption::VALUE_NONE, 'Print extract data report')
         ;
     }
 
     #[\Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $this->io->title('EMSCO - asset - extract');
+
         $path = $this->getArgumentString(self::ARG_PATH);
         $name = $this->getArgumentString(self::ARG_NAME);
 
         $files = new Finder()->in($path)->name($name);
 
+        $this->io->section('Extracting files');
+        $this->extract($files);
+
+        if ($this->getOptionBool(self::OPTION_REPORT)) {
+            $this->io->section('Report');
+            $this->report($files);
+        }
+
+        return self::EXECUTE_SUCCESS;
+    }
+
+    private function extract(Finder $files): void
+    {
         $progress = $this->io->createProgressBar($files->count());
         $progress->start();
 
         foreach ($files as $file) {
-            if (false === $realPath = $file->getRealPath()) {
-                $progress->advance();
-                continue;
+            $filename = Type::string($file->getRealPath());
+            $hash = $this->storageManager->computeFileHash($filename);
+
+            if (!$this->storageManager->head($hash)) {
+                $this->storageManager->saveFile($filename, StorageInterface::STORAGE_USAGE_ASSET);
             }
 
-            $hash = $this->storageManager->computeFileHash($realPath);
-            $this->extractorService->extractMetaData($hash, $realPath);
+            $this->extractorService->extractMetaData($hash, $filename, true);
 
             $progress->advance();
         }
-        $progress->finish();
 
-        return self::EXECUTE_SUCCESS;
+        $progress->finish();
+        $this->io->newLine(2);
+    }
+
+    private function report(Finder $files): void
+    {
+        $rows = [];
+        foreach ($files as $file) {
+            $filename = Type::string($file->getRealPath());
+            $hash = $this->storageManager->computeFileHash($filename);
+
+            if (null === $extractedData = $this->extractorService->findCachedExtractedData($hash)) {
+                throw new \RuntimeException('Extracted file not found');
+            }
+
+            $content = $extractedData->getContent(false);
+            $rows[] = [
+                'name' => $file->getFilename(),
+                'size' => $file->getSize(),
+                'length' => \strlen($content),
+                'words' => \str_word_count($content),
+            ];
+        }
+
+        $totals = \array_reduce($rows, static function ($carry, $row) {
+            $carry['size'] += $row['size'];
+            $carry['length'] += $row['length'];
+            $carry['words'] += $row['words'];
+
+            return $carry;
+        }, ['size' => 0, 'length' => 0, 'words' => 0]);
+
+        $rows[] = new TableSeparator();
+        $rows[] = ['name' => '<info>totals</info>', ...$totals];
+
+        $this->io->table(['name', 'size', 'length', 'words'], \array_map(static function ($row) {
+            return \is_array($row) ? [
+                $row['name'],
+                Converter::formatBytes($row['size']),
+                \number_format($row['length'], 0, ',', '.'),
+                \number_format($row['words'], 0, ',', '.'),
+            ] : $row;
+        }, $rows));
     }
 }

--- a/EMS/core-bundle/src/Command/ExtractAssetCommand.php
+++ b/EMS/core-bundle/src/Command/ExtractAssetCommand.php
@@ -110,6 +110,7 @@ class ExtractAssetCommand extends AbstractCommand
                 'size' => $file->getSize(),
                 'length' => \strlen($content),
                 'words' => \str_word_count($content),
+                'tokens' => $this->estimateTokens($content),
             ];
         }
 
@@ -117,20 +118,30 @@ class ExtractAssetCommand extends AbstractCommand
             $carry['size'] += $row['size'];
             $carry['length'] += $row['length'];
             $carry['words'] += $row['words'];
+            $carry['tokens'] += $row['tokens'];
 
             return $carry;
-        }, ['size' => 0, 'length' => 0, 'words' => 0]);
+        }, ['size' => 0, 'length' => 0, 'words' => 0, 'tokens' => 0]);
 
         $rows[] = new TableSeparator();
         $rows[] = ['name' => '<info>totals</info>', ...$totals];
 
-        $this->io->table(['name', 'size', 'length', 'words'], \array_map(static function ($row) {
+        $this->io->table(['name', 'size', 'length', 'words', 'tokens'], \array_map(static function ($row) {
             return \is_array($row) ? [
                 $row['name'],
                 Converter::formatBytes($row['size']),
                 \number_format($row['length'], 0, ',', '.'),
                 \number_format($row['words'], 0, ',', '.'),
+                \number_format($row['tokens'], 0, ',', '.'),
             ] : $row;
         }, $rows));
+    }
+
+    private function estimateTokens(string $content): int 
+    {
+        $words = preg_split('/\s+/', trim($content));
+        $wordCount = count($words);
+        
+        return (int) ceil($wordCount * 1.33);
     }
 }

--- a/EMS/core-bundle/src/Command/ExtractAssetCommand.php
+++ b/EMS/core-bundle/src/Command/ExtractAssetCommand.php
@@ -137,11 +137,14 @@ class ExtractAssetCommand extends AbstractCommand
         }, $rows));
     }
 
-    private function estimateTokens(string $content): int 
+    private function estimateTokens(string $content): int
     {
-        $words = preg_split('/\s+/', trim($content));
-        $wordCount = count($words);
-        
-        return (int) ceil($wordCount * 1.33);
+        if (false === $words = \preg_split('/\s+/', \trim($content))) {
+            throw new \RuntimeException('Invalid content');
+        }
+
+        $wordCount = \count($words);
+
+        return (int) \ceil($wordCount * 1.33);
     }
 }

--- a/EMS/core-bundle/src/Command/ExtractAssetCommand.php
+++ b/EMS/core-bundle/src/Command/ExtractAssetCommand.php
@@ -10,76 +10,63 @@ use EMS\CoreBundle\Commands;
 use EMS\CoreBundle\Service\AssetExtractorService;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
-use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Finder\Finder;
-use Symfony\Component\Finder\SplFileInfo;
 
 #[AsCommand(
     name: Commands::ASSET_EXTRACT,
-    description: 'Will extract data from all files found and load it in cache of the asset extractor service.',
-    hidden: false,
-    aliases: ['ems:asset:extract']
+    description: "Extracts data from all found files and loads it into the asset extractor service's cache",
+    aliases: ['ems:asset:extract'],
+    hidden: false
 )]
 class ExtractAssetCommand extends AbstractCommand
 {
-    public function __construct(protected LoggerInterface $logger, protected AssetExtractorService $extractorService, protected StorageManager $storageManager)
-    {
+    private const string ARG_PATH = 'path';
+    private const string ARG_NAME = 'name';
+
+    public function __construct(
+        protected LoggerInterface $logger,
+        protected AssetExtractorService $extractorService,
+        protected StorageManager $storageManager
+    ) {
         parent::__construct();
     }
 
     #[\Override]
     protected function configure(): void
     {
-        $this->addArgument(
-            'path',
-            InputArgument::REQUIRED,
-            'Path to the files to extract data from'
-        )
-            ->addArgument(
-                'name',
-                InputArgument::OPTIONAL,
-                'File pattern or file name i.e. *.pdf',
-                '*.*'
-            );
+        $this
+            ->addArgument(self::ARG_PATH, InputArgument::REQUIRED, 'Path to the files to extract data from')
+            ->addArgument(self::ARG_NAME, InputArgument::OPTIONAL, 'File pattern or file name i.e. *.pdf', '*.*')
+        ;
     }
 
     #[\Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $name = $input->getArgument('name');
-        if (!\is_string($name)) {
-            throw new \RuntimeException('Unexpected name argument');
-        }
-        $path = $input->getArgument('path');
-        if (!\is_string($path)) {
-            throw new \RuntimeException('Unexpected path argument');
-        }
+        $path = $this->getArgumentString(self::ARG_PATH);
+        $name = $this->getArgumentString(self::ARG_NAME);
 
-        $finder = new Finder();
-        $fileIterator = $finder->in($path)->files()->name($name);
+        $files = new Finder()->in($path)->name($name);
 
-        $progress = new ProgressBar($output, $fileIterator->count());
+        $progress = $this->io->createProgressBar($files->count());
         $progress->start();
 
-        /** @var SplFileInfo $file */
-        foreach ($fileIterator as $file) {
-            $realPath = $file->getRealPath();
-            if (false === $realPath) {
+        foreach ($files as $file) {
+            if (false === $realPath = $file->getRealPath()) {
                 $progress->advance();
                 continue;
             }
 
             $hash = $this->storageManager->computeFileHash($realPath);
-            if (\is_string($file->getRealPath())) {
-                $this->extractorService->extractData($hash, $realPath);
-            }
+            $this->extractorService->extractMetaData($hash, $realPath);
+
             $progress->advance();
         }
         $progress->finish();
 
-        return 0;
+        return self::EXECUTE_SUCCESS;
     }
 }

--- a/EMS/core-bundle/src/Helper/AssetExtractor/ExtractedData.php
+++ b/EMS/core-bundle/src/Helper/AssetExtractor/ExtractedData.php
@@ -83,9 +83,14 @@ class ExtractedData
         return isset($this->source['content']);
     }
 
-    public function getContent(): string
+    public function getContent(bool $applyMaxContentSize = true): string
     {
         $content = (string) ($this->source['content'] ?? '');
+
+        if (!$applyMaxContentSize) {
+            return $content;
+        }
+
         $trimContent = Text::superTrim($content);
 
         return \mb_substr($trimContent, 0, $this->maxContentSize, 'UTF-8');

--- a/EMS/core-bundle/src/Service/AssetExtractorService.php
+++ b/EMS/core-bundle/src/Service/AssetExtractorService.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace EMS\CoreBundle\Service;
 
 use Doctrine\Bundle\DoctrineBundle\Registry;
-use EMS\CommonBundle\Common\Converter;
 use EMS\CommonBundle\Helper\EmsFields;
 use EMS\CommonBundle\Helper\MimeTypeHelper;
 use EMS\CommonBundle\Storage\NotFoundException;
@@ -14,6 +13,7 @@ use EMS\CoreBundle\Helper\AssetExtractor\ExtractedData;
 use EMS\CoreBundle\Tika\TikaWrapper;
 use EMS\Helpers\File\File;
 use EMS\Helpers\File\TempFile;
+use EMS\Helpers\Standard\Number;
 use EMS\Helpers\Standard\Type;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
@@ -122,7 +122,7 @@ class AssetExtractorService implements CacheWarmerInterface
         $filesize = $this->fileService->getSize($hash);
         if (!$forced && $filesize > (3 * 1024 * 1024)) {
             $this->logger->warning('log.warning.asset_extract.file_to_large', [
-                'filesize' => Converter::formatBytes($filesize),
+                'filesize' => Number::formatBytes($filesize),
                 'max_size' => '3 MB',
             ]);
 

--- a/EMS/core-bundle/src/Service/AssetExtractorService.php
+++ b/EMS/core-bundle/src/Service/AssetExtractorService.php
@@ -98,18 +98,25 @@ class AssetExtractorService implements CacheWarmerInterface
         return $this->extractMetaData($hash, $file, $forced)->getSource();
     }
 
-    public function extractMetaData(string $hash, ?string $file = null, bool $forced = false, ?string $filename = null): ExtractedData
+    public function findCachedExtractedData(string $hash): ?ExtractedData
     {
         $manager = $this->doctrine->getManager();
         $repository = $manager->getRepository(CacheAssetExtractor::class);
 
         /** @var ?CacheAssetExtractor $cacheData */
-        $cacheData = $repository->findOneBy([
-            'hash' => $hash,
-        ]);
+        $cacheData = $repository->findOneBy(['hash' => $hash]);
 
         if ($cacheData instanceof CacheAssetExtractor) {
             return new ExtractedData($cacheData->getData() ?? [], $this->tikaMaxContent);
+        }
+
+        return null;
+    }
+
+    public function extractMetaData(string $hash, ?string $file = null, bool $forced = false, ?string $filename = null): ExtractedData
+    {
+        if (null !== $extractedData = $this->findCachedExtractedData($hash)) {
+            return $extractedData;
         }
 
         $filesize = $this->fileService->getSize($hash);
@@ -188,6 +195,8 @@ class AssetExtractorService implements CacheWarmerInterface
             $cacheData = new CacheAssetExtractor();
             $cacheData->setHash($hash);
             $cacheData->setData($out->getSource());
+
+            $manager = $this->doctrine->getManager();
             $manager->persist($cacheData);
             $manager->flush();
         }

--- a/EMS/helpers/src/Standard/Number.php
+++ b/EMS/helpers/src/Standard/Number.php
@@ -6,6 +6,13 @@ namespace EMS\Helpers\Standard;
 
 class Number
 {
+    public static function format(float|int $number): string
+    {
+        $decimals = \is_int($number) ? 0 : 2;
+
+        return \number_format($number, $decimals, ',', '.');
+    }
+
     public static function formatBytes(int $bytes, int $precision = 2): string
     {
         $units = ['B', 'KB', 'MB', 'GB', 'TB'];

--- a/EMS/helpers/src/Standard/Number.php
+++ b/EMS/helpers/src/Standard/Number.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\Helpers\Standard;
+
+class Number
+{
+    public static function formatBytes(int $bytes, int $precision = 2): string
+    {
+        $units = ['B', 'KB', 'MB', 'GB', 'TB'];
+        $bytes = \max($bytes, 0);
+
+        $pow = \floor(($bytes ? \log($bytes) : 0) / \log(1024));
+        $pow = \min($pow, \count($units) - 1);
+
+        $bytes /= 1024 ** $pow;
+
+        return \round($bytes, $precision).' '.$units[$pow];
+    }
+}

--- a/EMS/helpers/tests/Unit/Standard/NumberTest.php
+++ b/EMS/helpers/tests/Unit/Standard/NumberTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\Helpers\Tests\Unit\Standard;
+
+use EMS\Helpers\Standard\Number;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class NumberTest extends TestCase
+{
+    /**
+     * @return array<array<int|string>>
+     */
+    public static function byteProvider(): array
+    {
+        return [
+            [243, '243 B', '243 B', '243 B'],
+            [2496, '2.44 KB', '2 KB', '2.4375 KB'],
+            [24_962_496, '23.81 MB', '24 MB', '23.8061 MB'],
+            [249_624_962_496, '232.48 GB', '232 GB', '232.4814 GB'],
+            [2_496_249_624_962_496, '2270.33 TB', '2270 TB', '2270.3258 TB'],
+        ];
+    }
+
+    #[DataProvider('byteProvider')]
+    public function testBytes(int $byte, string $expected, string $expected2, string $expected3): void
+    {
+        self::assertSame($expected, Number::formatBytes($byte));
+        self::assertSame($expected2, Number::formatBytes($byte, 0));
+        self::assertSame($expected3, Number::formatBytes($byte, 4));
+    }
+}

--- a/EMS/helpers/tests/Unit/Standard/NumberTest.php
+++ b/EMS/helpers/tests/Unit/Standard/NumberTest.php
@@ -24,8 +24,15 @@ class NumberTest extends TestCase
         ];
     }
 
+    public function testFormat(): void
+    {
+        self::assertSame('77', Number::format(77));
+        self::assertSame('568,60', Number::format(568.5987));
+        self::assertSame('1.698.568,99', Number::format(1698568.99));
+    }
+
     #[DataProvider('byteProvider')]
-    public function testBytes(int $byte, string $expected, string $expected2, string $expected3): void
+    public function testFormatBytes(int $byte, string $expected, string $expected2, string $expected3): void
     {
         self::assertSame($expected, Number::formatBytes($byte));
         self::assertSame($expected2, Number::formatBytes($byte, 0));

--- a/build/translations
+++ b/build/translations
@@ -6,7 +6,7 @@ declare(strict_types=1);
 require __DIR__.'/../vendor/autoload.php';
 
 use App\Admin\Kernel;
-use EMS\CommonBundle\Common\Converter;
+use EMS\Helpers\Standard\Number;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputArgument;
@@ -213,7 +213,7 @@ $command = static function (InputInterface $input, OutputInterface $output): int
     $io->newLine();
     $io->listing([
         \sprintf('Duration: %d s', $buildStopWatch->getDuration() / 1000),
-        \sprintf('Memory: %s', Converter::formatBytes($buildStopWatch->getMemory())),
+        \sprintf('Memory: %s', Number::formatBytes($buildStopWatch->getMemory())),
     ]);
 
     return Command::SUCCESS;

--- a/config/phpstan-baseline.neon
+++ b/config/phpstan-baseline.neon
@@ -13,12 +13,6 @@ parameters:
 			message: '#^Call to deprecated method extractData\(\) of class EMS\\CoreBundle\\Service\\AssetExtractorService\.$#'
 			identifier: method.deprecated
 			count: 1
-			path: ../EMS/core-bundle/src/Command/ExtractAssetCommand.php
-
-		-
-			message: '#^Call to deprecated method extractData\(\) of class EMS\\CoreBundle\\Service\\AssetExtractorService\.$#'
-			identifier: method.deprecated
-			count: 1
 			path: ../EMS/core-bundle/src/Command/IndexFileCommand.php
 
 		-


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  n |
| New feature?   | y  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

We can now call the `emsco:asset:extract` command wit a new option `--report`. 
This will generate a table showing: Size, Length, Words, Tokens per document.

Refactor: introduced a new Number helper for formatting. Moved formatBytes from common to Helper.
