### PR TITLE
fix(admin/revision): detail current version is closed

### DIFF
--- a/EMS/core-bundle/src/Controller/Revision/DetailController.php
+++ b/EMS/core-bundle/src/Controller/Revision/DetailController.php
@@ -57,12 +57,12 @@ class DetailController extends AbstractController
         $revision = $this->revisionService->findByIdOrOuuid($contentType, $revisionId, $ouuid);
 
         if (null === $revision && $contentType->getVersioning()->enabled() && Uuid::isValid($ouuid)) {
-            // using version ouuid as ouuid should redirect to latest
-            $searchLatestVersion = $this->revisionRepository->findLatestVersion($contentType, $ouuid);
-            if ($searchLatestVersion && $searchLatestVersion->getOuuid() !== $ouuid) {
+            $document = $this->searchService->getDocument($contentType, $ouuid);
+
+            if ($document->getOuuid() !== $ouuid) {
                 return $this->redirectToRoute('emsco_view_revisions', [
                     'type' => $contentType->getName(),
-                    'ouuid' => $searchLatestVersion->getOuuid(),
+                    'ouuid' => $document->getOuuid(),
                 ]);
             }
         }


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

When the current version of a revision is closed, we should still just see the detail page.
The twig filter |data_link was already using the method.
