### PR TITLE
fix: user_group table can't be dropped before group_id

### DIFF
--- a/EMS/core-bundle/migrations/pdo_pgsql/Version20250220092804.php
+++ b/EMS/core-bundle/migrations/pdo_pgsql/Version20250220092804.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Application\Migrations;
 
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 final class Version20250220092804 extends AbstractMigration
@@ -15,6 +16,11 @@ final class Version20250220092804 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\PostgreSQLPlatform'."
+        );
+
         $this->addSql('CREATE TABLE user_group (name VARCHAR(255) NOT NULL, label VARCHAR(255) NOT NULL, roles JSON NOT NULL, created TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, modified TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, id UUID NOT NULL, PRIMARY KEY(id))');
         $this->addSql('CREATE UNIQUE INDEX UNIQ_8F02BF9D5E237E06 ON user_group (name)');
         $this->addSql('ALTER TABLE "user" ADD group_id UUID DEFAULT NULL');
@@ -24,9 +30,13 @@ final class Version20250220092804 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        $this->addSql('DROP TABLE user_group');
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\PostgreSQLPlatform'."
+        );
+
         $this->addSql('ALTER TABLE "user" DROP CONSTRAINT FK_8D93D649FE54D947');
-        $this->addSql('DROP INDEX IDX_8D93D649FE54D947');
         $this->addSql('ALTER TABLE "user" DROP group_id');
+        $this->addSql('DROP TABLE user_group');
     }
 }


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? |  n |
| Documentation? | n  |

