### PR TITLE
fix(admin/doctrine): invalid entity mapping for new EnvironmentRevision

### DIFF
--- a/EMS/core-bundle/config/doctrine/EnvironmentRevision.orm.xml
+++ b/EMS/core-bundle/config/doctrine/EnvironmentRevision.orm.xml
@@ -9,11 +9,11 @@
             <custom-id-generator class="Ramsey\Uuid\Doctrine\UuidGenerator"/>
         </id>
 
-        <many-to-one field="revision" target-entity="EMS\CoreBundle\Entity\Revision">
+        <many-to-one field="revision" target-entity="EMS\CoreBundle\Entity\Revision" inversed-by="environmentRevisions">
             <join-column name="revision_id" nullable="false"/>
         </many-to-one>
 
-        <many-to-one field="environment" target-entity="EMS\CoreBundle\Entity\Environment">
+        <many-to-one field="environment" target-entity="EMS\CoreBundle\Entity\Environment" inversed-by="environmentRevisions">
             <join-column name="environment_id" nullable="false"/>
         </many-to-one>
 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  |  n |
| Fixed tickets? | n  |
| Documentation? | n  |

The 'inversed-by' were missing leading to the following errors:

The field EMS\CoreBundle\Entity\Environment#environmentRevisions is on the inverse side of a bi-directional relationship, but the specified mappedBy association on the target-entity EMS\CoreBundle\Entity\EnvironmentRevision#environment does not contain the required 'inversedBy="environmentRevisions"' attribute.

The field EMS\CoreBundle\Entity\Revision#environmentRevisions is on the inverse side of a bi-directional relationship, but the specified mappedBy association on the target-entity EMS\CoreBundle\Entity\EnvironmentRevision#revision does not contain the required 'inversedBy="environmentRevisions"' attribute.
