### PR TITLE
fix(admin/environment): restore revision from trash (EnvironmentRevision)

### DIFF
--- a/EMS/common-bundle/src/Command/Admin/RestoreCommand.php
+++ b/EMS/common-bundle/src/Command/Admin/RestoreCommand.php
@@ -170,8 +170,9 @@ class RestoreCommand extends AbstractCommand
         $rows = [];
         $this->io->progressStart(\count($contentTypes));
         foreach ($contentTypes as $contentType) {
-            if (\in_array($contentType, $this->excludedContentTypes)) {
+            if (\in_array($contentType, $this->excludedContentTypes, true)) {
                 $this->io->note(\sprintf('Content type "%s" has been ignored as excluded (see EMS_EXCLUDED_CONTENT_TYPES)', $contentType));
+                $this->io->progressAdvance();
                 continue;
             }
             $rows[] = $this->restoreDocument($contentType);

--- a/EMS/common-bundle/src/Entity/EntityInterface.php
+++ b/EMS/common-bundle/src/Entity/EntityInterface.php
@@ -6,8 +6,5 @@ namespace EMS\CommonBundle\Entity;
 
 interface EntityInterface
 {
-    /**
-     * @return int|string
-     */
-    public function getId();
+    public function getId(): int|string;
 }

--- a/EMS/core-bundle/src/Core/Action/ActionRevisionConfig.php
+++ b/EMS/core-bundle/src/Core/Action/ActionRevisionConfig.php
@@ -46,12 +46,10 @@ class ActionRevisionConfig
 
     private static function getConfigResolver(FieldTypeTreeItem $fieldTree): OptionsResolver
     {
-        $fieldNormalizer = function (Options $options, array $value) use ($fieldTree) {
-            return \array_filter(\array_map(
-                callback: static fn (string $name) => $fieldTree->findByName($name)?->getFieldType(),
-                array: $value
-            ));
-        };
+        $fieldNormalizer = (fn (Options $options, array $value) => \array_filter(\array_map(
+            callback: static fn (string $name) => $fieldTree->findByName($name)?->getFieldType(),
+            array: $value
+        )));
 
         $optionResolver = new OptionsResolver();
         $optionResolver

--- a/EMS/core-bundle/src/Entity/EnvironmentRevision.php
+++ b/EMS/core-bundle/src/Entity/EnvironmentRevision.php
@@ -10,7 +10,7 @@ use Ramsey\Uuid\UuidInterface;
 
 class EnvironmentRevision implements EntityInterface
 {
-    private readonly UuidInterface $id;
+    private UuidInterface $id;
     private Environment $environment;
     private Revision $revision;
     private \DateTime $created;

--- a/EMS/core-bundle/src/Entity/Revision.php
+++ b/EMS/core-bundle/src/Entity/Revision.php
@@ -529,8 +529,9 @@ class Revision implements EntityInterface, \Stringable
     public function addEnvironment(Environment $environment, string $username): self
     {
         if (\array_any(
-            $this->environmentRevisions->toArray(), 
-            static fn (EnvironmentRevision $er) => $er->getEnvironment() === $environment && null === $er->getDeleted())
+            $this->environmentRevisions->toArray(),
+            static fn (EnvironmentRevision $er) => $er->getEnvironment() === $environment && null === $er->getDeleted()
+        )
         ) {
             return $this;
         }

--- a/EMS/core-bundle/src/Entity/Revision.php
+++ b/EMS/core-bundle/src/Entity/Revision.php
@@ -528,10 +528,11 @@ class Revision implements EntityInterface, \Stringable
 
     public function addEnvironment(Environment $environment, string $username): self
     {
-        foreach ($this->environmentRevisions as $environmentRevision) {
-            if ($environmentRevision->getEnvironment() === $environment) {
-                return $this;
-            }
+        if (\array_any(
+            $this->environmentRevisions->toArray(), 
+            static fn (EnvironmentRevision $er) => $er->getEnvironment() === $environment && null === $er->getDeleted())
+        ) {
+            return $this;
         }
         $environmentRevision = new EnvironmentRevision();
         $environmentRevision->setEnvironment($environment);
@@ -551,7 +552,7 @@ class Revision implements EntityInterface, \Stringable
 
     public function removeEnvironment(Environment $environment, string $username): self
     {
-        foreach ($this->environmentRevisions as $key => $environmentRevision) {
+        foreach ($this->environmentRevisions as $environmentRevision) {
             if ($environmentRevision->getEnvironment() === $environment) {
                 $environmentRevision->setDeleted(new \DateTime());
                 $environmentRevision->setDeletedBy($username);

--- a/EMS/core-bundle/src/Form/DataField/ActionFieldType.php
+++ b/EMS/core-bundle/src/Form/DataField/ActionFieldType.php
@@ -54,6 +54,7 @@ class ActionFieldType extends DataFieldType
         $view->vars['revisionId'] = $revision->getId();
     }
 
+    #[\Override]
     public function getDefaultOptions(string $name): array
     {
         $defaultOptions = parent::getDefaultOptions($name);

--- a/config/rector.php
+++ b/config/rector.php
@@ -50,6 +50,6 @@ return RectorConfig::configure()
         ReadOnlyPropertyRector::class => [
             __DIR__ . '/../EMS/core-bundle/src/Entity',
             __DIR__ . '/../EMS/common-bundle/src/Entity',
-            __DIR__ . '/../EMS/submission-bundle-bundle/src/Entity',
+            __DIR__ . '/../EMS/submission-bundle/src/Entity',
         ],
     ]);

--- a/config/rector.php
+++ b/config/rector.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
 use Rector\Config\RectorConfig;
+use Rector\Doctrine\Set\DoctrineSetList;
+use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
 use Rector\Symfony\Set\SymfonySetList;
 
 return RectorConfig::configure()
@@ -44,4 +46,10 @@ return RectorConfig::configure()
         SymfonySetList::SYMFONY_CODE_QUALITY,
         SymfonySetList::SYMFONY_CONSTRUCTOR_INJECTION,
     ])
-;
+    ->withSkip([
+        ReadOnlyPropertyRector::class => [
+            __DIR__ . '/../EMS/core-bundle/src/Entity',
+            __DIR__ . '/../EMS/common-bundle/src/Entity',
+            __DIR__ . '/../EMS/submission-bundle-bundle/src/Entity',
+        ],
+    ]);


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  |  n |
| Fixed tickets? | n  |
| Documentation? | n  |

- Because the environmentRevision entry already existed as deleted.

- And the $id property on the entity should not be readonly, fixes:
Attempting to change readonly property EMS\CoreBundle\Entity\EnvironmentRevision::$id.
