### PR TITLE
fix(admin/revision): cascade delete environments

### DIFF
--- a/EMS/core-bundle/config/doctrine/EnvironmentRevision.orm.xml
+++ b/EMS/core-bundle/config/doctrine/EnvironmentRevision.orm.xml
@@ -10,7 +10,7 @@
         </id>
 
         <many-to-one field="revision" target-entity="EMS\CoreBundle\Entity\Revision" inversed-by="environmentRevisions">
-            <join-column name="revision_id" nullable="false"/>
+            <join-column name="revision_id" nullable="false" on-delete="CASCADE" />
         </many-to-one>
 
         <many-to-one field="environment" target-entity="EMS\CoreBundle\Entity\Environment" inversed-by="environmentRevisions">

--- a/EMS/core-bundle/migrations/pdo_mysql/Version20250509111207.php
+++ b/EMS/core-bundle/migrations/pdo_mysql/Version20250509111207.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Platforms\MariaDBPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250509111207 extends AbstractMigration
+{
+    #[\Override]
+    public function getDescription(): string
+    {
+        return 'Fix environment revision cascade delete, when deleting revision';
+    }
+
+    #[\Override]
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof MySQLPlatform
+            && !$this->connection->getDatabasePlatform() instanceof MariaDBPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MySQLPlatform'."
+        );
+        
+        $this->addSql(<<<'SQL'
+            ALTER TABLE environment_revision DROP FOREIGN KEY FK_895F7B701DFA7C8F
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE environment_revision ADD CONSTRAINT FK_895F7B701DFA7C8F FOREIGN KEY (revision_id) REFERENCES revision (id) ON DELETE CASCADE
+        SQL);
+    }
+
+    #[\Override]
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof MySQLPlatform
+            && !$this->connection->getDatabasePlatform() instanceof MariaDBPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MySQLPlatform'."
+        );
+        
+        $this->addSql(<<<'SQL'
+            ALTER TABLE environment_revision DROP FOREIGN KEY FK_895F7B701DFA7C8F
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE environment_revision ADD CONSTRAINT FK_895F7B701DFA7C8F FOREIGN KEY (revision_id) REFERENCES revision (id)
+        SQL);
+    }
+}

--- a/EMS/core-bundle/migrations/pdo_pgsql/Version20250509110741.php
+++ b/EMS/core-bundle/migrations/pdo_pgsql/Version20250509110741.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250509110741 extends AbstractMigration
+{
+    #[\Override]
+    public function getDescription(): string
+    {
+        return 'Fix environment revision cascade delete, when deleting revision';
+    }
+
+    #[\Override]
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\PostgreSQLPlatform'."
+        );
+        
+        $this->addSql(<<<'SQL'
+            ALTER TABLE environment_revision DROP CONSTRAINT FK_895F7B701DFA7C8F
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE environment_revision ADD CONSTRAINT FK_895F7B701DFA7C8F FOREIGN KEY (revision_id) REFERENCES revision (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE
+        SQL);
+    }
+
+    #[\Override]
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\PostgreSQLPlatform'."
+        );
+        
+        $this->addSql(<<<'SQL'
+            ALTER TABLE environment_revision DROP CONSTRAINT fk_895f7b701dfa7c8f
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE environment_revision ADD CONSTRAINT fk_895f7b701dfa7c8f FOREIGN KEY (revision_id) REFERENCES revision (id) NOT DEFERRABLE INITIALLY IMMEDIATE
+        SQL);
+    }
+}


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

On delete revision, by for example emsco:revision:delete, we are not cascade deleting the revision environments.
