### PR TITLE
fix(admin/contentType): invalid mapping for multiplex with locales variable

### DIFF
--- a/EMS/core-bundle/src/Entity/Group.php
+++ b/EMS/core-bundle/src/Entity/Group.php
@@ -10,7 +10,7 @@ use EMS\CoreBundle\Entity\Helper\JsonDeserializer;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
 
-class Group extends JsonDeserializer implements EntityInterface, \JsonSerializable
+class Group extends JsonDeserializer implements EntityInterface, \JsonSerializable, \Stringable
 {
     use CreatedModifiedTrait;
 

--- a/EMS/core-bundle/src/Form/DataField/MultiplexedTabContainerFieldType.php
+++ b/EMS/core-bundle/src/Form/DataField/MultiplexedTabContainerFieldType.php
@@ -11,6 +11,7 @@ use EMS\CoreBundle\Form\DataTransformer\DataFieldModelTransformer;
 use EMS\CoreBundle\Form\DataTransformer\DataFieldViewTransformer;
 use EMS\CoreBundle\Form\Field\IconPickerType;
 use EMS\CoreBundle\Service\ElasticsearchService;
+use EMS\Helpers\Standard\Json;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -103,16 +104,26 @@ final class MultiplexedTabContainerFieldType extends DataFieldType
         $resolver->setDefault(self::ICON_DISPLAY_OPTION, null);
     }
 
+    /** @return string[] */
+    private static function getLocaleValues(FieldType $fieldType): array
+    {
+        if ($fieldType->getDisplayOption(self::WITH_LOCALES_VARIABLE_DISPLAY_OPTION, false)) {
+            return Json::decode($_ENV['EMSCH_LOCALES'] ?? []);
+        }
+
+        if ($values = $fieldType->getDisplayOption(self::VALUES_DISPLAY_OPTION)) {
+            return self::textAreaToArray($values);
+        }
+
+        return [];
+    }
+
     #[\Override]
     public function generateMapping(FieldType $current): array
     {
-        $values = $current->getDisplayOption(self::VALUES_DISPLAY_OPTION);
-        if (null === $values) {
-            return [];
-        }
-
-        $values = self::textAreaToArray($values);
         $mapping = [];
+        $values = self::getLocaleValues($current);
+
         foreach ($values as $value) {
             $mapping[$value] = ['properties' => []];
         }
@@ -123,12 +134,7 @@ final class MultiplexedTabContainerFieldType extends DataFieldType
     #[\Override]
     public static function getJsonNames(FieldType $current): array
     {
-        $values = $current->getDisplayOption(self::VALUES_DISPLAY_OPTION);
-        if (null === $values) {
-            return [];
-        }
-
-        return self::textAreaToArray($values);
+        return self::getLocaleValues($current);
     }
 
     #[\Override]


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? |  n |
| Documentation? | n  |

Multiplex with the option 'withLocalesVariable' was not creating the correct mapping.
Not the best solution because we need to acces $_ENV because of the static method.
Removing the static cause a lot of code refactoring in the RawDataTransformer.
