### PR TITLE
feat(cli/import): support exclude expression

### DIFF
--- a/EMS/common-bundle/src/Service/ExpressionService.php
+++ b/EMS/common-bundle/src/Service/ExpressionService.php
@@ -90,6 +90,16 @@ final class ExpressionService implements ExpressionServiceInterface
                 return \substr($str, $offset, $length);
             }
         );
+        $expressionLanguage->register(
+            'trim',
+            fn ($value) => \sprintf('(trim(%1$s))', $value),
+            fn ($arguments, $value) => \trim($value)
+        );
+        $expressionLanguage->register(
+            'empty',
+            fn ($value) => \sprintf('(empty(%1$s))', $value),
+            fn ($arguments, $value) => null === $value || '' === $value || [] === $value
+        );
 
         return $expressionLanguage;
     }

--- a/docs/elasticms-cli/commands.md
+++ b/docs/elasticms-cli/commands.md
@@ -132,6 +132,9 @@ php bin/console emscli:file-reader:import pages.csv page \
   * Define the input file encoding
 * `exclude_rows`: int[] (default=[])
   * Pass an array of row positions to exclude (0 is first row, -1 is last row)
+* `exclude_expression`: ?string (default=null)
+  * Exclude rows based on and expression (context row array and string ouuid)
+  * example skip rows where the ID column is empty: `row["ID"] == """`
 * `generate_hash`: bool (default=false)
   * Use the OUUID column and the content type name in order to generate a "better" ouuid
 * `ouuid_expression`: ?string (default="row['ouuid']")

--- a/docs/elasticms-cli/commands.md
+++ b/docs/elasticms-cli/commands.md
@@ -134,7 +134,7 @@ php bin/console emscli:file-reader:import pages.csv page \
   * Pass an array of row positions to exclude (0 is first row, -1 is last row)
 * `exclude_expression`: ?string (default=null)
   * Exclude rows based on and expression (context row array and string ouuid)
-  * example skip rows where the ID column is empty: `row["ID"] == """`
+  * example skip rows where the ID column is empty: `empty(trim(row[\"ID\"]))`
 * `generate_hash`: bool (default=false)
   * Use the OUUID column and the content type name in order to generate a "better" ouuid
 * `ouuid_expression`: ?string (default="row['ouuid']")

--- a/elasticms-cli/src/Client/File/ImportConfig.php
+++ b/elasticms-cli/src/Client/File/ImportConfig.php
@@ -18,6 +18,7 @@ class ImportConfig
         public ?string $delimiter = null,
         public ?string $encoding = null,
         public array $excludeRows = [],
+        public ?string $excludeExpression = null,
         public bool $generateHash = false,
         public bool $generateOuuid = false,
         public ?string $ouuidExpression = "row['ouuid']",
@@ -39,6 +40,7 @@ class ImportConfig
                 'delimiter' => null,
                 'encoding' => null,
                 'exclude_rows' => [],
+                'exclude_expression' => null,
                 'generate_hash' => false,
                 'generate_ouuid' => false,
                 'ouuid_expression' => 'row[\'ouuid\']',
@@ -48,6 +50,7 @@ class ImportConfig
             ->setAllowedTypes('delete_missing_documents', 'bool')
             ->setAllowedTypes('generate_hash', 'bool')
             ->setAllowedTypes('generate_ouuid', 'bool')
+            ->setAllowedTypes('exclude_expression', ['string', 'null'])
             ->setAllowedTypes('ouuid_expression', ['string', 'null'])
             ->setAllowedTypes('ouuid_version_expression', ['string', 'null'])
             ->setAllowedTypes('ouuid_prefix', ['string', 'null'])
@@ -61,6 +64,7 @@ class ImportConfig
             delimiter: $options['delimiter'],
             encoding: $options['encoding'],
             excludeRows: $options['exclude_rows'],
+            excludeExpression: $options['exclude_expression'],
             generateHash: $options['generate_hash'],
             generateOuuid: $options['generate_ouuid'],
             ouuidExpression: $options['ouuid_expression'],

--- a/elasticms-cli/src/Command/Import/AbstractImportCommand.php
+++ b/elasticms-cli/src/Command/Import/AbstractImportCommand.php
@@ -50,6 +50,7 @@ abstract class AbstractImportCommand extends AbstractCommand
 
     private int $countIndex = 0;
     private int $countDigest = 0;
+    private int $countExclude = 0;
 
     public function __construct(
         private readonly AdminHelper $adminHelper,
@@ -112,6 +113,7 @@ abstract class AbstractImportCommand extends AbstractCommand
 
             foreach ($docs as $ouuid => $rawData) {
                 if ($this->excludeExpression($config, $ouuid, $rawData)) {
+                    ++$this->countExclude;
                     continue;
                 }
 
@@ -144,6 +146,7 @@ abstract class AbstractImportCommand extends AbstractCommand
         $this->io->definitionList(
             'Summary',
             ['Index' => $this->countIndex],
+            ['Excluded' => $this->countExclude],
             ['Digested' => $this->countDigest],
             ['Delete' => \count($ouuids)]
         );

--- a/elasticms-cli/src/Command/Import/AbstractImportCommand.php
+++ b/elasticms-cli/src/Command/Import/AbstractImportCommand.php
@@ -12,6 +12,7 @@ use Elastica\Query\Terms;
 use EMS\CommonBundle\Common\Admin\AdminHelper;
 use EMS\CommonBundle\Common\Command\AbstractCommand;
 use EMS\CommonBundle\Contracts\CoreApi\Endpoint\Data\DataInterface;
+use EMS\CommonBundle\Contracts\ExpressionServiceInterface;
 use EMS\CommonBundle\Search\Search;
 use EMS\CommonBundle\Storage\File\FileInterface;
 use EMS\CommonBundle\Storage\NotFoundException;
@@ -23,7 +24,6 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
 abstract class AbstractImportCommand extends AbstractCommand
 {
@@ -48,14 +48,13 @@ abstract class AbstractImportCommand extends AbstractCommand
     private int $scrollSize;
     private int $chunkSize;
 
-    private ExpressionLanguage $expressionLanguage;
-
     private int $countIndex = 0;
     private int $countDigest = 0;
 
     public function __construct(
         private readonly AdminHelper $adminHelper,
         private readonly StorageManager $storageManager,
+        private readonly ExpressionServiceInterface $expressionService,
     ) {
         parent::__construct();
     }
@@ -89,8 +88,6 @@ abstract class AbstractImportCommand extends AbstractCommand
         $this->flushSize = $this->getOptionInt(self::OPTION_FLUSH_SIZE);
         $this->chunkSize = $this->getOptionInt(self::OPTION_CHUNK_SIZE);
         $this->scrollSize = $this->getOptionInt(self::OPTION_SCROLL_SIZE);
-
-        $this->expressionLanguage = new ExpressionLanguage();
     }
 
     public function import(ImportConfig $config, \Generator $records): void
@@ -114,6 +111,10 @@ abstract class AbstractImportCommand extends AbstractCommand
             $docs = $this->filterDigested($docs);
 
             foreach ($docs as $ouuid => $rawData) {
+                if ($this->excludeExpression($config, $ouuid, $rawData)) {
+                    continue;
+                }
+
                 if (!$this->dryRun) {
                     $queue->add($contentTypeApi->indexAsync(
                         ouuid: $ouuid,
@@ -182,9 +183,12 @@ abstract class AbstractImportCommand extends AbstractCommand
             $rawData['_sync_metadata'] = $row;
 
             if (null !== $ouuidVersionExpression = $config->ouuidVersionExpression) {
-                $rawData['_version_uuid'] = UuidGenerator::fromValue(
-                    value: $this->expressionLanguage->evaluate($ouuidVersionExpression, ['row' => $row])
-                );
+                $ouuidVersionValue = $this->expressionService->evaluateToString($ouuidVersionExpression, ['row' => $row]);
+                if (null === $ouuidVersionValue) {
+                    throw new \RuntimeException(\sprintf('Could not make version ouuid from expression: %s', $ouuidVersionExpression));
+                }
+
+                $rawData['_version_uuid'] = UuidGenerator::fromValue($ouuidVersionValue);
             }
 
             if (null !== $this->digestField) {
@@ -214,7 +218,7 @@ abstract class AbstractImportCommand extends AbstractCommand
             return null;
         }
 
-        $ouuid = $this->expressionLanguage->evaluate($config->ouuidExpression, ['row' => $row]);
+        $ouuid = $this->expressionService->evaluateToString($config->ouuidExpression, ['row' => $row]);
         $prefix = $config->ouuidPrefix;
 
         return (string) match (true) {
@@ -223,6 +227,21 @@ abstract class AbstractImportCommand extends AbstractCommand
             $config->generateHash => Hash::string(\sprintf('FileReaderImport:%s:%s', $this->contentType, $ouuid)),
             default => $ouuid,
         };
+    }
+
+    /**
+     * @param array<string, string> $rawData
+     */
+    private function excludeExpression(ImportConfig $config, string $ouuid, array $rawData): bool
+    {
+        if (null === $expression = $config->excludeExpression) {
+            return false;
+        }
+
+        return $this->expressionService->evaluateToBool($expression, [
+            'ouuid' => $ouuid,
+            'row' => $rawData['_sync_metadata'],
+        ]);
     }
 
     /**

--- a/elasticms-cli/src/Command/Import/DatabaseImportCommand.php
+++ b/elasticms-cli/src/Command/Import/DatabaseImportCommand.php
@@ -7,6 +7,7 @@ namespace App\CLI\Command\Import;
 use App\CLI\Commands;
 use Doctrine\DBAL\Connection;
 use EMS\CommonBundle\Common\Admin\AdminHelper;
+use EMS\CommonBundle\Contracts\ExpressionServiceInterface;
 use EMS\CommonBundle\Storage\StorageManager;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
@@ -27,9 +28,10 @@ final class DatabaseImportCommand extends AbstractImportCommand
     public function __construct(
         private readonly Connection $connection,
         AdminHelper $adminHelper,
-        StorageManager $storageManager
+        StorageManager $storageManager,
+        ExpressionServiceInterface $expressionService,
     ) {
-        parent::__construct($adminHelper, $storageManager);
+        parent::__construct($adminHelper, $storageManager, $expressionService);
     }
 
     #[\Override]

--- a/elasticms-cli/src/Command/Import/FileImportCommand.php
+++ b/elasticms-cli/src/Command/Import/FileImportCommand.php
@@ -6,6 +6,7 @@ namespace App\CLI\Command\Import;
 
 use App\CLI\Commands;
 use EMS\CommonBundle\Common\Admin\AdminHelper;
+use EMS\CommonBundle\Contracts\ExpressionServiceInterface;
 use EMS\CommonBundle\Contracts\File\FileReaderInterface;
 use EMS\CommonBundle\Helper\MimeTypeHelper;
 use EMS\CommonBundle\Storage\StorageManager;
@@ -33,8 +34,9 @@ final class FileImportCommand extends AbstractImportCommand
         private readonly FileReaderInterface $fileReader,
         AdminHelper $adminHelper,
         StorageManager $storageManager,
+        ExpressionServiceInterface $expressionService,
     ) {
-        parent::__construct($adminHelper, $storageManager);
+        parent::__construct($adminHelper, $storageManager, $expressionService);
     }
 
     #[\Override]


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | n  |
| New feature?   | y  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | y  |

For this pr we are now using the ExpressionService in the file and database cli import commands.
Because this service has a they perfect method `evaluateToBool`

If the new method `excludeExpression` return true, the row will not be imported.
If now exclude expression is defined this function returns false, otherwise it return the result of the passed expression.

Added to new expression function `empty` and `trim`. Because sending the job from an actions causes "" to be not correctly escaped. Symfony arg tokenizer is remove the empty string. But it's better to use custom functions.

In the `empty` function we do not use the php empty, because this can not be used inside a closure on an argument value. 
