### PR TITLE
fix(common/core-api): json decode on forward stream for form file

### DIFF
--- a/EMS/common-bundle/src/Common/CoreApi/Client.php
+++ b/EMS/common-bundle/src/Common/CoreApi/Client.php
@@ -114,8 +114,7 @@ class Client
      */
     public function forwardResponse(string $resource, array $query = []): StreamedResponse
     {
-        $request = $this->get($resource, $query);
-        $response = $request->response;
+        $response = $this->getResponse($resource, $query);
         if (!$response instanceof StreamableInterface) {
             throw new \RuntimeException('no stream response');
         }
@@ -126,9 +125,9 @@ class Client
                 \flush();
             }
             \fclose($stream);
-        }, $request->response->getStatusCode());
+        }, $response->getStatusCode());
 
-        $headers = $request->response->getHeaders();
+        $headers = $response->getHeaders();
 
         $streamResponse->headers->set('Content-Type', $headers['content-type']);
         $streamResponse->headers->set('Content-Disposition', $headers['content-disposition']);


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

In the demo we have a protected emsch route:

```yaml
emsch_api_form_attachment:
    config:
        path: '/form/{submissionId}/attachment/{submissionFileId}'
        defaults: { apiName: backend, _authenticated: true }
        controller: 'emsch.controller.api::getSubmissionFile'
        requirements: { submissionId: '.*', submissionFileId: '.*' }
```

This route will use the coreApi for asking for the submission file. The core API is returning a stream response but we are json decoding it by using 'get' which returns a result object. 

Fixed by using 'getResponse' which returns the response object, but not json decoding it.
