### PR TITLE
fix(admin/mercure): change default dev env MERCURE_URL

### DIFF
--- a/elasticms-admin/.env.dist
+++ b/elasticms-admin/.env.dist
@@ -15,7 +15,7 @@ MESSENGER_TRANSPORT_DSN=redis://localhost:6379/messages
 ###< symfony/messenger ###
 
 ###> symfony/mercure-bundle ###
-MERCURE_URL=http://mercure.localhost/.well-known/mercure
+MERCURE_URL=http://localhost:3000/.well-known/mercure
 MERCURE_PUBLIC_URL=http://mercure.localhost/.well-known/mercure
 MERCURE_JWT_KEY=3MVVIRhoV7MMfXjeLMUUeeV1Bi2xP4N5vQLNcImaj2s
 ###< symfony/mercure-bundle ###


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | n  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? |  n |

Update the default dev URL. The private mercure url is just localhost:3000
