### PR TITLE
feat(twig): add global emschLocales variable

### DIFF
--- a/EMS/client-helper-bundle/src/DependencyInjection/EMSClientHelperExtension.php
+++ b/EMS/client-helper-bundle/src/DependencyInjection/EMSClientHelperExtension.php
@@ -11,11 +11,12 @@ use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
-final class EMSClientHelperExtension extends Extension
+final class EMSClientHelperExtension extends Extension implements PrependExtensionInterface
 {
     #[\Override]
     public function load(array $configs, ContainerBuilder $container): void
@@ -59,6 +60,24 @@ final class EMSClientHelperExtension extends Extension
         }
 
         $loader->load('api.xml');
+    }
+
+    #[\Override]
+    public function prepend(ContainerBuilder $container): void
+    {
+        $bundles = $container->getParameter('kernel.bundles');
+
+        if (\is_array($bundles) && !isset($bundles['TwigBundle'])) {
+            return;
+        }
+
+        $config = $container->getExtensionConfig($this->getAlias())[0] ?? [];
+
+        $container->prependExtensionConfig('twig', [
+            'globals' => [
+                'emschLocales' => $config['locales'] ?? [],
+            ],
+        ]);
     }
 
     /**

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -42,6 +42,12 @@
 
  * It's always a good idea to rebuild indexes on upgrade: `emsco:environment:rebuild --all`
 
+## version 6.4.1
+
+* Add a new twig global ```emschLocales``` which contains the EMSCH_LOCALES
+  Because it is added by the clientHelperBundle it is available in admin and website templates
+  Replace ```app.request.server.get('EMSCH_LOCALES')|json_decode``` by ```emschLocales```
+
 ## version 6.4.0
 
 * Add [mercure](https://mercure.rocks) (open solution for real-time communications)


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | n  |
| New feature?   | y  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

We want to use the EMSCH_LOCALES on more places, also in post processing of content types.
But running a recompute means we do not have access to app.request offcourse, it's better to add global twig variable for accessing the EMSCH_LOCALES variable.
