### PR TITLE
fix(admin/trash): role Edit can "Put back"

### DIFF
--- a/EMS/core-bundle/src/Controller/Revision/TrashController.php
+++ b/EMS/core-bundle/src/Controller/Revision/TrashController.php
@@ -80,7 +80,7 @@ class TrashController extends AbstractController
 
     public function putBack(ContentType $contentType, string $ouuid): RedirectResponse
     {
-        if (!$this->isGranted($contentType->role(ContentTypeRoles::CREATE))) {
+        if (!$this->isGranted($contentType->role(ContentTypeRoles::EDIT))) {
             throw $this->createAccessDeniedException();
         }
 

--- a/EMS/core-bundle/src/DataTable/Type/Revision/RevisionTrashDataTableType.php
+++ b/EMS/core-bundle/src/DataTable/Type/Revision/RevisionTrashDataTableType.php
@@ -56,7 +56,7 @@ class RevisionTrashDataTableType extends AbstractTableType implements QueryServi
         $table->addColumnDefinition(new UserTableColumn(t('field.user_deleted', [], 'emsco-core'), 'deletedBy'));
         $table->addColumnDefinition(new DatetimeTableColumn(t('field.date_modified', [], 'emsco-core'), 'modified'));
 
-        if ($this->authorizationChecker->isGranted($contentType->role(ContentTypeRoles::CREATE))) {
+        if ($this->authorizationChecker->isGranted($contentType->role(ContentTypeRoles::EDIT))) {
             $table->addDynamicItemPostAction(
                 route: Routes::DATA_TRASH_PUT_BACK,
                 labelKey: t('revision.trash.put_back', [], 'emsco-core'),


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   |  n  |
| BC breaks?     |  n |
| Deprecations?  |  n |
| Fixed tickets? |  n |
| Documentation? | n |

Change Role for "Put Back" on trash, the action do an edit and not a create. 
The User with Edit role and not Create Role can "put back" from trash.

