### PR TITLE
fix(admin/environment): rebuild correct compare current env

### DIFF
--- a/EMS/core-bundle/src/Entity/Revision.php
+++ b/EMS/core-bundle/src/Entity/Revision.php
@@ -547,7 +547,7 @@ class Revision implements EntityInterface, \Stringable
     public function getCurrentEnvironmentRevision(Environment $environment): EnvironmentRevision
     {
         foreach ($this->environmentRevisions as $environmentRevision) {
-            if ($environmentRevision->getEnvironment() !== $environment || null !== $environmentRevision->getDeleted()) {
+            if ($environmentRevision->getEnvironment()->getId() !== $environment->getId() || null !== $environmentRevision->getDeleted()) {
                 continue;
             }
 

--- a/EMS/core-bundle/src/Repository/RevisionRepository.php
+++ b/EMS/core-bundle/src/Repository/RevisionRepository.php
@@ -217,17 +217,20 @@ class RevisionRepository extends EntityRepository
     public function getRevisionsPaginatorPerEnvironmentAndContentType(Environment $env, ContentType $contentType, int $page = 0, int $size = 50): Paginator
     {
         $qb = $this->createQueryBuilder('r');
-        $qb->join('r.environmentRevisions', 'er')
-        ->where('er.environment = :env')
-        ->andWhere('r.contentType = :ct')
+        $qb
+            ->addSelect('er, e')
+            ->join('r.environmentRevisions', 'er')
+            ->join('er.environment', 'e')
+            ->andWhere('er.environment = :env')
+            ->andWhere('r.contentType = :ct')
             ->andWhere($qb->expr()->isNull('er.deleted'))
-        ->setMaxResults($size)
-        ->setFirstResult($page * $size)
-        ->orderBy('r.id', 'asc')
-        ->setParameters(new ArrayCollection([
-            new Parameter('env', $env),
-            new Parameter('ct', $contentType),
-        ]));
+            ->setMaxResults($size)
+            ->setFirstResult($page * $size)
+            ->orderBy('r.id', 'asc')
+            ->setParameters(new ArrayCollection([
+                new Parameter('env', $env),
+                new Parameter('ct', $contentType),
+            ]));
 
         return new Paginator($qb->getQuery());
     }


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

When rebuilding a lot of revisions, doctrine may use proxy classes the compare against a proxy class will return false.
Improved the getRevisionsPaginatorPerEnvironmentAndContentType only used in the reindex command, for not running to many queries. 

The rebuild command still runs to many queries for building the mapping. Looping fieldType by fieldType querying each fieldType. We should use the fieldType manager and fetch all fieldTypes at once. This will be fixed in >= 6.5.0
