### PR TITLE
fix(admin/doctrine): fieldType options can be null

### DIFF
--- a/EMS/core-bundle/migrations/pdo_mysql/Version20250111190930.php
+++ b/EMS/core-bundle/migrations/pdo_mysql/Version20250111190930.php
@@ -42,7 +42,7 @@ final class Version20250111190930 extends AbstractMigration
         );
         $fieldTypes = $this->connection->executeQuery('select id, type, options from field_type');
         while ($fieldType = $fieldTypes->fetchAssociative()) {
-            $options = Json::decode($fieldType['options']);
+            $options = Json::decode($fieldType['options'] ?? '{}');
             if (!isset($options[FieldType::MAPPING_OPTIONS]['index'])) {
                 continue;
             }

--- a/EMS/core-bundle/migrations/pdo_mysql/Version20250112174825.php
+++ b/EMS/core-bundle/migrations/pdo_mysql/Version20250112174825.php
@@ -30,7 +30,7 @@ final class Version20250112174825 extends AbstractMigration
         );
         $fieldTypes = $this->connection->executeQuery('select id, type, options from field_type');
         while ($fieldType = $fieldTypes->fetchAssociative()) {
-            $options = Json::decode($fieldType['options']);
+            $options = Json::decode($fieldType['options'] ?? '{}');
             if ('EMS\CoreBundle\Form\DataField\RadioFieldType' === $fieldType['type']) {
                 $options[FieldType::DISPLAY_OPTIONS]['expanded'] = true;
                 $options[FieldType::DISPLAY_OPTIONS]['multiple'] = false;

--- a/EMS/core-bundle/migrations/pdo_pgsql/Version20250111190930.php
+++ b/EMS/core-bundle/migrations/pdo_pgsql/Version20250111190930.php
@@ -40,7 +40,7 @@ final class Version20250111190930 extends AbstractMigration
         );
         $fieldTypes = $this->connection->executeQuery('select id, type, options from field_type');
         while ($fieldType = $fieldTypes->fetchAssociative()) {
-            $options = Json::decode($fieldType['options']);
+            $options = Json::decode($fieldType['options'] ?? '{}');
             if (!isset($options[FieldType::MAPPING_OPTIONS]['index'])) {
                 continue;
             }

--- a/EMS/core-bundle/migrations/pdo_pgsql/Version20250112174825.php
+++ b/EMS/core-bundle/migrations/pdo_pgsql/Version20250112174825.php
@@ -28,7 +28,7 @@ final class Version20250112174825 extends AbstractMigration
         );
         $fieldTypes = $this->connection->executeQuery('select id, type, options from field_type');
         while ($fieldType = $fieldTypes->fetchAssociative()) {
-            $options = Json::decode($fieldType['options']);
+            $options = Json::decode($fieldType['options'] ?? '{}');
             if ('EMS\CoreBundle\Form\DataField\RadioFieldType' === $fieldType['type']) {
                 $options[FieldType::DISPLAY_OPTIONS]['expanded'] = true;
                 $options[FieldType::DISPLAY_OPTIONS]['multiple'] = false;


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

The field options is a nullable column. We encountered this during migrations 
