### PR TITLE
fix(admin/contentType): versioning fields empty string

### DIFF
--- a/EMS/core-bundle/src/Core/ContentType/Version/VersionFields.php
+++ b/EMS/core-bundle/src/Core/ContentType/Version/VersionFields.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace EMS\CoreBundle\Core\ContentType\Version;
 
-use EMS\Helpers\ArrayHelper\ArrayHelper;
-
 /**
  * @implements \ArrayAccess<string, ?string>
  */
@@ -30,7 +28,8 @@ class VersionFields implements \ArrayAccess
     public function __construct(array $data)
     {
         foreach (self::FIELDS as $field) {
-            $this->fields[$field] = $data[$field] ?? null;
+            $value = $data[$field] ?? null;
+            $this->fields[$field] = ('' === $value ? null : $value);
         }
     }
 
@@ -39,10 +38,7 @@ class VersionFields implements \ArrayAccess
      */
     public function getData(): array
     {
-        /** @var array<string, ?string> $cleaned */
-        $cleaned = ArrayHelper::map($this->fields, fn (?string $v) => (null !== $v && \strlen($v) > 0 ? $v : null));
-
-        return $cleaned;
+        return $this->fields;
     }
 
     #[\Override]
@@ -60,7 +56,7 @@ class VersionFields implements \ArrayAccess
     #[\Override]
     public function offsetSet($offset, $value): void
     {
-        $this->fields[$offset] = $value;
+        $this->fields[$offset] = ('' === $value ? null : $value);
     }
 
     #[\Override]

--- a/EMS/core-bundle/src/Core/ContentType/Version/Versioning.php
+++ b/EMS/core-bundle/src/Core/ContentType/Version/Versioning.php
@@ -13,13 +13,11 @@ class Versioning
     private ?FieldType $rootFieldType = null;
 
     /**
-     * @param array<string, ?string> $fields
-     * @param array<string, bool>    $options
-     * @param string[]               $tags
+     * @param string[] $tags
      */
     public function __construct(
-        private array $fields,
-        private array $options,
+        private VersionFields $fields,
+        private VersionOptions $options,
         private array $tags
     ) {
     }
@@ -41,12 +39,12 @@ class Versioning
 
     public function getFields(): VersionFields
     {
-        return new VersionFields($this->fields ?? []);
+        return $this->fields;
     }
 
     public function getOptions(): VersionOptions
     {
-        return new VersionOptions($this->options ?? []);
+        return $this->options;
     }
 
     /** @return string[] */
@@ -57,12 +55,12 @@ class Versioning
 
     public function setFields(VersionFields $versionFields): void
     {
-        $this->fields = $versionFields->getData();
+        $this->fields = $versionFields;
     }
 
     public function setOptions(VersionOptions $versionOptions): void
     {
-        $this->options = $versionOptions->getData();
+        $this->options = $versionOptions;
     }
 
     public function setRootFieldType(?FieldType $rootFieldType): void

--- a/EMS/core-bundle/src/Entity/ContentType.php
+++ b/EMS/core-bundle/src/Entity/ContentType.php
@@ -964,8 +964,8 @@ class ContentType extends JsonDeserializer implements \JsonSerializable, EntityI
     public function getVersioning(): Versioning
     {
         $versioning = new Versioning(
-            fields: $this->versionFields ?? [],
-            options: $this->versionOptions ?? [],
+            fields: new VersionFields($this->versionFields ?? []),
+            options: new VersionOptions($this->versionOptions ?? []),
             tags: $this->versionTags ?? []
         );
 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Issue comes from https://github.com/ems-project/elasticms/pull/1224 Possibly in the database the version fields are empty string, the code should convert these to null values. On updating the content type the fields are now correctly stored in the database.