### PR TITLE
fix(admin/environment): correct counter on overview

### DIFF
--- a/EMS/core-bundle/config/repositories.xml
+++ b/EMS/core-bundle/config/repositories.xml
@@ -15,6 +15,9 @@
         <service id="ems.repository.channel" class="EMS\CoreBundle\Repository\ChannelRepository">
             <argument type="service" id="doctrine"/>
         </service>
+        <service id="ems.repository.environment_revision" class="EMS\CoreBundle\Repository\EnvironmentRevisionRepository">
+            <argument type="service" id="doctrine"/>
+        </service>
         <service id="ems.repository.query_search" class="EMS\CoreBundle\Repository\QuerySearchRepository">
             <argument type="service" id="doctrine"/>
         </service>

--- a/EMS/core-bundle/config/services.xml
+++ b/EMS/core-bundle/config/services.xml
@@ -336,6 +336,7 @@
             <argument type="service" id="logger" />
             <argument type="service" id="ems_common.service.elastica" />
             <argument type="service" id="ems.service.alias" />
+            <argument type="service" id="ems.repository.environment_revision" />
             <argument>%ems_core.instance_id%</argument>
             <tag name="emsco.entity.service" priority="80" />
         </service>

--- a/EMS/core-bundle/src/Repository/EnvironmentRepository.php
+++ b/EMS/core-bundle/src/Repository/EnvironmentRepository.php
@@ -7,7 +7,6 @@ namespace EMS\CoreBundle\Repository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\ReadableCollection;
 use Doctrine\DBAL\ArrayParameterType;
-use Doctrine\DBAL\ParameterType;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\QueryBuilder;
 use EMS\CoreBundle\Entity\Environment;
@@ -65,33 +64,6 @@ class EnvironmentRepository extends EntityRepository
         $qb->select('e.alias, e.name, e.managed');
 
         return $qb->getQuery()->getResult();
-    }
-
-    /**
-     * @return array<int, int>
-     */
-    public function countRevisionsById(?bool $deleted = null): array
-    {
-        $qb = $this->getEntityManager()->getConnection()->createQueryBuilder();
-        $qb
-            ->select('e.id', 'count(er.revision_id)')
-            ->from('environment', 'e')
-            ->leftJoin('e', 'environment_revision', 'er', 'e.id = er.environment_id')
-            ->join('er', 'revision', 'r', 'r.id = er.revision_id')
-            ->andWhere($qb->expr()->eq('e.managed', ':managed'))
-            ->setParameter('managed', true, ParameterType::BOOLEAN)
-            ->groupBy('e.id');
-
-        if ($deleted) {
-            $qb
-                ->andWhere($qb->expr()->eq('r.deleted', ':deleted'))
-                ->setParameter('deleted', true, ParameterType::BOOLEAN);
-        }
-
-        /** @var array<int, int> $result */
-        $result = $qb->fetchAllKeyValue();
-
-        return $result;
     }
 
     /**

--- a/EMS/core-bundle/src/Repository/EnvironmentRevisionRepository.php
+++ b/EMS/core-bundle/src/Repository/EnvironmentRevisionRepository.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\Repository;
+
+use Doctrine\Bundle\DoctrineBundle\Registry;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\DBAL\ParameterType;
+use EMS\CoreBundle\Entity\EnvironmentRevision;
+
+/**
+ * @extends ServiceEntityRepository<EnvironmentRevision>
+ *
+ * @method EnvironmentRevision|null find($id, $lockMode = null, $lockVersion = null)
+ * @method EnvironmentRevision|null findOneBy(mixed[] $criteria, mixed[] $orderBy = null)
+ * @method EnvironmentRevision[]    findBy(mixed[] $criteria, mixed[] $orderBy = null, $limit = null, $offset = null)
+ */
+class EnvironmentRevisionRepository extends ServiceEntityRepository
+{
+    public function __construct(Registry $registry)
+    {
+        parent::__construct($registry, EnvironmentRevision::class);
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    public function countRevisions(bool $deleted = false, bool $managed = true): array
+    {
+        $qb = $this->getEntityManager()->getConnection()->createQueryBuilder();
+        $qb
+            ->select('er.environment_id', 'count(er.revision_id)')
+            ->from('environment_revision', 'er')
+            ->join('er', 'revision', 'r', 'r.id = er.revision_id')
+            ->join('er', 'environment', 'e', 'e.id = er.environment_id')
+            ->andWhere($qb->expr()->eq('e.managed', ':managed'))
+            ->setParameter('managed', $managed, ParameterType::BOOLEAN)
+            ->groupBy('er.environment_id');
+
+        if ($deleted) {
+            $qb
+                ->andWhere($qb->expr()->isNotNull('er.deleted'))
+                ->andWhere($qb->expr()->isNull('r.end_time'))
+                ->andWhere($qb->expr()->eq('r.deleted', ':deleted'))
+                ->setParameter('deleted', $deleted, ParameterType::BOOLEAN);
+        } else {
+            $qb->andWhere($qb->expr()->isNull('er.deleted'));
+        }
+
+        /** @var array<int, int> $result */
+        $result = $qb->fetchAllKeyValue();
+
+        return $result;
+    }
+}

--- a/EMS/core-bundle/src/Repository/EnvironmentRevisionRepository.php
+++ b/EMS/core-bundle/src/Repository/EnvironmentRevisionRepository.php
@@ -26,7 +26,7 @@ class EnvironmentRevisionRepository extends ServiceEntityRepository
     /**
      * @return array<int, int>
      */
-    public function countRevisions(bool $deleted = false, bool $managed = true): array
+    public function countDocumentsByEnvironments(bool $deleted = false, bool $managed = true): array
     {
         $qb = $this->getEntityManager()->getConnection()->createQueryBuilder();
         $qb

--- a/EMS/core-bundle/src/Service/EnvironmentService.php
+++ b/EMS/core-bundle/src/Service/EnvironmentService.php
@@ -548,8 +548,8 @@ class EnvironmentService implements EntityServiceInterface
 
         if (null === $stats) {
             $stats = [
-                'revisions' => $this->environmentRevisionRepository->countRevisions(),
-                'revisions_deleted' => $this->environmentRevisionRepository->countRevisions(deleted: true),
+                'revisions' => $this->environmentRevisionRepository->countDocumentsByEnvironments(),
+                'revisions_deleted' => $this->environmentRevisionRepository->countDocumentsByEnvironments(deleted: true),
             ];
         }
 

--- a/EMS/core-bundle/src/Service/EnvironmentService.php
+++ b/EMS/core-bundle/src/Service/EnvironmentService.php
@@ -22,6 +22,7 @@ use EMS\CoreBundle\Entity\Helper\JsonClass;
 use EMS\CoreBundle\Entity\Revision;
 use EMS\CoreBundle\Repository\AnalyzerRepository;
 use EMS\CoreBundle\Repository\EnvironmentRepository;
+use EMS\CoreBundle\Repository\EnvironmentRevisionRepository;
 use EMS\CoreBundle\Repository\FilterRepository;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
@@ -44,6 +45,7 @@ class EnvironmentService implements EntityServiceInterface
         private readonly LoggerInterface $logger,
         private readonly ElasticaService $elasticaService,
         private readonly AliasService $aliasService,
+        private readonly EnvironmentRevisionRepository $environmentRevisionRepository,
         private readonly string $instanceId,
     ) {
         $environmentRepository = $doctrine->getRepository(Environment::class);
@@ -546,8 +548,8 @@ class EnvironmentService implements EntityServiceInterface
 
         if (null === $stats) {
             $stats = [
-                'revisions' => $this->environmentRepository->countRevisionsById(),
-                'revisions_deleted' => $this->environmentRepository->countRevisionsById(deleted: true),
+                'revisions' => $this->environmentRevisionRepository->countRevisions(),
+                'revisions_deleted' => $this->environmentRevisionRepository->countRevisions(deleted: true),
             ];
         }
 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

With the refactoring of the environment revision table, we need to count correctly the published and deleted revisions. Added a new EnvironmentRevisionRepository for doing this correct.
