### PR TITLE
fix(admin/revision): bulk unpublish flag environment revision as deleted

### DIFF
--- a/EMS/core-bundle/src/Command/Environment/AlignCommand.php
+++ b/EMS/core-bundle/src/Command/Environment/AlignCommand.php
@@ -197,7 +197,7 @@ class AlignCommand extends AbstractEnvironmentCommand
                     continue;
                 }
 
-                $this->publishService->bulkUnpublish($revision, $this->target);
+                $this->publishService->bulkUnpublish($revision, $this->target, self::LOCK_USER);
                 ++$countUnpublished;
             }
 

--- a/EMS/core-bundle/src/Command/Environment/UnpublishCommand.php
+++ b/EMS/core-bundle/src/Command/Environment/UnpublishCommand.php
@@ -81,7 +81,7 @@ final class UnpublishCommand extends AbstractEnvironmentCommand
                 $this->io->progressAdvance();
 
                 try {
-                    $this->publishService->bulkUnpublish($revision, $transactionEnvironment);
+                    $this->publishService->bulkUnpublish($revision, $transactionEnvironment, self::LOCK_USER);
                     ++$this->counter;
                 } catch (\LogicException $e) {
                     $this->warnings[$e->getMessage()] = ($this->warnings[$e->getMessage()] ?? 0) + 1;

--- a/EMS/core-bundle/src/Repository/RevisionRepository.php
+++ b/EMS/core-bundle/src/Repository/RevisionRepository.php
@@ -113,10 +113,11 @@ class RevisionRepository extends EntityRepository
     {
         $qb = $this->createQueryBuilder('r');
         $qb
-            ->addSelect('ce, c')
+            ->addSelect('ce, c, er, e')
             ->join('r.contentType', 'c')
             ->join('c.environment', 'ce')
             ->join('r.environmentRevisions', 'er')
+            ->join('er.environment', 'e')
             ->andWhere($qb->expr()->in('r.ouuid', ':ouuids'))
             ->andWhere($qb->expr()->isNull('er.deleted'))
             ->andWhere($qb->expr()->eq('er.environment', ':environment'))

--- a/EMS/core-bundle/src/Service/PublishService.php
+++ b/EMS/core-bundle/src/Service/PublishService.php
@@ -156,15 +156,15 @@ class PublishService
         return $already ? 0 : 1;
     }
 
-    public function bulkUnpublish(Revision $revision, Environment $environment): void
+    public function bulkUnpublish(Revision $revision, Environment $environment, string $username): void
     {
         $contentType = $revision->giveContentType();
 
         if ($contentType->giveEnvironment() === $environment) {
             throw new \LogicException('Unpublish failed: is default environment');
         }
-
-        $revision->getEnvironments()->removeElement($environment);
+        
+        $revision->removeEnvironment($environment, $username);
         $this->bulker->delete($environment->getAlias(), $revision->giveOuuid());
     }
 

--- a/EMS/core-bundle/src/Service/PublishService.php
+++ b/EMS/core-bundle/src/Service/PublishService.php
@@ -163,7 +163,7 @@ class PublishService
         if ($contentType->giveEnvironment() === $environment) {
             throw new \LogicException('Unpublish failed: is default environment');
         }
-        
+
         $revision->removeEnvironment($environment, $username);
         $this->bulker->delete($environment->getAlias(), $revision->giveOuuid());
     }


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Bulk unpublish was not correctly removing the environments in the database. 

