### PR TITLE
fix(admin/datatable): use post for ajax request core data tables

### DIFF
--- a/EMS/core-bundle/src/Resources/config/routing/datatable.xml
+++ b/EMS/core-bundle/src/Resources/config/routing/datatable.xml
@@ -6,7 +6,7 @@
 
     <route id="emsco_datatable_ajax_table" path="/ajax/table/{hash}/{optionsCacheKey}"
            controller="EMS\CoreBundle\Controller\ContentManagement\DatatableController::ajaxData"
-           methods="GET">
+           methods="GET|POST">
         <default key="optionsCacheKey" xsi:nil="true" />
     </route>
 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Because the uploaded files datatable is broken by https://github.com/ems-project/elasticms/pull/1339
