### PR TITLE
fix(admin/media-lib): delete folder not granted

### DIFF
--- a/EMS/core-bundle/src/Service/DataService.php
+++ b/EMS/core-bundle/src/Service/DataService.php
@@ -1193,7 +1193,7 @@ class DataService
         $contentType = (\is_string($contentType)) ? $this->contentTypeService->giveByName($contentType) : $contentType;
         $contentType->validate();
 
-        if (!$this->authorizationChecker->isGranted($contentType->role(ContentTypeRoles::DELETE))) {
+        if (null === $username && !$this->authorizationChecker->isGranted($contentType->role(ContentTypeRoles::DELETE))) {
             throw new AccessDeniedException('Delete role not granted!');
         }
 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

This authorization check was added for the core bridge feature, but now the media library delete is also check if the user is granted. If we pass a username string, it means that we are in cli or async (messenger) and their is no authenticated user, so we only need to call the authorizationChecker if the user === null
