### PR TITLE
feat(cli/import): support query for search documents

### DIFF
--- a/docs/elasticms-cli/commands.md
+++ b/docs/elasticms-cli/commands.md
@@ -126,6 +126,8 @@ php bin/console emscli:file-reader:import pages.csv page \
   * Define the csv delimiter, default 
 * `default_data`: array (default=[])
   * Data array will be merged with row data
+* `query`: array (default=null)
+  * Base query for searching the existing documents, use for delete missing documents
 * `delete_missing_documents`: bool (default=false)
   * The command will delete content type document that are missing in the import file
 * `encoding`: ?string (default=null)

--- a/elasticms-cli/src/Client/File/ImportConfig.php
+++ b/elasticms-cli/src/Client/File/ImportConfig.php
@@ -10,11 +10,13 @@ class ImportConfig
 {
     /**
      * @param array<string, mixed> $defaultData
+     * @param array<string, mixed> $query
      * @param int[]                $excludeRows
      */
     private function __construct(
         public array $defaultData = [],
         public bool $deleteMissingDocuments = false,
+        public ?array $query = null,
         public ?string $delimiter = null,
         public ?string $encoding = null,
         public array $excludeRows = [],
@@ -37,6 +39,7 @@ class ImportConfig
             ->setDefaults([
                 'default_data' => [],
                 'delete_missing_documents' => false,
+                'query' => null,
                 'delimiter' => null,
                 'encoding' => null,
                 'exclude_rows' => [],
@@ -48,6 +51,7 @@ class ImportConfig
                 'ouuid_prefix' => null,
             ])
             ->setAllowedTypes('delete_missing_documents', 'bool')
+            ->setAllowedTypes('query', ['array', 'null'])
             ->setAllowedTypes('generate_hash', 'bool')
             ->setAllowedTypes('generate_ouuid', 'bool')
             ->setAllowedTypes('exclude_expression', ['string', 'null'])
@@ -61,6 +65,7 @@ class ImportConfig
         return new self(
             defaultData: $options['default_data'],
             deleteMissingDocuments: $options['delete_missing_documents'],
+            query: $options['query'],
             delimiter: $options['delimiter'],
             encoding: $options['encoding'],
             excludeRows: $options['exclude_rows'],

--- a/elasticms-cli/src/Command/Import/AbstractImportCommand.php
+++ b/elasticms-cli/src/Command/Import/AbstractImportCommand.php
@@ -99,7 +99,7 @@ abstract class AbstractImportCommand extends AbstractCommand
             throw new \RuntimeException(\sprintf('Not authenticated for %s, run ems:admin:login', $this->adminHelper->getCoreApi()->getBaseUrl()));
         }
 
-        $ouuids = $config->deleteMissingDocuments ? $this->searchExistingOuuids() : [];
+        $ouuids = $config->deleteMissingDocuments ? $this->searchExistingOuuids($config) : [];
 
         $progressBar = $this->io->createProgressBar();
         $progressBar->start();
@@ -140,7 +140,7 @@ abstract class AbstractImportCommand extends AbstractCommand
         }
 
         if (!$this->dryRun && $config->deleteMissingDocuments && \count($ouuids) > 0) {
-            $this->deleteMissingDocuments($contentTypeApi, ...\array_keys($ouuids));
+            $this->deleteMissingDocuments($contentTypeApi, ...$ouuids);
         }
 
         $this->io->definitionList(
@@ -311,15 +311,17 @@ abstract class AbstractImportCommand extends AbstractCommand
     }
 
     /**
-     * @return array<string, bool>
+     * @return string[]
      */
-    private function searchExistingOuuids(): array
+    private function searchExistingOuuids(ImportConfig $config): array
     {
+        $query = $config->query ? new BoolQuery()->addMust($config->query) : null;
+
         $ouuids = [];
-        $search = $this->createSearch();
+        $search = $this->createSearch($query);
 
         foreach ($this->adminHelper->getCoreApi()->search()->scroll($search, $this->scrollSize) as $hit) {
-            $ouuids[$hit->getOuuid()] = true;
+            $ouuids[] = $hit->getOuuid();
         }
 
         return $ouuids;


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | y  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

When searching the existing documents, we may want to define a query. For example the default data contains a parent link, we only want to work with existing data of that parent.
