### PR TITLE
fix(admin/json-menu-nested): display template not rendering choices

### DIFF
--- a/EMS/admin-ui-bundle/templates/bootstrap5/macros/data-field-type.html.twig
+++ b/EMS/admin-ui-bundle/templates/bootstrap5/macros/data-field-type.html.twig
@@ -989,7 +989,7 @@
     {%- set color = not doCompare ? '' : not dataField.rawData ? 'bg-red' : not compareRawData|emsco_get_string(dataField.fieldType.name) ? 'bg-green' : 'bg-orange' -%}
     {%- set displayOptions = dataField.fieldType.options.displayOptions -%}
     {%- set jmnField = displayOptions.json_menu_nested_field|default(false) -%}
-    {%- set jmnQuery = displayOptions.query|default(false) -%}
+    {%- set jmnQuery = displayOptions.query is defined ? displayOptions.query|ems_json_decode : false -%}
 
     {%- if jmnField and jmnQuery and dataField.rawData is not null -%}
         {% if displayOptions.environment|default(null) is not null %}
@@ -997,12 +997,11 @@
         {% else %}
             {% set index = dataField.fieldType.contentType.environment.alias %}
         {% endif %}
-        {%- set jmnQuery = jmnQuery|ems_json_decode -%}
-        {%-  set hits = emsco_search(
+        {%- set hits = emsco_search(
             index,
             jmnQuery.query|default({}),
             [],
-            20,
+            jmnQuery.size|default(5000),
             jmnQuery.from|default(0),
             jmnQuery.sort|default(null),
             jmnQuery._source|default(null)

--- a/EMS/core-bundle/src/Form/DataField/JsonMenuNestedLinkFieldType.php
+++ b/EMS/core-bundle/src/Form/DataField/JsonMenuNestedLinkFieldType.php
@@ -291,10 +291,11 @@ class JsonMenuNestedLinkFieldType extends DataFieldType
 
     private function createJsonMenuNested(string $index, string $jmnQuery, string $jmnField): JsonMenuNested
     {
+        $searchQuery = Json::decode($jmnQuery);
         $search = $this->elasticaService->convertElasticsearchSearch([
-            'size' => 5000,
+            'size' => $searchQuery['size'] ?? 5000,
             'index' => $index,
-            'body' => $jmnQuery,
+            'body' => $searchQuery,
         ]);
 
         $structures = [];

--- a/EMS/core-bundle/templates/macros/data-field-type.html.twig
+++ b/EMS/core-bundle/templates/macros/data-field-type.html.twig
@@ -994,7 +994,7 @@
 	{%- set color = not doCompare ? '' : not dataField.rawData ? 'bg-red' : not compareRawData|emsco_get_string(dataField.fieldType.name) ? 'bg-green' : 'bg-orange' -%}
 	{%- set displayOptions = dataField.fieldType.options.displayOptions -%}
 	{%- set jmnField = displayOptions.json_menu_nested_field|default(false) -%}
-	{%- set jmnQuery = displayOptions.query|default(false) -%}
+    {%- set jmnQuery = displayOptions.query is defined ? displayOptions.query|ems_json_decode : false -%}
 
 	{%- if jmnField and jmnQuery and dataField.rawData is not null -%}
         {% if displayOptions.environment|default(null) is not null %}
@@ -1002,11 +1002,11 @@
         {% else %}
             {% set index = dataField.fieldType.contentType.environment.alias %}
         {% endif %}
-		{%-  set hits = emsco_search(
+		{%- set hits = emsco_search(
 			index,
 			jmnQuery.query|default({}),
 			[],
-			20,
+            jmnQuery.size|default(5000),
 			jmnQuery.from|default(0),
 			jmnQuery.sort|default(null),
 			jmnQuery._source|default(null)


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Because we are not passing a correct query. It works on some projects if the 'default' environment does not contain more than 20 documents.

Strange but in the admin-ui-bundle the json query was decoded. Now also in the core and the twig template has been aligned for this fix.
