### PR TITLE
feat(cli/import): support align environments

### DIFF
--- a/docs/elasticms-cli/commands.md
+++ b/docs/elasticms-cli/commands.md
@@ -122,12 +122,13 @@ php bin/console emscli:file-reader:import pages.csv page \
 --config='./var/files/config.json'
 ```
 
-* `delimiter`: ?string (default=null) 
-  * Define the csv delimiter, default 
+* `delimiter`: ?string (default=null)
+  * Define the csv delimiter
 * `default_data`: array (default=[])
   * Data array will be merged with row data
 * `query`: array (default=null)
-  * Base query for searching the existing documents, use for delete missing documents
+  * Base query for searching the existing documents, use for delete missing
+    documents and alignment.
 * `delete_missing_documents`: bool (default=false)
   * The command will delete content type document that are missing in the import file
 * `encoding`: ?string (default=null)
@@ -146,10 +147,14 @@ php bin/console emscli:file-reader:import pages.csv page \
   * Expression language apply to excel rows for generating a version uuid saved in `_version_uuid` 
 * `ouuid_prefix`: ?string (default=null)
   * The ouuid will prefix with this value before hashing
+* `align_environments`: array (default[])
+  * Example
+    `[{'source':'preview','target':'live'},{'source':'preview','target':'default'}]`,
+    if query is defined this will be used as search-query for the alignment.
 
 ### Example
 
-I.e.: `ems:file:impo --config='{"ouuid_expression":null}' /home/dockerce/documents/promo/features.xlsx feature`
+I.e.: `ems:import:file --config='{"ouuid_expression":null}' /home/dockerce/documents/promo/features.xlsx feature`
 
 During the import an associate array containing the Excel row is available in the source `_sync_metadata`.
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -58,7 +58,7 @@
 ## version 6.1.1
 
 We added a new cli command `emscli:import:database`.
-Good practice to replace `emscli:file-reader:import` now alias for `emscli:file:import`
+Good practice to replace `emscli:file-reader:import` now alias for `emscli:import:file`
 
 ## Switch to CK Editor 5 (still in beta)
 

--- a/elasticms-cli/src/Client/File/ImportConfig.php
+++ b/elasticms-cli/src/Client/File/ImportConfig.php
@@ -12,6 +12,10 @@ class ImportConfig
      * @param array<string, mixed> $defaultData
      * @param array<string, mixed> $query
      * @param int[]                $excludeRows
+     * @param array<int, array{
+     *     'source': string,
+     *     'target': string
+     * }>                          $alignEnvironments
      */
     private function __construct(
         public array $defaultData = [],
@@ -26,6 +30,7 @@ class ImportConfig
         public ?string $ouuidExpression = "row['ouuid']",
         public ?string $ouuidVersionExpression = null,
         public ?string $ouuidPrefix = null,
+        public array $alignEnvironments = []
     ) {
     }
 
@@ -49,6 +54,7 @@ class ImportConfig
                 'ouuid_expression' => 'row[\'ouuid\']',
                 'ouuid_version_expression' => null,
                 'ouuid_prefix' => null,
+                'align_environments' => [],
             ])
             ->setAllowedTypes('delete_missing_documents', 'bool')
             ->setAllowedTypes('query', ['array', 'null'])
@@ -58,6 +64,16 @@ class ImportConfig
             ->setAllowedTypes('ouuid_expression', ['string', 'null'])
             ->setAllowedTypes('ouuid_version_expression', ['string', 'null'])
             ->setAllowedTypes('ouuid_prefix', ['string', 'null'])
+            ->setAllowedTypes('align_environments', ['array'])
+            ->setNormalizer('align_environments', function (OptionsResolver $resolver, array $value) {
+                $alignEnvironment = new OptionsResolver();
+                $alignEnvironment
+                    ->setRequired(['source', 'target'])
+                    ->setAllowedTypes('source', 'string')
+                    ->setAllowedTypes('target', 'string');
+
+                return \array_map(static fn (mixed $item) => $alignEnvironment->resolve($item), $value);
+            })
         ;
 
         $options = $optionsResolver->resolve($config);
@@ -75,6 +91,7 @@ class ImportConfig
             ouuidExpression: $options['ouuid_expression'],
             ouuidVersionExpression: $options['ouuid_version_expression'],
             ouuidPrefix: $options['ouuid_prefix'],
+            alignEnvironments: $options['align_environments'],
         );
     }
 }

--- a/elasticms-cli/src/Command/Import/AbstractImportCommand.php
+++ b/elasticms-cli/src/Command/Import/AbstractImportCommand.php
@@ -143,6 +143,8 @@ abstract class AbstractImportCommand extends AbstractCommand
             $this->deleteMissingDocuments($contentTypeApi, ...$ouuids);
         }
 
+        $this->alignEnvironments($config);
+
         $this->io->definitionList(
             'Summary',
             ['Index' => $this->countIndex],
@@ -335,5 +337,36 @@ abstract class AbstractImportCommand extends AbstractCommand
         $search->setContentTypes([$this->contentType]);
 
         return $search;
+    }
+
+    private function alignEnvironments(ImportConfig $config): void
+    {
+        $alignEnvironments = $config->alignEnvironments;
+
+        if (0 === \count($alignEnvironments)) {
+            return;
+        }
+
+        $this->io->newLine(2);
+        $this->io->section('Align environments');
+
+        $adminApi = $this->adminHelper->getCoreApi()->admin();
+
+        foreach ($alignEnvironments as $align) {
+            $options = ['--force'];
+            if ($config->query) {
+                $options[] = \sprintf("--search-query='%s'", Json::encode($config->query));
+            }
+
+            $command = [
+                'emsco:environment:align',
+                ...$options,
+                '--',
+                $align['source'],
+                $align['target'],
+            ];
+
+            $adminApi->runCommand(\implode(' ', $command), $this->output);
+        }
     }
 }


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  n |
| New feature?   | y  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

After an import we may want to align the imported documents to an environment.
