### PR TITLE
fix(admin/user): profile group only print if defined

### DIFF
--- a/EMS/core-bundle/templates/user/profile/show.html.twig
+++ b/EMS/core-bundle/templates/user/profile/show.html.twig
@@ -55,9 +55,11 @@
                                 {%- endfor %}
                             </i>
                         </li>
-                        <li class="list-group-item">
-                            <b>{{ 'field.group'|trans }}</b> <i class="pull-right">{{ user.group.label }}</i>
-                        </li>
+                        {%- if user.group -%}
+                            <li class="list-group-item">
+                                <b>{{ 'field.group'|trans }}</b> <i class="pull-right">{{ user.group.label }}</i>
+                            </li>
+                        {%- endif -%}
                         <li class="list-group-item">
                             <b>{{ 'view.profile.show.wysiwyg'|trans }}</b> <i class="pull-right">{% if user.wysiwygProfile %}{{ user.wysiwygProfile.name }}{% endif %}</i>
                         </li>


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

In 'dev' mode we received the following error: Impossible to access an attribute ("label") on a null variable in @EMSCore/user/profile/show.html.twig at line 59.

