### PR TITLE
fix(common/backup): exclude _published by from export

### DIFF
--- a/EMS/common-bundle/src/Elasticsearch/Document/Document.php
+++ b/EMS/common-bundle/src/Elasticsearch/Document/Document.php
@@ -126,6 +126,7 @@ class Document implements DocumentInterface
                 $source[EMSSource::FIELD_FINALIZATION_DATETIME],
                 $source[EMSSource::FIELD_FINALIZED_BY],
                 $source[EMSSource::FIELD_HASH],
+                $source[EMSSource::FIELD_PUBLICATION_BY],
                 $source[EMSSource::FIELD_PUBLICATION_DATETIME],
                 $source[EMSSource::FIELD_SIGNATURE]
             );

--- a/EMS/common-bundle/src/Elasticsearch/Document/EMSSource.php
+++ b/EMS/common-bundle/src/Elasticsearch/Document/EMSSource.php
@@ -21,6 +21,7 @@ final class EMSSource implements EMSSourceInterface
     public const string FIELD_FINALIZATION_DATETIME = '_finalization_datetime';
     public const string FIELD_HASH = '_sha1';
     public const string FIELD_SIGNATURE = '_signature';
+    public const string FIELD_PUBLICATION_BY = '_published_by';
     public const string FIELD_PUBLICATION_DATETIME = '_published_datetime';
     public const string FIELD_VERSION_UUID = '_version_uuid';
     public const string FIELD_VERSION_TAG = '_version_tag';


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Exclude the new added field '_published_by', maybe in the future it's better too just exclude all fields that start with an underscore.
