### PR TITLE
fix(common/job): correct set status for core jobs

### DIFF
--- a/EMS/core-bundle/src/Service/JobService.php
+++ b/EMS/core-bundle/src/Service/JobService.php
@@ -195,8 +195,7 @@ class JobService implements EntityServiceInterface
         $job->setStarted(true);
         $this->repository->save($job);
 
-        $output = new JobOutput($this->repository, $job->getId());
-        $output->setDecorated(true);
+        $output = $this->getJobOutput($job);
         $output->writeln('Job ready to be launch');
 
         return $output;
@@ -342,11 +341,16 @@ class JobService implements EntityServiceInterface
     public function write(int $jobId, string $message, bool $newLine): void
     {
         $job = $this->repository->findById($jobId);
-        $job->setOutput($job->getOutput().$message.($newLine ? PHP_EOL : ''));
 
-        $this->em->persist($job);
-        $this->em->flush();
+        $output = $this->getJobOutput($job);
+        $output->doWrite($message, $newLine);
+    }
 
-        $this->logger->info('Job '.$job->getCommand().' completed.');
+    private function getJobOutput(Job $job): JobOutput
+    {
+        $output = new JobOutput($this->repository, $job->getId());
+        $output->setDecorated(true);
+
+        return $output;
     }
 }


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

The write method is only used by the api route, which is used by the cli -> common for write job output.
Using the doWrite method, will also correctly set the status of the job and save it into the db.
