### PR TITLE
fix(admin/environment): correct remove/add with version revisions 

### DIFF
--- a/EMS/core-bundle/migrations/pdo_pgsql/Version20250426083639.php
+++ b/EMS/core-bundle/migrations/pdo_pgsql/Version20250426083639.php
@@ -97,6 +97,10 @@ final class Version20250426083639 extends AbstractMigration
         );
 
         $this->addSql(<<<'SQL'
+            DELETE FROM environment_revision WHERE deleted IS NOT NULL
+        SQL);
+
+        $this->addSql(<<<'SQL'
             ALTER TABLE environment_revision DROP CONSTRAINT fk_895f7b701dfa7c8f
         SQL);
         $this->addSql(<<<'SQL'

--- a/EMS/core-bundle/migrations/pdo_pgsql/Version20250517093114.php
+++ b/EMS/core-bundle/migrations/pdo_pgsql/Version20250517093114.php
@@ -38,7 +38,7 @@ final class Version20250517093114 extends AbstractMigration
         );
 
         $this->addSql(<<<'SQL'
-            ALTER TABLE template DROP allowed_remote_host
+            ALTER TABLE template DROP allowed_remote_hosts
         SQL);
     }
 }

--- a/EMS/core-bundle/src/Entity/Revision.php
+++ b/EMS/core-bundle/src/Entity/Revision.php
@@ -566,6 +566,10 @@ class Revision implements EntityInterface, \Stringable
     public function removeEnvironment(Environment $environment, string $username): self
     {
         foreach ($this->environmentRevisions as $environmentRevision) {
+            if (null !== $environmentRevision->getDeleted()) {
+                continue;
+            }
+
             if ($environmentRevision->getEnvironment() === $environment) {
                 $environmentRevision->setDeleted(new \DateTime());
                 $environmentRevision->setDeletedBy($username);

--- a/EMS/core-bundle/src/Repository/RevisionRepository.php
+++ b/EMS/core-bundle/src/Repository/RevisionRepository.php
@@ -21,7 +21,6 @@ use EMS\CoreBundle\Entity\ContentType;
 use EMS\CoreBundle\Entity\Environment;
 use EMS\CoreBundle\Entity\Release;
 use EMS\CoreBundle\Entity\Revision;
-use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
 
 /**
@@ -133,31 +132,6 @@ class RevisionRepository extends EntityRepository
     {
         $this->getEntityManager()->persist($revision);
         $this->getEntityManager()->flush();
-    }
-
-    public function addEnvironment(Revision $revision, Environment $environment, string $username): int
-    {
-        $conn = $this->getEntityManager()->getConnection();
-        $stmt = $conn->prepare('insert into environment_revision (id, environment_id, revision_id, created,  created_by, deleted, deleted_by) VALUES(:id, :envId, :revId, :now, :username, null, null)');
-        $stmt->bindValue('id', Uuid::uuid4()->toString());
-        $stmt->bindValue('envId', $environment->getId());
-        $stmt->bindValue('revId', $revision->getId());
-        $stmt->bindValue('now', new \DateTime()->format('Y-m-d H:i:s'));
-        $stmt->bindValue('username', $username);
-
-        return (int) $stmt->executeStatement();
-    }
-
-    public function removeEnvironment(Revision $revision, Environment $environment, string $username): int
-    {
-        $conn = $this->getEntityManager()->getConnection();
-        $stmt = $conn->prepare('update environment_revision set deleted = :now, deleted_by = :username  where environment_id = :envId and revision_id = :revId and deleted is null');
-        $stmt->bindValue('envId', $environment->getId());
-        $stmt->bindValue('revId', $revision->getId());
-        $stmt->bindValue('now', new \DateTime()->format('Y-m-d H:i:s'));
-        $stmt->bindValue('username', $username);
-
-        return (int) $stmt->executeStatement();
     }
 
     /**

--- a/EMS/core-bundle/src/Service/DataService.php
+++ b/EMS/core-bundle/src/Service/DataService.php
@@ -767,7 +767,7 @@ class DataService
             $ouuid = $revision->getOuuid();
             if (null !== $ouuid) {
                 $item = $repository->findByOuuidContentTypeAndEnvironment($revision);
-                if ($item) {
+                if ($item && $revision !== $item) {
                     $this->lockRevision($item, null, false, $username);
                     $previousObjectArray = $item->getRawData();
                     $item->removeEnvironment($revision->giveContentType()->giveEnvironment(), $username);

--- a/EMS/core-bundle/src/Service/PublishService.php
+++ b/EMS/core-bundle/src/Service/PublishService.php
@@ -141,10 +141,12 @@ class PublishService
         $already = $revisionEnvironment === $revision;
 
         if (!$already && $revisionEnvironment) {
-            $this->revRepository->removeEnvironment($revisionEnvironment, $environment, $commandUser);
+            $revisionEnvironment->removeEnvironment($environment, $commandUser);
+            $this->revRepository->save($revisionEnvironment);
         }
         if (!$already) {
-            $this->revRepository->addEnvironment($revision, $environment, $commandUser);
+            $revision->addEnvironment($environment, $commandUser);
+            $this->revRepository->save($revision);
         }
 
         $this->dataService->sign($revision, true);
@@ -230,7 +232,8 @@ class PublishService
             $already = true;
             $this->logger->notice('service.publish.already_published', $logContext);
         } elseif ($item) {
-            $this->revRepository->removeEnvironment($item, $environment, $username);
+            $item->removeEnvironment($environment, $username);
+            $this->revRepository->save($item);
         }
 
         if (null === $commandUser) {
@@ -244,7 +247,8 @@ class PublishService
         }
 
         if (!$already) {
-            $this->revRepository->addEnvironment($revision, $environment, $username);
+            $revision->addEnvironment($environment, $username);
+            $this->revRepository->save($revision);
 
             if (null === $commandUser) {
                 $this->auditLogger->notice('log.published.success', [...[


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

We should not use dbal queries, because orm collection will not be updated. removeEnvironment should skip already removed environments.

Fix doctrine migrations, rollback was failing
