### PR TITLE
chore(docker): overwrite postgres volume name

### DIFF
--- a/docker/.env.dist
+++ b/docker/.env.dist
@@ -12,6 +12,7 @@ ELK_VERSION=elk7
 EMS_VERSION=5.13.5
 
 POSTGRES_VERSION=17
+#POSTGRES_VOLUME=postgres
 
 ###> Cluster's variables ###
 # Set the cluster name

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -166,6 +166,8 @@ volumes:
   s3:
   mariadb:
   postgres:
+      name: ${POSTGRES_VOLUME-postgres}
+      external: false
   mercure_data:
   mercure_config:
 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  n |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Make it possible to overwrite the postgresSQL volume name.
