### PR TITLE
fix(admin/environment): revert align command use dbal queries

### DIFF
--- a/EMS/core-bundle/config/services.xml
+++ b/EMS/core-bundle/config/services.xml
@@ -411,6 +411,7 @@
             <argument type="service" id="emsco.logger"/>
             <argument type="service" id="emsco.logger.audit"/>
             <argument type="service" id="ems.elasticsearch.bulker"/>
+            <argument type="service" id="ems.repository.environment_revision"/>
         </service>
         <service id="ems.service.notification" class="EMS\CoreBundle\Service\NotificationService">
             <argument type="service" id="doctrine"/>

--- a/EMS/core-bundle/src/Repository/EnvironmentRevisionRepository.php
+++ b/EMS/core-bundle/src/Repository/EnvironmentRevisionRepository.php
@@ -7,7 +7,10 @@ namespace EMS\CoreBundle\Repository;
 use Doctrine\Bundle\DoctrineBundle\Registry;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\DBAL\ParameterType;
+use EMS\CoreBundle\Entity\Environment;
 use EMS\CoreBundle\Entity\EnvironmentRevision;
+use EMS\CoreBundle\Entity\Revision;
+use Ramsey\Uuid\Uuid;
 
 /**
  * @extends ServiceEntityRepository<EnvironmentRevision>
@@ -52,5 +55,30 @@ class EnvironmentRevisionRepository extends ServiceEntityRepository
         $result = $qb->fetchAllKeyValue();
 
         return $result;
+    }
+
+    public function delete(Revision $revision, Environment $environment, string $username): int
+    {
+        $conn = $this->getEntityManager()->getConnection();
+        $stmt = $conn->prepare('update environment_revision set deleted = :now, deleted_by = :username  where environment_id = :envId and revision_id = :revId and deleted is null');
+        $stmt->bindValue('envId', $environment->getId());
+        $stmt->bindValue('revId', $revision->getId());
+        $stmt->bindValue('now', new \DateTime()->format('Y-m-d H:i:s'));
+        $stmt->bindValue('username', $username);
+
+        return (int) $stmt->executeStatement();
+    }
+
+    public function create(Revision $revision, Environment $environment, string $username): int
+    {
+        $conn = $this->getEntityManager()->getConnection();
+        $stmt = $conn->prepare('insert into environment_revision (id, environment_id, revision_id, created,  created_by, deleted, deleted_by) VALUES(:id, :envId, :revId, :now, :username, null, null)');
+        $stmt->bindValue('id', Uuid::uuid4()->toString());
+        $stmt->bindValue('envId', $environment->getId());
+        $stmt->bindValue('revId', $revision->getId());
+        $stmt->bindValue('now', new \DateTime()->format('Y-m-d H:i:s'));
+        $stmt->bindValue('username', $username);
+
+        return (int) $stmt->executeStatement();
     }
 }

--- a/EMS/core-bundle/src/Service/PublishService.php
+++ b/EMS/core-bundle/src/Service/PublishService.php
@@ -20,6 +20,7 @@ use EMS\CoreBundle\Entity\Environment;
 use EMS\CoreBundle\Entity\Revision;
 use EMS\CoreBundle\Event\RevisionPublishEvent;
 use EMS\CoreBundle\Event\RevisionUnpublishEvent;
+use EMS\CoreBundle\Repository\EnvironmentRevisionRepository;
 use EMS\CoreBundle\Repository\RevisionRepository;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -43,6 +44,7 @@ class PublishService
         private readonly LoggerInterface $logger,
         private readonly LoggerInterface $auditLogger,
         private readonly Bulker $bulker,
+        private readonly EnvironmentRevisionRepository $environmentRevisionRepository,
     ) {
         /** @var RevisionRepository $revRepository */
         $revRepository = $this->doctrine->getManager()->getRepository(Revision::class);
@@ -141,12 +143,10 @@ class PublishService
         $already = $revisionEnvironment === $revision;
 
         if (!$already && $revisionEnvironment) {
-            $revisionEnvironment->removeEnvironment($environment, $commandUser);
-            $this->revRepository->save($revisionEnvironment);
+            $this->environmentRevisionRepository->delete($revisionEnvironment, $environment, $commandUser);
         }
         if (!$already) {
-            $revision->addEnvironment($environment, $commandUser);
-            $this->revRepository->save($revision);
+            $this->environmentRevisionRepository->create($revision, $environment, $commandUser);
         }
 
         $this->dataService->sign($revision, true);


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Broken in 6.4.5 with this pr: https://github.com/ems-project/elasticms/pull/1362

The alignment command was now too slow, we should keep on using dbal queries for alignment.