### PR TITLE
fix(admin/environment): revert unpublish command use dbal queries

### DIFF
--- a/EMS/core-bundle/src/Command/Environment/UnpublishCommand.php
+++ b/EMS/core-bundle/src/Command/Environment/UnpublishCommand.php
@@ -75,13 +75,12 @@ final class UnpublishCommand extends AbstractEnvironmentCommand
         foreach ($this->revisionSearcher->search($this->environment, $search) as $revisions) {
             $this->revisionSearcher->lock($revisions, $this->lockUser);
             $this->publishService->bulkStart($bulkSize, $this->logger);
-            $transactionEnvironment = $this->environmentService->clearCache()->giveByName($this->environment->getName());
 
             foreach ($revisions->transaction() as $revision) {
                 $this->io->progressAdvance();
 
                 try {
-                    $this->publishService->bulkUnpublish($revision, $transactionEnvironment, self::LOCK_USER);
+                    $this->publishService->bulkUnpublish($revision, $this->environment, self::LOCK_USER);
                     ++$this->counter;
                 } catch (\LogicException $e) {
                     $this->warnings[$e->getMessage()] = ($this->warnings[$e->getMessage()] ?? 0) + 1;

--- a/EMS/core-bundle/src/Service/PublishService.php
+++ b/EMS/core-bundle/src/Service/PublishService.php
@@ -166,7 +166,7 @@ class PublishService
             throw new \LogicException('Unpublish failed: is default environment');
         }
 
-        $revision->removeEnvironment($environment, $username);
+        $this->environmentRevisionRepository->delete($revision, $environment, $username);
         $this->bulker->delete($environment->getAlias(), $revision->giveOuuid());
     }
 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Broken in 6.4.5 with this pr: https://github.com/ems-project/elasticms/pull/1362

Unpublish command should also use the bulk dbal queries
