### PR TITLE
fix(common/spreadsheet): config value_binder

### DIFF
--- a/EMS/common-bundle/src/Common/Spreadsheet/SpreadsheetGeneratorService.php
+++ b/EMS/common-bundle/src/Common/Spreadsheet/SpreadsheetGeneratorService.php
@@ -7,7 +7,10 @@ namespace EMS\CommonBundle\Common\Spreadsheet;
 use EMS\CommonBundle\Common\Converter;
 use EMS\CommonBundle\Contracts\Spreadsheet\SpreadsheetGeneratorServiceInterface;
 use EMS\Helpers\File\TempFile;
+use PhpOffice\PhpSpreadsheet\Cell\AdvancedValueBinder;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
+use PhpOffice\PhpSpreadsheet\Cell\DefaultValueBinder;
+use PhpOffice\PhpSpreadsheet\Cell\StringValueBinder;
 use PhpOffice\PhpSpreadsheet\Settings;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
@@ -84,6 +87,12 @@ final class SpreadsheetGeneratorService implements SpreadsheetGeneratorServiceIn
         $cache = new Psr16Cache(new FilesystemAdapter());
         Settings::setCache($cache);
 
+        $spreadsheet->setValueBinder(match ($config[self::VALUE_BINDER] ?? null) {
+            'string' => new StringValueBinder(),
+            'advanced' => new AdvancedValueBinder(),
+            default => new DefaultValueBinder(),
+        });
+
         $i = 0;
         $maxCol = 1;
         foreach ($config[self::SHEETS] as $sheetConfig) {
@@ -137,6 +146,7 @@ final class SpreadsheetGeneratorService implements SpreadsheetGeneratorServiceIn
             self::CONTENT_DISPOSITION => 'attachment',
             self::WRITER => self::XLSX_WRITER,
             self::CSV_SEPARATOR => ',',
+            self::VALUE_BINDER => null,
             'active_sheet' => 0,
         ];
     }
@@ -156,6 +166,7 @@ final class SpreadsheetGeneratorService implements SpreadsheetGeneratorServiceIn
         $resolver->setAllowedTypes(self::CONTENT_DISPOSITION, ['string']);
         $resolver->setAllowedValues(self::WRITER, [self::XLSX_WRITER, self::CSV_WRITER]);
         $resolver->setAllowedValues(self::CONTENT_DISPOSITION, ['attachment', 'inline']);
+        $resolver->setAllowedValues(self::VALUE_BINDER, [null, 'string', 'advanced']);
 
         /** @var array{writer: string, filename: string, disposition: string, sheets: array<mixed>, csv_separator: string} $resolved */
         $resolved = $resolver->resolve($config);

--- a/EMS/common-bundle/src/Contracts/Spreadsheet/SpreadsheetGeneratorServiceInterface.php
+++ b/EMS/common-bundle/src/Contracts/Spreadsheet/SpreadsheetGeneratorServiceInterface.php
@@ -19,6 +19,7 @@ interface SpreadsheetGeneratorServiceInterface
     public const CONTENT_DISPOSITION = 'disposition';
     public const CELL_DATA = 'data';
     public const CELL_STYLE = 'style';
+    public const VALUE_BINDER = 'value_binder';
 
     /**
      * @param array<mixed> $config

--- a/docs/dev/common-bundle/spreadsheet.md
+++ b/docs/dev/common-bundle/spreadsheet.md
@@ -9,6 +9,7 @@ Two writer are supported:
     "filename": "custom-filename",
     "disposition": "attachment",
     "writer": "xlsx",
+    "value_binder": "string",
     "sheets": [
         {
             "name": "Sheet 1",
@@ -29,6 +30,15 @@ Two writer are supported:
 
 {{- config|json_encode|raw -}}
 ```
+
+The `value_binder` config allows following values:
+- `null`: use DefaultValueBinder
+- `string`: use StringValueBinder
+- `advanced`: use AdvancedValueBinder
+
+More info about [value binders](https://phpspreadsheet.readthedocs.io/en/latest/topics/accessing-cells/#using-value-binders-to-facilitate-data-entry).
+
+
 Different config for definition of Cell are available (config may be mixed up)
 
 - `without style`: directly string value or an array { "data" : "stringValue" }


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Spreadsheet export format excel are not correct. Sometimes we just want the string values, by default it will convert 5.10 into 5,1.
