### PR TITLE
refactor(admin/action): execute job action in service

### DIFF
--- a/EMS/core-bundle/config/controllers.xml
+++ b/EMS/core-bundle/config/controllers.xml
@@ -227,13 +227,10 @@
             <argument type="service" id="ems.service.index" />
             <argument type="service" id="translator" />
             <argument type="service" id="ems.content_type.view_types" />
-            <argument type="service" id="twig" />
-            <argument type="service" id="ems.service.job" />
             <argument type="service" id="EMS\CoreBundle\Repository\ContentTypeRepository" />
             <argument type="service" id="ems.repository.search" />
             <argument type="service" id="EMS\CoreBundle\Repository\RevisionRepository" />
-            <argument type="service" id="EMS\CoreBundle\Repository\TemplateRepository" />
-            <argument type="service" id="EMS\CoreBundle\Repository\EnvironmentRepository" />
+            <argument type="service" id="ems.service.action" />
             <argument type="service" id="ems_core.core_ui.flash_message_logger" />
             <argument>%ems_core.template_namespace%</argument>
             <call method="setContainer"/>

--- a/EMS/core-bundle/config/services.xml
+++ b/EMS/core-bundle/config/services.xml
@@ -496,6 +496,9 @@
         <service id="ems.service.action" class="EMS\CoreBundle\Service\ActionService">
             <argument type="service" id="ems.repository.template"/>
             <argument type="service" id="logger"/>
+            <argument type="service" id="ems.service.search"/>
+            <argument type="service" id="twig"/>
+            <argument type="service" id="EMS\CoreBundle\Service\JobService"/>
         </service>
         <service id="ems.service.release" class="EMS\CoreBundle\Service\ReleaseService">
             <argument type="service" id="ems.repository.release"/>

--- a/EMS/core-bundle/src/Controller/ContentManagement/DataController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/DataController.php
@@ -18,7 +18,6 @@ use EMS\CoreBundle\Entity\Environment;
 use EMS\CoreBundle\Entity\Form\Search;
 use EMS\CoreBundle\Entity\Form\SearchFilter;
 use EMS\CoreBundle\Entity\Revision;
-use EMS\CoreBundle\Entity\Template;
 use EMS\CoreBundle\Entity\UserInterface;
 use EMS\CoreBundle\Entity\View;
 use EMS\CoreBundle\Exception\DuplicateOuuidException;
@@ -27,16 +26,14 @@ use EMS\CoreBundle\Form\Field\IconTextType;
 use EMS\CoreBundle\Form\Form\RevisionType;
 use EMS\CoreBundle\Helper\EmsCoreResponse;
 use EMS\CoreBundle\Repository\ContentTypeRepository;
-use EMS\CoreBundle\Repository\EnvironmentRepository;
 use EMS\CoreBundle\Repository\RevisionRepository;
 use EMS\CoreBundle\Repository\SearchRepository;
-use EMS\CoreBundle\Repository\TemplateRepository;
 use EMS\CoreBundle\Routes;
+use EMS\CoreBundle\Service\ActionService;
 use EMS\CoreBundle\Service\ContentTypeService;
 use EMS\CoreBundle\Service\DataService;
 use EMS\CoreBundle\Service\EnvironmentService;
 use EMS\CoreBundle\Service\IndexService;
-use EMS\CoreBundle\Service\JobService;
 use EMS\CoreBundle\Service\PublishService;
 use EMS\CoreBundle\Service\SearchService;
 use EMS\CoreBundle\Twig\AppExtension;
@@ -51,10 +48,9 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Core\User\UserInterface as SymfonyUserInterface;
 use Symfony\Component\Validator\Constraints\Regex;
 use Symfony\Contracts\Translation\TranslatorInterface;
-use Twig\Environment as TwigEnvironment;
 
 class DataController extends AbstractController
 {
@@ -67,13 +63,10 @@ class DataController extends AbstractController
         private readonly IndexService $indexService,
         private readonly TranslatorInterface $translator,
         private readonly ViewTypes $viewTypes,
-        private readonly TwigEnvironment $twig,
-        private readonly JobService $jobService,
         private readonly ContentTypeRepository $contentTypeRepository,
         private readonly SearchRepository $searchRepository,
         private readonly RevisionRepository $revisionRepository,
-        private readonly TemplateRepository $templateRepository,
-        private readonly EnvironmentRepository $environmentRepository,
+        private readonly ActionService $actionService,
         private readonly FlashMessageLogger $flashMessageLogger,
         private readonly string $templateNamespace,
     ) {
@@ -479,69 +472,21 @@ class DataController extends AbstractController
         return $viewType->generateResponse($view, $request);
     }
 
-    public function customViewJob(string $environmentName, int $templateId, string $ouuid, Request $request): Response
+    public function customViewJob(Request $request, SymfonyUserInterface $user, string $environmentName, int $templateId, string $ouuid): Response
     {
-        /** @var Template|null $template * */
-        $template = $this->templateRepository->find($templateId);
-        /** @var Environment|null $env */
-        $env = $this->environmentRepository->findOneByName($environmentName);
-
-        if (null === $template || !$env) {
-            throw new NotFoundHttpException();
-        }
-
-        $document = $this->searchService->getDocument($template->giveContentType(), $ouuid, $env);
-
-        $success = false;
         try {
-            $command = $this->twig->createTemplate($template->getBody())->render([
-                'environment' => $env->getName(),
-                'contentType' => $template->getContentType(),
-                'object' => $document,
-                'source' => $document->getSource(),
-            ]);
-
-            $user = $this->getUser();
-            if (!$user instanceof UserInterface) {
-                throw new \RuntimeException('Unexpected user object');
-            }
-            $job = $this->jobService->createCommand($user, $command, $template->getTag());
-
-            $success = true;
-            $this->logger->notice('log.data.job.initialized', [
-                EmsFields::LOG_CONTENTTYPE_FIELD => $template->giveContentType()->getName(),
-                EmsFields::LOG_OPERATION_FIELD => EmsFields::LOG_OPERATION_UPDATE,
-                EmsFields::LOG_OUUID_FIELD => $ouuid,
-                'template_id' => $template->getId(),
-                'job_id' => $job->getId(),
-                'template_name' => $template->getName(),
-                'template_label' => $template->getLabel(),
-                'environment' => $env->getLabel(),
-            ]);
+            $action = $this->actionService->giveById($templateId);
+            $environment = $this->environmentService->giveByName($environmentName);
+            $job = $this->actionService->executeJobAction($user, $action, $ouuid, $environment);
 
             return EmsCoreResponse::createJsonResponse($request, true, [
                 'jobId' => $job->getId(),
-                'jobUrl' => $this->generateUrl('emsco_job_start', ['job' => $job->getId()], UrlGeneratorInterface::ABSOLUTE_PATH),
-                'url' => $this->generateUrl('emsco_job_status', ['job' => $job->getId()], UrlGeneratorInterface::ABSOLUTE_PATH),
+                'jobUrl' => $this->generateUrl(Routes::JOB_START, ['job' => $job->getId()]),
+                'url' => $this->generateUrl(Routes::JOB_STATUS, ['job' => $job->getId()]),
             ]);
-        } catch (\Throwable $e) {
-            $this->logger->error('log.data.job.initialize_failed', [
-                EmsFields::LOG_CONTENTTYPE_FIELD => $template->giveContentType()->getName(),
-                EmsFields::LOG_OUUID_FIELD => $ouuid,
-                EmsFields::LOG_ERROR_MESSAGE_FIELD => $e->getMessage(),
-                EmsFields::LOG_EXCEPTION_FIELD => $e,
-                'template_name' => $template->getName(),
-                'template_label' => $template->getLabel(),
-                'environment' => $env->getLabel(),
-            ]);
+        } catch (\Throwable) {
+            return EmsCoreResponse::createJsonResponse($request, false);
         }
-
-        $response = $this->flashMessageLogger->buildJsonResponse([
-            'success' => $success,
-        ]);
-        $response->headers->set('Content-Type', 'application/json');
-
-        return $response;
     }
 
     public function ajaxUpdate(int $revisionId, Request $request, PublishService $publishService): Response

--- a/EMS/core-bundle/src/Routes.php
+++ b/EMS/core-bundle/src/Routes.php
@@ -85,6 +85,8 @@ class Routes
     final public const string I18N_ADD = 'emsco_i18n_add';
     final public const string I18N_EDIT = 'emsco_i18n_edit';
     final public const string I18N_DELETE = 'emsco_i18n_delete';
+    final public const string JOB_START = 'emsco_job_start';
+    final public const string JOB_STATUS = 'emsco_job_status';
     final public const string RELEASE_INDEX = 'emsco_release_index';
     final public const string RELEASE_VIEW = 'emsco_release_view';
     final public const string RELEASE_ADD = 'emsco_release_add';

--- a/EMS/core-bundle/src/Service/ActionService.php
+++ b/EMS/core-bundle/src/Service/ActionService.php
@@ -5,15 +5,82 @@ declare(strict_types=1);
 namespace EMS\CoreBundle\Service;
 
 use EMS\CommonBundle\Entity\EntityInterface;
+use EMS\CommonBundle\Helper\EmsFields;
 use EMS\CoreBundle\Entity\ContentType;
+use EMS\CoreBundle\Entity\Environment;
+use EMS\CoreBundle\Entity\Job;
 use EMS\CoreBundle\Entity\Template;
+use EMS\CoreBundle\Form\Field\RenderOptionType;
 use EMS\CoreBundle\Repository\TemplateRepository;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Twig\Environment as Twig;
 
 final readonly class ActionService implements EntityServiceInterface
 {
-    public function __construct(private TemplateRepository $templateRepository, private LoggerInterface $logger)
+    public function __construct(
+        private TemplateRepository $templateRepository,
+        private LoggerInterface $logger,
+        private SearchService $searchService,
+        private Twig $twig,
+        private JobService $jobService,
+    ) {
+    }
+
+    public function giveById(int $id): Template
     {
+        if (null === $action = $this->templateRepository->findOneBy(['id' => $id])) {
+            throw new \RuntimeException(\sprintf('Action with id "%s" could not be found.', $id));
+        }
+
+        return $action;
+    }
+
+    public function executeJobAction(UserInterface $user, Template $jobAction, string $uuid, ?Environment $environment): Job
+    {
+        try {
+            if (RenderOptionType::JOB !== $jobAction->getRenderOption()) {
+                throw new \RuntimeException('Expected render option job action.');
+            }
+
+            $contentType = $jobAction->giveContentType();
+            $environment ??= $contentType->giveEnvironment();
+
+            $document = $this->searchService->getDocument($contentType, $uuid, $environment);
+
+            $command = $this->twig->createTemplate($jobAction->getBody())->render([
+                'environment' => $environment->getName(),
+                'contentType' => $contentType,
+                'object' => $document,
+                'source' => $document->getSource(),
+            ]);
+
+            $job = $this->jobService->createCommand($user, $command, $jobAction->getTag());
+
+            $this->logger->notice('log.data.job.initialized', [
+                EmsFields::LOG_CONTENTTYPE_FIELD => $contentType->getName(),
+                EmsFields::LOG_OPERATION_FIELD => EmsFields::LOG_OPERATION_UPDATE,
+                EmsFields::LOG_OUUID_FIELD => $uuid,
+                'template_id' => $jobAction->getId(),
+                'job_id' => $job->getId(),
+                'template_name' => $jobAction->getName(),
+                'template_label' => $jobAction->getLabel(),
+                'environment' => $environment->getLabel(),
+            ]);
+
+            return $job;
+        } catch (\Throwable $e) {
+            $this->logger->error('log.data.job.initialize_failed', [
+                EmsFields::LOG_CONTENTTYPE_FIELD => $jobAction->giveContentType()->getName(),
+                EmsFields::LOG_OUUID_FIELD => $uuid,
+                EmsFields::LOG_ERROR_MESSAGE_FIELD => $e->getMessage(),
+                EmsFields::LOG_EXCEPTION_FIELD => $e,
+                'template_name' => $jobAction->getName(),
+                'template_label' => $jobAction->getLabel(),
+                'environment' => $environment?->getLabel(),
+            ]);
+            throw $e;
+        }
     }
 
     /**


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  n |
| New feature?   | y  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Introduced an API route for starting an action job on a specific document. While testing, it became clear that the emsco_job Twig function provides a simpler solution for triggering these jobs.

Even though the API route is no longer the preferred approach, this refactoring remains valuable as it moves the controller logic for executing an action into the service layer, improving separation of concerns and maintainability.


