### PR TITLE
feat(common/spreadsheet): support excel date fields

### DIFF
--- a/EMS/common-bundle/src/Common/Spreadsheet/Cell.php
+++ b/EMS/common-bundle/src/Common/Spreadsheet/Cell.php
@@ -6,13 +6,12 @@ namespace EMS\CommonBundle\Common\Spreadsheet;
 
 readonly class Cell
 {
-    public const string TYPE_DATE = 'date';
-
     public const string CELL_DATA = 'data';
+    public const string CELL_FORMAT_DISPLAY = 'format_display';
+    public const string CELL_FORMAT_INPUT = 'format_input';
     public const string CELL_STYLE = 'style';
     public const string CELL_TYPE = 'type';
-    public const string CELL_FORMAT_INPUT = 'format_input';
-    public const string CELL_FORMAT_DISPLAY = 'format_display';
+    public const string TYPE_DATE = 'date';
 
     /** @param array<mixed> $style */
     public function __construct(
@@ -24,13 +23,13 @@ readonly class Cell
     ) {
     }
 
-    public function isType(string $type): bool
-    {
-        return $this->type === $type;
-    }
-
     public function hasStyle(): bool
     {
         return \count($this->style) > 0;
+    }
+
+    public function isType(string $type): bool
+    {
+        return $this->type === $type;
     }
 }

--- a/EMS/common-bundle/src/Common/Spreadsheet/Cell.php
+++ b/EMS/common-bundle/src/Common/Spreadsheet/Cell.php
@@ -4,8 +4,16 @@ declare(strict_types=1);
 
 namespace EMS\CommonBundle\Common\Spreadsheet;
 
-readonly class SpreadsheetCell
+readonly class Cell
 {
+    public const string TYPE_DATE = 'date';
+
+    public const string CELL_DATA = 'data';
+    public const string CELL_STYLE = 'style';
+    public const string CELL_TYPE = 'type';
+    public const string CELL_FORMAT_INPUT = 'format_input';
+    public const string CELL_FORMAT_DISPLAY = 'format_display';
+
     /** @param array<mixed> $style */
     public function __construct(
         public string $data,

--- a/EMS/common-bundle/src/Common/Spreadsheet/Cell.php
+++ b/EMS/common-bundle/src/Common/Spreadsheet/Cell.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace EMS\CommonBundle\Common\Spreadsheet;
 
-class SpreadsheetCell
+readonly class SpreadsheetCell
 {
     /** @param array<mixed> $style */
     public function __construct(

--- a/EMS/common-bundle/src/Common/Spreadsheet/SpreadsheetCell.php
+++ b/EMS/common-bundle/src/Common/Spreadsheet/SpreadsheetCell.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CommonBundle\Common\Spreadsheet;
+
+class SpreadsheetCell
+{
+    /** @param array<mixed> $style */
+    public function __construct(
+        public string $data,
+        public array $style = [],
+        public ?string $type = null,
+        public ?string $formatInput = null,
+        public ?string $formatDisplay = null,
+    ) {
+    }
+
+    public function isType(string $type): bool
+    {
+        return $this->type === $type;
+    }
+
+    public function hasStyle(): bool
+    {
+        return \count($this->style) > 0;
+    }
+}

--- a/EMS/common-bundle/src/Common/Spreadsheet/SpreadsheetGeneratorService.php
+++ b/EMS/common-bundle/src/Common/Spreadsheet/SpreadsheetGeneratorService.php
@@ -114,9 +114,7 @@ final class SpreadsheetGeneratorService implements SpreadsheetGeneratorServiceIn
                         $sheet->setDataValidation($cellCoordinate, $validation);
                     }
 
-                    $value = \is_array($value) ? $value : [self::CELL_DATA => $value];
-                    $cell = $this->resolveOptionsCell($value);
-                    $this->addCell($sheet, $cellCoordinate, $cell);
+                    $this->addCell($sheet, $cellCoordinate, $this->buildCellFromValue($value));
 
                     ++$k;
                     $maxCol = $k > $maxCol ? $k : $maxCol;
@@ -136,21 +134,21 @@ final class SpreadsheetGeneratorService implements SpreadsheetGeneratorServiceIn
         return $spreadsheet;
     }
 
-    private function addCell(Worksheet $sheet, string $cellCoordinate, SpreadsheetCell $cell): void
+    private function addCell(Worksheet $sheet, string $cellCoordinate, Cell $cell): void
     {
         $data = $cell->data;
-        if ($cell->isType('date') && '' !== $data && null !== $formatInput = $cell->formatInput) {
+        if ($cell->isType(Cell::TYPE_DATE) && '' !== $data && null !== $formatInput = $cell->formatInput) {
             $data = DateTime::createFromFormat($data, $formatInput)->setTime(0, 0);
             $valueBinder = new DefaultValueBinder();
         }
 
-        $value = $cell->isType('date') ? Date::PHPToExcel($data) : Converter::stringify($data);
+        $value = $cell->isType(Cell::TYPE_DATE) ? Date::PHPToExcel($data) : Converter::stringify($data);
         $sheet->setCellValue($cellCoordinate, $value, $valueBinder ?? null);
 
         if ($cell->hasStyle()) {
             $sheet->getStyle($cellCoordinate)->applyFromArray($cell->style);
         }
-        if ($cell->isType('date') && null !== $formatDisplay = $cell->formatDisplay) {
+        if ($cell->isType(Cell::TYPE_DATE) && null !== $formatDisplay = $cell->formatDisplay) {
             $sheet->getStyle($cellCoordinate)->getNumberFormat()->setFormatCode($formatDisplay);
         }
     }
@@ -196,32 +194,34 @@ final class SpreadsheetGeneratorService implements SpreadsheetGeneratorServiceIn
     /**
      * @param array<mixed> $config
      */
-    private function resolveOptionsCell(array $config): SpreadsheetCell
+    private function buildCellFromValue(string|array $config): Cell
     {
+        $config = \is_array($config) ? $config : [Cell::CELL_DATA => $config];
+
         $resolver = new OptionsResolver();
         $resolver
             ->setDefaults([
-                self::CELL_STYLE => [],
-                self::CELL_TYPE => null,
-                self::CELL_FORMAT_INPUT => null,
-                self::CELL_FORMAT_DISPLAY => null,
+                Cell::CELL_STYLE => [],
+                Cell::CELL_TYPE => null,
+                Cell::CELL_FORMAT_INPUT => null,
+                Cell::CELL_FORMAT_DISPLAY => null,
             ])
-            ->setRequired([self::CELL_DATA])
-            ->setAllowedValues(self::CELL_TYPE, [null, 'date'])
-            ->setAllowedTypes(self::CELL_STYLE, ['array'])
-            ->setAllowedTypes(self::CELL_FORMAT_INPUT, ['null', 'string'])
-            ->setAllowedTypes(self::CELL_FORMAT_DISPLAY, ['null', 'string'])
+            ->setRequired([Cell::CELL_DATA])
+            ->setAllowedValues(Cell::CELL_TYPE, [null, 'date'])
+            ->setAllowedTypes(Cell::CELL_STYLE, ['array'])
+            ->setAllowedTypes(Cell::CELL_FORMAT_INPUT, ['null', 'string'])
+            ->setAllowedTypes(Cell::CELL_FORMAT_DISPLAY, ['null', 'string'])
         ;
 
         /** @var array{data: string, type?: string, style: array<mixed>, format_input?: string, format_display?: string} $resolved */
         $resolved = $resolver->resolve($config);
 
-        return new SpreadsheetCell(
-            $resolved[self::CELL_DATA],
-            $resolved[self::CELL_STYLE],
-            $resolved[self::CELL_TYPE] ?? null,
-            $resolved[self::CELL_FORMAT_INPUT] ?? null,
-            $resolved[self::CELL_FORMAT_DISPLAY] ?? null,
+        return new Cell(
+            $resolved[Cell::CELL_DATA],
+            $resolved[Cell::CELL_STYLE],
+            $resolved[Cell::CELL_TYPE] ?? null,
+            $resolved[Cell::CELL_FORMAT_INPUT] ?? null,
+            $resolved[Cell::CELL_FORMAT_DISPLAY] ?? null,
         );
     }
 

--- a/EMS/common-bundle/src/Common/Spreadsheet/SpreadsheetGeneratorService.php
+++ b/EMS/common-bundle/src/Common/Spreadsheet/SpreadsheetGeneratorService.php
@@ -7,12 +7,15 @@ namespace EMS\CommonBundle\Common\Spreadsheet;
 use EMS\CommonBundle\Common\Converter;
 use EMS\CommonBundle\Contracts\Spreadsheet\SpreadsheetGeneratorServiceInterface;
 use EMS\Helpers\File\TempFile;
+use EMS\Helpers\Standard\DateTime;
 use PhpOffice\PhpSpreadsheet\Cell\AdvancedValueBinder;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Cell\DefaultValueBinder;
 use PhpOffice\PhpSpreadsheet\Cell\StringValueBinder;
 use PhpOffice\PhpSpreadsheet\Settings;
+use PhpOffice\PhpSpreadsheet\Shared\Date;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Psr16Cache;
@@ -103,21 +106,18 @@ final class SpreadsheetGeneratorService implements SpreadsheetGeneratorServiceIn
             foreach ($sheetConfig['rows'] as $row) {
                 $k = 1;
                 foreach ($row as $value) {
+                    $cellCoordinate = Coordinate::stringFromColumnIndex($k).$j;
+
                     if (\array_key_exists('validations', $sheetConfig) && null != $sheetConfig['validations'][$k - 1]) {
                         $spreadsheetValidation = $sheetConfig['validations'][$k - 1];
-                        $validation = $spreadsheetValidation->addValidation($sheet->getCell(Coordinate::stringFromColumnIndex($k).$j)->getDataValidation());
-                        $sheet->setDataValidation(Coordinate::stringFromColumnIndex($k).$j, $validation);
+                        $validation = $spreadsheetValidation->addValidation($sheet->getCell($cellCoordinate)->getDataValidation());
+                        $sheet->setDataValidation($cellCoordinate, $validation);
                     }
 
-                    if (!\is_array($value)) {
-                        $value = [self::CELL_DATA => $value];
-                    }
-                    $value = $this->resolveOptionsCell($value);
-                    $sheet->setCellValue(Coordinate::stringFromColumnIndex($k).$j, Converter::stringify($value[self::CELL_DATA]));
-                    if (!empty($value[self::CELL_STYLE])) {
-                        $sheet->getStyle(Coordinate::stringFromColumnIndex($k).$j)
-                            ->applyFromArray($value[self::CELL_STYLE]);
-                    }
+                    $value = \is_array($value) ? $value : [self::CELL_DATA => $value];
+                    $cell = $this->resolveOptionsCell($value);
+                    $this->addCell($sheet, $cellCoordinate, $cell);
+
                     ++$k;
                     $maxCol = $k > $maxCol ? $k : $maxCol;
                 }
@@ -134,6 +134,25 @@ final class SpreadsheetGeneratorService implements SpreadsheetGeneratorServiceIn
         }
 
         return $spreadsheet;
+    }
+
+    private function addCell(Worksheet $sheet, string $cellCoordinate, SpreadsheetCell $cell): void
+    {
+        $data = $cell->data;
+        if ($cell->isType('date') && '' !== $data && null !== $formatInput = $cell->formatInput) {
+            $data = DateTime::createFromFormat($data, $formatInput)->setTime(0, 0);
+            $valueBinder = new DefaultValueBinder();
+        }
+
+        $value = $cell->isType('date') ? Date::PHPToExcel($data) : Converter::stringify($data);
+        $sheet->setCellValue($cellCoordinate, $value, $valueBinder ?? null);
+
+        if ($cell->hasStyle()) {
+            $sheet->getStyle($cellCoordinate)->applyFromArray($cell->style);
+        }
+        if ($cell->isType('date') && null !== $formatDisplay = $cell->formatDisplay) {
+            $sheet->getStyle($cellCoordinate)->getNumberFormat()->setFormatCode($formatDisplay);
+        }
     }
 
     /**
@@ -176,20 +195,34 @@ final class SpreadsheetGeneratorService implements SpreadsheetGeneratorServiceIn
 
     /**
      * @param array<mixed> $config
-     *
-     * @return array{data: string, style: array<mixed>}
      */
-    private function resolveOptionsCell(array $config): array
+    private function resolveOptionsCell(array $config): SpreadsheetCell
     {
         $resolver = new OptionsResolver();
-        $resolver->setDefaults([self::CELL_STYLE => []]);
-        $resolver->setRequired([self::CELL_DATA]);
-        $resolver->setAllowedTypes(self::CELL_STYLE, ['array']);
+        $resolver
+            ->setDefaults([
+                self::CELL_STYLE => [],
+                self::CELL_TYPE => null,
+                self::CELL_FORMAT_INPUT => null,
+                self::CELL_FORMAT_DISPLAY => null,
+            ])
+            ->setRequired([self::CELL_DATA])
+            ->setAllowedValues(self::CELL_TYPE, [null, 'date'])
+            ->setAllowedTypes(self::CELL_STYLE, ['array'])
+            ->setAllowedTypes(self::CELL_FORMAT_INPUT, ['null', 'string'])
+            ->setAllowedTypes(self::CELL_FORMAT_DISPLAY, ['null', 'string'])
+        ;
 
-        /** @var array{data: string, style: array<mixed>} $resolved */
+        /** @var array{data: string, type?: string, style: array<mixed>, format_input?: string, format_display?: string} $resolved */
         $resolved = $resolver->resolve($config);
 
-        return $resolved;
+        return new SpreadsheetCell(
+            $resolved[self::CELL_DATA],
+            $resolved[self::CELL_STYLE],
+            $resolved[self::CELL_TYPE] ?? null,
+            $resolved[self::CELL_FORMAT_INPUT] ?? null,
+            $resolved[self::CELL_FORMAT_DISPLAY] ?? null,
+        );
     }
 
     /**

--- a/EMS/common-bundle/src/Contracts/Spreadsheet/SpreadsheetGeneratorServiceInterface.php
+++ b/EMS/common-bundle/src/Contracts/Spreadsheet/SpreadsheetGeneratorServiceInterface.php
@@ -18,11 +18,6 @@ interface SpreadsheetGeneratorServiceInterface
     public const string SHEETS = 'sheets';
     public const string CONTENT_FILENAME = 'filename';
     public const string CONTENT_DISPOSITION = 'disposition';
-    public const string CELL_DATA = 'data';
-    public const string CELL_STYLE = 'style';
-    public const string CELL_TYPE = 'type';
-    public const string CELL_FORMAT_INPUT = 'format_input';
-    public const string CELL_FORMAT_DISPLAY = 'format_display';
     public const string VALUE_BINDER = 'value_binder';
 
     /**

--- a/EMS/common-bundle/src/Contracts/Spreadsheet/SpreadsheetGeneratorServiceInterface.php
+++ b/EMS/common-bundle/src/Contracts/Spreadsheet/SpreadsheetGeneratorServiceInterface.php
@@ -9,17 +9,21 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 
 interface SpreadsheetGeneratorServiceInterface
 {
-    public const WRITER = 'writer';
-    public const XLSX_WRITER = 'xlsx';
-    public const CSV_WRITER = 'csv';
-    public const FORMAT_WRITERS = [self::CSV_WRITER, self::XLSX_WRITER];
-    public const CSV_SEPARATOR = 'csv_separator';
-    public const SHEETS = 'sheets';
-    public const CONTENT_FILENAME = 'filename';
-    public const CONTENT_DISPOSITION = 'disposition';
-    public const CELL_DATA = 'data';
-    public const CELL_STYLE = 'style';
-    public const VALUE_BINDER = 'value_binder';
+    public const string WRITER = 'writer';
+    public const string XLSX_WRITER = 'xlsx';
+    public const string CSV_WRITER = 'csv';
+    /** @var string[] */
+    public const array FORMAT_WRITERS = [self::CSV_WRITER, self::XLSX_WRITER];
+    public const string CSV_SEPARATOR = 'csv_separator';
+    public const string SHEETS = 'sheets';
+    public const string CONTENT_FILENAME = 'filename';
+    public const string CONTENT_DISPOSITION = 'disposition';
+    public const string CELL_DATA = 'data';
+    public const string CELL_STYLE = 'style';
+    public const string CELL_TYPE = 'type';
+    public const string CELL_FORMAT_INPUT = 'format_input';
+    public const string CELL_FORMAT_DISPLAY = 'format_display';
+    public const string VALUE_BINDER = 'value_binder';
 
     /**
      * @param array<mixed> $config

--- a/docs/dev/common-bundle/spreadsheet.md
+++ b/docs/dev/common-bundle/spreadsheet.md
@@ -1,6 +1,9 @@
+# Spreadsheets
+
 In Twig you can set the spreadsheet options by generating a JSON
 
 Two writer are supported:
+
 - `xlsx`: Generate a Microsoft Excel file
 - `csv`: Generate a CSV file
 
@@ -31,13 +34,18 @@ Two writer are supported:
 {{- config|json_encode|raw -}}
 ```
 
+## Value binders
+
 The `value_binder` config allows following values:
+
 - `null`: use DefaultValueBinder
 - `string`: use StringValueBinder
 - `advanced`: use AdvancedValueBinder
 
-More info about [value binders](https://phpspreadsheet.readthedocs.io/en/latest/topics/accessing-cells/#using-value-binders-to-facilitate-data-entry).
+More info
+about [value binders](https://phpspreadsheet.readthedocs.io/en/latest/topics/accessing-cells/#using-value-binders-to-facilitate-data-entry).
 
+## Style cells
 
 Different config for definition of Cell are available (config may be mixed up)
 
@@ -55,6 +63,7 @@ Different config for definition of Cell are available (config may be mixed up)
         ],
     ]
 ```
+
 - `with style`: need an array { "data" : "stringValue", "style" : [] }
 
 ```twig
@@ -92,4 +101,41 @@ Different config for definition of Cell are available (config may be mixed up)
     ]
 
 ```
-- More information of style (styleArray only): [refers to Phpspreadsheet Documentation](https://phpspreadsheet.readthedocs.io/en/latest/topics/recipes/#styles)
+
+- More information of style (styleArray
+  only): [refers to Phpspreadsheet Documentation](https://phpspreadsheet.readthedocs.io/en/latest/topics/recipes/#styles)
+
+## Date cells
+
+When dates are exported as strings, all cells in the column will initially
+contain string values. However, if a user edits one of these cells in Excel,
+that specific cell is automatically converted into a real date value, while the
+others remain strings.
+As a result, the column ends up containing mixed data types.
+When reading the file back, the edited cell is interpreted as a numeric date (
+Excel stores dates internally as integers) and will therefore be returned in the
+m/d/Y format.
+
+To avoid mixed data types, any value that represents a date should be stored as
+a proper date type instead of a string.
+
+Define:
+
+- Type: date
+- Format input: use by php for converting the data into a \DateTime object
+- Format display: use by formatting the object in excel
+
+```json
+{
+  "rows": [
+    [
+      {
+        "data": "23/08/2025",
+        "type": "date",
+        "format_input": "d/m/Y",
+        "format_display": "dd/mm/yyyy"
+      }
+    ]
+  ]
+}
+```


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | n  |
| New feature?   | y  |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

This PR fixes inconsistent handling of dates in exported Excel files.

**Problem:**
Previously, dates were exported as strings. If a user modified one of these cells in Excel, the edited value was automatically converted into a real date, while the other cells remained strings.
This resulted in mixed data types within the same column. When reading the file back, Excel interpreted the modified value as a numeric date (since dates are internally stored as integers), which was then returned in m/d/Y format.



