### PR TITLE
fix(common/spreadsheet): allow mixed as cell value

### DIFF
--- a/EMS/common-bundle/src/Common/Spreadsheet/Cell.php
+++ b/EMS/common-bundle/src/Common/Spreadsheet/Cell.php
@@ -15,7 +15,7 @@ readonly class Cell
 
     /** @param array<mixed> $style */
     public function __construct(
-        public string $data,
+        public mixed $data,
         public array $style = [],
         public ?string $type = null,
         public ?string $formatInput = null,

--- a/EMS/common-bundle/src/Common/Spreadsheet/SpreadsheetGeneratorService.php
+++ b/EMS/common-bundle/src/Common/Spreadsheet/SpreadsheetGeneratorService.php
@@ -190,7 +190,7 @@ final class SpreadsheetGeneratorService implements SpreadsheetGeneratorServiceIn
 
         return $resolved;
     }
-    
+
     private function buildCellFromValue(mixed $config): Cell
     {
         $config = \is_array($config) ? $config : [Cell::CELL_DATA => $config];
@@ -210,7 +210,7 @@ final class SpreadsheetGeneratorService implements SpreadsheetGeneratorServiceIn
             ->setAllowedTypes(Cell::CELL_FORMAT_DISPLAY, ['null', 'string'])
         ;
 
-        /** @var array{data: string, type?: string, style: array<mixed>, format_input?: string, format_display?: string} $resolved */
+        /** @var array{data: mixed, type?: string, style: array<mixed>, format_input?: string, format_display?: string} $resolved */
         $resolved = $resolver->resolve($config);
 
         return new Cell(

--- a/EMS/common-bundle/src/Common/Spreadsheet/SpreadsheetGeneratorService.php
+++ b/EMS/common-bundle/src/Common/Spreadsheet/SpreadsheetGeneratorService.php
@@ -190,11 +190,8 @@ final class SpreadsheetGeneratorService implements SpreadsheetGeneratorServiceIn
 
         return $resolved;
     }
-
-    /**
-     * @param array<mixed> $config
-     */
-    private function buildCellFromValue(string|array $config): Cell
+    
+    private function buildCellFromValue(mixed $config): Cell
     {
         $config = \is_array($config) ? $config : [Cell::CELL_DATA => $config];
 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Passing int or float from twig was caushing an issue, because the code only allows array or strings
