### PR TITLE
fix(web/sso): env variable SESSION_COOKIE_SAMESITE

### DIFF
--- a/docs/elasticms-web/parameters.md
+++ b/docs/elasticms-web/parameters.md
@@ -24,6 +24,14 @@ A secret seed.
 
 Define the max connections to the API client, when using async calls. By default it is set to `4`.
 
+### SESSION_COOKIE_SAMESITE
+
+By default, this option is set to `strict`. However, when using Single Sign-On (
+SSO) with Keycloak on a different domain, you need to change it to `lax` to
+ensure that cross-domain authentication cookies work correctly. See
+the [Symfony session configuration documentation](https://symfony.com/doc/current/session.html#cookie-samesite)
+for more details.
+
 ### Behind a Load Balancer or a Reverse Proxy
 
 ```dotenv

--- a/docs/elasticms-web/security.md
+++ b/docs/elasticms-web/security.md
@@ -86,6 +86,8 @@ Enable a dev IDP see [dev-env](/getting-started/dev-env.md#identity-provider-idp
 
 Note: the current SSO implementation does only support the login. The logout on the IDP was not required.
 
+!> If Keycloak runs on a different domain, you need to set the environment variable [SESSION_COOKIE_SAMESITE](/elasticms-web/parameters.md#SESSION_COOKIE_SAMESITE) to lax.
+
 ## Implementation
 
 > See the demo project for a full implementation.

--- a/docs/getting-started/dev-env.md
+++ b/docs/getting-started/dev-env.md
@@ -194,7 +194,9 @@ EMSCH_SAML_IDP_PUBLIC_KEY='MIICoTCCAYkCBgGGOshSgDANBgkqhkiG9w0BAQsFADAUMRIwEAYDV
 EMSCH_SAML_IDP_SSO='http://keycloak.localhost/realms/elasticms/protocol/saml'
 ```
 
-> *IMPORT* For using xDebug change http://keycloak.localhost -> http://localhost:9081
+!> For using xDebug change http://keycloak.localhost -> http://localhost:9081
+
+!> If Keycloak runs on a different domain, you need to set the environment variable [SESSION_COOKIE_SAMESITE](/elasticms-web/parameters.md#SESSION_COOKIE_SAMESITE) to lax.
 
 | Variable                          | Location                                                                                                                                           |
 |-----------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/elasticms-web/config/packages/framework.yaml
+++ b/elasticms-web/config/packages/framework.yaml
@@ -1,5 +1,6 @@
 parameters:
     env(DEFAULT_LOCAL): 'en'
+    env(SESSION_COOKIE_SAMESITE): strict
     env(HTTP_CLIENT_MAX_CONNECTIONS): 4
 
 framework:
@@ -14,7 +15,7 @@ framework:
     session:
         handler_id: ~
         cookie_secure: auto
-        cookie_samesite: strict
+        cookie_samesite: '%env(SESSION_COOKIE_SAMESITE)%'
         storage_factory_id: session.storage.factory.native
 
     esi: true


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

This PR introduces support for the SESSION_COOKIE_SAMESITE environment variable.

Default behavior: SESSION_COOKIE_SAMESITE is set to strict, which provides strong CSRF protection.

New option: When using Single Sign-On (SSO) with Keycloak on a different domain, this variable can now be configured as lax to allow cross-domain authentication cookies.

https://symfony.com/doc/current/reference/configuration/framework.html#cookie-samesite


