### PR TITLE
fix(admin/session): cookie_samesite lax

### DIFF
--- a/elasticms-admin/config/packages/framework.yaml
+++ b/elasticms-admin/config/packages/framework.yaml
@@ -15,7 +15,7 @@ framework:
     session:
         handler_id: ~
         cookie_secure: auto
-        cookie_samesite: strict
+        cookie_samesite: lax
         storage_factory_id: session.storage.factory.native
 
     esi: true


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Setting the cookie_samesite to lax makes links to the admin not redirecting to the login page.
