### PR TITLE
fix(admin/channel): new option prefix_instance_id

### DIFF
--- a/EMS/admin-ui-bundle/templates/bootstrap5/datatable/template_block_columns.html.twig
+++ b/EMS/admin-ui-bundle/templates/bootstrap5/datatable/template_block_columns.html.twig
@@ -144,8 +144,7 @@
 
 {%- block channel_alias -%}
     {%- if line.data.options.prefix_instance_id|default(false) -%}
-        {{ ems_instance_id }}{{ line.data.alias }}
-    {%- else -%}
-        {{ line.data.alias }}
+        {{- ems_instance_id -}}
     {%- endif -%}
+    {{- line.data.alias -}}
 {%- endblock channel_alias -%}

--- a/EMS/admin-ui-bundle/templates/bootstrap5/datatable/template_block_columns.html.twig
+++ b/EMS/admin-ui-bundle/templates/bootstrap5/datatable/template_block_columns.html.twig
@@ -141,3 +141,11 @@
         }) -}}
     {%- endif -%}
 {% endblock release_unpublish_target %}
+
+{%- block channel_alias -%}
+    {%- if line.data.options.prefix_instance_id|default(false) -%}
+        {{ ems_instance_id }}{{ line.data.alias }}
+    {%- else -%}
+        {{ line.data.alias }}
+    {%- endif -%}
+{%- endblock channel_alias -%}

--- a/EMS/core-bundle/config/datatable.xml
+++ b/EMS/core-bundle/config/datatable.xml
@@ -113,6 +113,7 @@
         </service>
         <service id="emsco.data_table.channel" class="EMS\CoreBundle\DataTable\Type\ChannelDataTableType">
             <argument type="service" id="ems.service.channel"/>
+            <argument>%ems_core.template_namespace%</argument>
             <tag name="emsco.datatable" />
         </service>
         <service id="emsco.data_table.wysiwygProfile" class="EMS\CoreBundle\DataTable\Type\Wysiwyg\WysiwygProfileDataTableType">

--- a/EMS/core-bundle/config/services.xml
+++ b/EMS/core-bundle/config/services.xml
@@ -69,6 +69,7 @@
             <argument type="service" id="logger"/>
             <argument type="service" id="ems.service.index"/>
             <argument>%ems_core.security.firewall.core%</argument>
+            <argument>%ems_core.instance_id%</argument>
         </service>
         <service id="emsco.data_table.type.collection" class="EMS\CoreBundle\Core\DataTable\Type\DataTableTypeCollection">
             <argument type="tagged_iterator" tag="emsco.datatable" />

--- a/EMS/core-bundle/src/DataTable/Type/ChannelDataTableType.php
+++ b/EMS/core-bundle/src/DataTable/Type/ChannelDataTableType.php
@@ -8,6 +8,7 @@ use EMS\CoreBundle\Core\DataTable\Type\AbstractEntityTableType;
 use EMS\CoreBundle\Entity\Channel;
 use EMS\CoreBundle\Form\Data\BoolTableColumn;
 use EMS\CoreBundle\Form\Data\EntityTable;
+use EMS\CoreBundle\Form\Data\TemplateBlockTableColumn;
 use EMS\CoreBundle\Roles;
 use EMS\CoreBundle\Service\Channel\ChannelService;
 
@@ -17,7 +18,7 @@ class ChannelDataTableType extends AbstractEntityTableType
 {
     use DataTableTypeTrait;
 
-    public function __construct(ChannelService $entityService)
+    public function __construct(ChannelService $entityService, private readonly string $templateNamespace)
     {
         parent::__construct($entityService);
     }
@@ -31,7 +32,13 @@ class ChannelDataTableType extends AbstractEntityTableType
             target: '_blank'
         );
 
-        $table->addColumn(t('field.alias', [], 'emsco-core'), 'alias');
+        $table->addColumnDefinition(
+            new TemplateBlockTableColumn(
+                label: t('field.alias', [], 'emsco-core'),
+                blockName: 'channel_alias',
+                template: "@$this->templateNamespace/datatable/template_block_columns.html.twig"
+            )
+        );
         $table->addColumnDefinition(new BoolTableColumn(t('field.public_access', [], 'emsco-core'), 'public'));
 
         $this

--- a/EMS/core-bundle/src/DependencyInjection/EMSCoreExtension.php
+++ b/EMS/core-bundle/src/DependencyInjection/EMSCoreExtension.php
@@ -99,6 +99,7 @@ class EMSCoreExtension extends Extension implements PrependExtensionInterface
             'theme_color' => $configs[0]['theme_color'] ?? Configuration::THEME_COLOR,
             'ems_name' => $configs[0]['name'] ?? Configuration::NAME,
             'ems_shortname' => $configs[0]['shortname'] ?? Configuration::SHORTNAME,
+            'ems_instance_id' => $configs[0]['instance_id'] ?? Configuration::INSTANCE_ID,
             'paging_size' => $configs[0]['paging_size'] ?? Configuration::PAGING_SIZE,
             'circles_object' => $configs[0]['circles_object'] ?? Configuration::CIRCLES_OBJECT,
             'datepicker_daysofweek_highlighted' => $configs[0]['datepicker_daysofweek_highlighted'] ?? Configuration::DATEPICKER_DAYSOFWEEK_HIGHLIGHTED,

--- a/EMS/core-bundle/src/Form/DataTransformer/ChannelOptionsTransformer.php
+++ b/EMS/core-bundle/src/Form/DataTransformer/ChannelOptionsTransformer.php
@@ -19,6 +19,7 @@ final class ChannelOptionsTransformer implements DataTransformerInterface
         $attributes = $this->jsonFormat($value, 'attributes');
 
         return [
+            'prefix_instance_id' => $value['prefix_instance_id'] ?? false,
             'searchConfig' => $searchConfig,
             'entryPath' => $value['entryPath'] ?? null,
             'attributes' => $attributes,
@@ -29,6 +30,7 @@ final class ChannelOptionsTransformer implements DataTransformerInterface
     public function reverseTransform($value)
     {
         return [
+            'prefix_instance_id' => $value['prefix_instance_id'] ?? '',
             'searchConfig' => $value['searchConfig'] ?? '',
             'entryPath' => $value['entryPath'] ?? '',
             'attributes' => $value['attributes'] ?? '',

--- a/EMS/core-bundle/src/Form/Subform/ChannelOptionsType.php
+++ b/EMS/core-bundle/src/Form/Subform/ChannelOptionsType.php
@@ -6,6 +6,7 @@ namespace EMS\CoreBundle\Form\Subform;
 
 use EMS\CoreBundle\Form\Field\CodeEditorType;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 use function Symfony\Component\Translation\t;
@@ -23,6 +24,13 @@ final class ChannelOptionsType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
+            ->add('prefix_instance_id', CheckboxType::class, [
+                'label' => t('key.prefix_instance_id', [], 'emsco-core'),
+                'required' => false,
+                'row_attr' => [
+                    'class' => 'col-md-12',
+                ],
+            ])
             ->add('entryPath', null, [
                 'label' => t('field.entry_path', [], 'emsco-core'),
                 'required' => false,

--- a/EMS/core-bundle/src/Service/Channel/ChannelRegistrar.php
+++ b/EMS/core-bundle/src/Service/Channel/ChannelRegistrar.php
@@ -23,6 +23,7 @@ final readonly class ChannelRegistrar
         private LoggerInterface $logger,
         private IndexService $indexService,
         private string $firewallName,
+        private string $instanceId
     ) {
     }
 
@@ -46,9 +47,17 @@ final readonly class ChannelRegistrar
         }
 
         $baseUrl = \vsprintf('%s://%s%s', [$request->getScheme(), $request->getHttpHost(), $request->getBasePath()]);
-        $defaultSearchConfigOption = (isset($channel->getOptions()['searchConfig']) && '' !== $channel->getOptions()['searchConfig']) ? $channel->getOptions()['searchConfig'] : '{}';
+
+        $options = $channel->getOptions();
+
+        $prefixInstanceId = $options['prefix_instance_id'] ?? false;
+        if (true === $prefixInstanceId) {
+            $alias = $this->instanceId.$alias;
+        }
+
+        $defaultSearchConfigOption = (isset($options['searchConfig']) && '' !== $options['searchConfig']) ? $options['searchConfig'] : '{}';
         $searchConfig = Json::decode((string) $defaultSearchConfigOption);
-        $defaultAttributesOption = (isset($channel->getOptions()['attributes']) && '' !== $channel->getOptions()['attributes']) ? $channel->getOptions()['attributes'] : '{}';
+        $defaultAttributesOption = (isset($options['attributes']) && '' !== $options['attributes']) ? $options['attributes'] : '{}';
         $attributes = Json::decode((string) $defaultAttributesOption);
 
         if (!$this->indexService->hasIndex($alias)) {

--- a/EMS/core-bundle/templates/datatable/template_block_columns.html.twig
+++ b/EMS/core-bundle/templates/datatable/template_block_columns.html.twig
@@ -145,3 +145,11 @@
         }) -}}
     {%- endif -%}
 {% endblock release_unpublish_target %}
+
+{%- block channel_alias -%}
+    {%- if line.data.options.prefix_instance_id|default(false) -%}
+        {{ ems_instance_id }}{{ line.data.alias }}
+    {%- else -%}
+        {{ line.data.alias }}
+    {%- endif -%}
+{%- endblock channel_alias -%}

--- a/EMS/core-bundle/templates/datatable/template_block_columns.html.twig
+++ b/EMS/core-bundle/templates/datatable/template_block_columns.html.twig
@@ -148,8 +148,7 @@
 
 {%- block channel_alias -%}
     {%- if line.data.options.prefix_instance_id|default(false) -%}
-        {{ ems_instance_id }}{{ line.data.alias }}
-    {%- else -%}
-        {{ line.data.alias }}
+        {{- ems_instance_id -}}
     {%- endif -%}
+    {{- line.data.alias -}}
 {%- endblock channel_alias -%}

--- a/EMS/core-bundle/translations/emsco-core+intl-icu.en.yml
+++ b/EMS/core-bundle/translations/emsco-core+intl-icu.en.yml
@@ -280,6 +280,7 @@ key:
     orphan_indexes: 'Orphan indexes'
     overview: Overview
     portrait: Portrait
+    prefix_instance_id: 'Prefix alias with instance ID'
     public_channel: 'Make channel available for non-authenticated users ?'
     public_view: 'Publicly available (without authentication)'
     publishers: Publishers


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | y  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Running multiple admins with the same configuration but different instance_id currently causes issues with the channels, because the alias is hardcoded.
The solution is to allow prefixing the alias with the instance_id. This can be enabled by selecting the option “Prefix with instance ID”. By default, this option is disabled.
