### PR TITLE
fix(common/zip): disable defaultEnableZeroHeader for zipStream

### DIFF
--- a/EMS/common-bundle/src/Storage/Processor/Zip.php
+++ b/EMS/common-bundle/src/Storage/Processor/Zip.php
@@ -23,7 +23,7 @@ class Zip
             throw new \RuntimeException('Unexpected false temporary stream');
         }
 
-        $zip = new ZipStream(OperationMode::NORMAL, '', $stream, CompressionMethod::DEFLATE, 6, false, true);
+        $zip = new ZipStream(OperationMode::NORMAL, '', $stream, CompressionMethod::DEFLATE, 6, false, true, false);
         foreach ($this->config->getFiles() as $file) {
             $zip->addFileFromPsr7Stream($file['filename'], $file['stream']);
         }

--- a/EMS/common-bundle/src/Storage/Processor/Zip.php
+++ b/EMS/common-bundle/src/Storage/Processor/Zip.php
@@ -21,6 +21,9 @@ class Zip
     {
         $file = TempFile::create();
         $stream = \fopen($file->path, 'r+');
+        if (false === $stream) {
+            throw new \RuntimeException('Unexpected false temporary stream');
+        }
 
         $zip = new ZipStream(OperationMode::NORMAL, '', $stream, CompressionMethod::DEFLATE, 6, false, true, false);
         foreach ($this->config->getFiles() as $file) {

--- a/EMS/common-bundle/src/Storage/Processor/Zip.php
+++ b/EMS/common-bundle/src/Storage/Processor/Zip.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EMS\CommonBundle\Storage\Processor;
 
+use EMS\Helpers\File\TempFile;
 use GuzzleHttp\Psr7\Stream;
 use Psr\Http\Message\StreamInterface;
 use ZipStream\CompressionMethod;
@@ -18,10 +19,8 @@ class Zip
 
     public function generate(): StreamInterface
     {
-        $stream = \fopen('php://temp', 'r+');
-        if (false === $stream) {
-            throw new \RuntimeException('Unexpected false temporary stream');
-        }
+        $file = TempFile::create();
+        $stream = \fopen($file->path, 'r+');
 
         $zip = new ZipStream(OperationMode::NORMAL, '', $stream, CompressionMethod::DEFLATE, 6, false, true, false);
         foreach ($this->config->getFiles() as $file) {


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  |  n |
| Fixed tickets? |  n |
| Documentation? | n  |

