### PR TITLE
feat(cli/sync): support sync ems index over skeleton

### DIFF
--- a/EMS/client-helper-bundle/config/routing.xml
+++ b/EMS/client-helper-bundle/config/routing.xml
@@ -61,6 +61,11 @@
             <tag name="controller.service_arguments"/>
         </service>
 
+        <service id="emsch.controller.elasticsearch" class="EMS\ClientHelperBundle\Controller\ElasticsearchController">
+            <argument type="service" id="ems_common.elastica.client" />
+            <tag name="controller.service_arguments"/>
+        </service>
+
         <service id="emsch.controller.spreadsheet" class="EMS\ClientHelperBundle\Controller\SpreadsheetController">
             <argument type="service" id="emsch.routing.handler" />
             <argument type="service" id="ems_common.service.spreadsheet_generator_service"/>

--- a/EMS/client-helper-bundle/config/routing.xml
+++ b/EMS/client-helper-bundle/config/routing.xml
@@ -62,6 +62,7 @@
         </service>
 
         <service id="emsch.controller.elasticsearch" class="EMS\ClientHelperBundle\Controller\ElasticsearchController">
+            <argument type="service" id="emsch.routing.handler" />
             <argument type="service" id="ems_common.elastica.client" />
             <tag name="controller.service_arguments"/>
         </service>

--- a/EMS/client-helper-bundle/src/Controller/ElasticsearchController.php
+++ b/EMS/client-helper-bundle/src/Controller/ElasticsearchController.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\ClientHelperBundle\Controller;
+
+use EMS\CommonBundle\Elasticsearch\Client;
+use EMS\Helpers\Standard\Json;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+class ElasticsearchController
+{
+    public function __construct(
+        private readonly Client $client,
+    ) {
+    }
+
+    public function index(Request $request): JsonResponse
+    {
+        $path = '/'.\rtrim($request->get('path'), '/');
+        $index = $request->get('index');
+
+        $data = '' !== $request->getContent() ? Json::decode($request->getContent()) : [];
+        $query = $request->query->all();
+
+        if (null !== $index && !\preg_match('/^(?![_-])[a-z0-9_-]{1,255}$/', $index)) {
+            throw new \InvalidArgumentException("Invalid index name: $index");
+        }
+
+        return $this->request($index.$path, 'GET', $data, $query);
+    }
+
+    public function scroll(Request $request): JsonResponse
+    {
+        $method = $request->getMethod();
+        $data = '' !== $request->getContent() ? Json::decode($request->getContent()) : [];
+
+        $scroll = $data['scroll'] ?? null;
+        $scrollId = $data['scroll_id'] ?? null;
+
+        if (null === $scrollId) {
+            throw new \InvalidArgumentException("Missing 'scroll_id'");
+        }
+        if (Request::METHOD_GET === $method && null === $scroll) {
+            throw new \InvalidArgumentException("Missing 'scroll'");
+        }
+
+        return $this->request('_search/scroll', $method, match ($method) {
+            Request::METHOD_GET => ['scroll' => $scroll, 'scroll_id' => $scrollId],
+            Request::METHOD_DELETE => ['scroll_id' => $scrollId],
+            default => throw new BadRequestHttpException(),
+        });
+    }
+
+    /**
+     * @param array<mixed> $data
+     * @param array<mixed> $query
+     */
+    private function request(string $path, string $method, array $data = [], array $query = []): JsonResponse
+    {
+        $response = $this->client->request($path, $method, $data, $query);
+
+        return new JsonResponse($response->getData());
+    }
+}

--- a/EMS/client-helper-bundle/src/Controller/ElasticsearchController.php
+++ b/EMS/client-helper-bundle/src/Controller/ElasticsearchController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EMS\ClientHelperBundle\Controller;
 
+use EMS\ClientHelperBundle\Helper\Request\Handler;
 use EMS\CommonBundle\Elasticsearch\Client;
 use EMS\Helpers\Standard\Json;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -13,12 +14,15 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 class ElasticsearchController
 {
     public function __construct(
+        private readonly Handler $handler,
         private readonly Client $client,
     ) {
     }
 
     public function index(Request $request): JsonResponse
     {
+        $this->handler->handleStaticTemplate($request)?->renderBlock('preRequest');
+
         $path = '/'.\rtrim($request->get('path'), '/');
         $index = $request->get('index');
 
@@ -34,6 +38,8 @@ class ElasticsearchController
 
     public function scroll(Request $request): JsonResponse
     {
+        $this->handler->handleStaticTemplate($request)?->renderBlock('preRequest');
+
         $method = $request->getMethod();
         $data = '' !== $request->getContent() ? Json::decode($request->getContent()) : [];
 

--- a/EMS/client-helper-bundle/src/Controller/ElasticsearchController.php
+++ b/EMS/client-helper-bundle/src/Controller/ElasticsearchController.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace EMS\ClientHelperBundle\Controller;
 
+use Elastica\Exception\ConnectionException;
+use Elastica\Exception\ResponseException;
 use EMS\ClientHelperBundle\Helper\Request\Handler;
 use EMS\CommonBundle\Elasticsearch\Client;
 use EMS\Helpers\Standard\Json;
@@ -66,8 +68,12 @@ class ElasticsearchController
      */
     private function request(string $path, string $method, array $data = [], array $query = []): JsonResponse
     {
-        $response = $this->client->request($path, $method, $data, $query);
+        try {
+            $response = $this->client->request($path, $method, $data, $query);
 
-        return new JsonResponse($response->getData());
+            return new JsonResponse($response->getData());
+        } catch (ResponseException|ConnectionException $e) {
+            return new JsonResponse($e->getResponse()->getData(), $e->getResponse()->getStatus());
+        }
     }
 }

--- a/EMS/client-helper-bundle/src/Controller/ElasticsearchController.php
+++ b/EMS/client-helper-bundle/src/Controller/ElasticsearchController.php
@@ -73,7 +73,11 @@ class ElasticsearchController
 
             return new JsonResponse($response->getData());
         } catch (ResponseException|ConnectionException $e) {
-            return new JsonResponse($e->getResponse()->getData(), $e->getResponse()->getStatus());
+            if (null === $response = $e->getResponse()) {
+                throw $e;
+            }
+
+            return new JsonResponse($response->getData(), $response->getStatus());
         }
     }
 }

--- a/EMS/client-helper-bundle/src/Helper/Request/Handler.php
+++ b/EMS/client-helper-bundle/src/Helper/Request/Handler.php
@@ -57,6 +57,15 @@ final readonly class Handler implements HandlerInterface
         );
     }
 
+    public function handleStaticTemplate(Request $request): ?TemplateInterface
+    {
+        if ('[template]' === $this->getRoute($request)->getOption('template')) {
+            return null;
+        }
+
+        return $this->handle($request);
+    }
+
     private function getRoute(Request $request): SymfonyRoute
     {
         $name = $request->attributes->get('_route');

--- a/EMS/common-bundle/src/Command/SynchronizeCommand.php
+++ b/EMS/common-bundle/src/Command/SynchronizeCommand.php
@@ -139,13 +139,13 @@ class SynchronizeCommand extends AbstractCommand
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->io->title(\sprintf('Synchronizing %s to %s', $this->source, $this->target));
-        $this->sourceClient = Synchronizer::create($this->httpClient, $this->source, $this->targetHeaders);
+        $this->sourceClient = Synchronizer::create($this->httpClient, $this->source, $this->sourceHeaders);
         if (!$this->sourceClient->isDefined()) {
             throw new \RuntimeException('Source index not found');
         }
         $this->io->info(\sprintf('Source index %s', $this->sourceClient->getIndex()));
 
-        $this->targetClient = Synchronizer::create($this->httpClient, $this->target, $this->sourceHeaders);
+        $this->targetClient = Synchronizer::create($this->httpClient, $this->target, $this->targetHeaders);
         $this->alignMappings();
         $this->io->info(\sprintf('Target index %s', $this->targetClient->getIndex()));
         $this->synchronizeContentTypes();

--- a/EMS/common-bundle/src/Command/SynchronizeCommand.php
+++ b/EMS/common-bundle/src/Command/SynchronizeCommand.php
@@ -7,7 +7,6 @@ namespace EMS\CommonBundle\Command;
 use Elastica\Aggregation\Max;
 use Elastica\Aggregation\Terms as TermsAggregation;
 use Elastica\Query;
-use Elastica\Query\MatchAll;
 use EMS\CommonBundle\Commands;
 use EMS\CommonBundle\Common\Command\AbstractCommand;
 use EMS\CommonBundle\Elasticsearch\Document\EMSSource;
@@ -219,8 +218,7 @@ class SynchronizeCommand extends AbstractCommand
         $maxFinalized = new Max(self::AGGREGATION_FINALIZED);
         $maxFinalized->setField(EMSSource::FIELD_FINALIZATION_DATETIME);
         $aggregation->addAggregation($maxFinalized);
-        $search = new MatchAll();
-        $query = new Query($search);
+        $query = new Query(['query' => ['bool' => ['must' => []]]]);
         $query->setSize(0);
         $query->addAggregation($aggregation);
 

--- a/EMS/common-bundle/src/Elasticsearch/Sync/Synchronizer.php
+++ b/EMS/common-bundle/src/Elasticsearch/Sync/Synchronizer.php
@@ -128,10 +128,11 @@ class Synchronizer
             ]),
         ]);
         $sourceMappings['_meta'] = $metas;
-        $body = [
-            'mappings' => $sourceMappings,
-            'settings' => $settings,
-        ];
+        $body = ['mappings' => $sourceMappings];
+        if (\count($settings) > 0) {
+            $body['settings'] = $settings;
+        }
+
         $response = Json::decode($client->request('PUT', '', [
             'body' => Json::encode($body),
         ])->getContent());

--- a/docs/dev/client-helper-bundle/routing.md
+++ b/docs/dev/client-helper-bundle/routing.md
@@ -6,11 +6,14 @@
   * [Config Defaults](#config-defaults)
   * [Controllers](#controllers)
     * [Redirect controller](#redirect-controller)
+      * [Redirect a host](#redirect-a-host)
     * [Search controller](#search-controller)
     * [Pdf controller](#pdf-controller)
     * [Spreadsheet controller](#spreadsheet-controller)
     * [Asset controller](#asset-controller)
+    * [ElasticSearch Controller](#elasticsearch-controller)
   * [EMSCH cache (sub-request)](#emsch-cache-sub-request)
+  * [Route to assets in archive](#route-to-assets-in-archive)
 <!-- TOC -->
 
 ## Options
@@ -296,6 +299,42 @@ example_asset:
  - `filename`: File name
  - `headers`: Associative with response headers. 
  - `immutable`: optional for defining if the asset is immutable [devault value = false]
+
+### ElasticSearch Controller
+
+This controller is for proxy an elasticSearch index and scrolling.
+Ideal for using as source argument in the `ems:indexes:synchronize` command.
+
+```yaml
+api_index:
+  config:
+    path: '/api/{index}/{path}'
+    method: [ GET ]
+    requirements: { path: .*, index: 'demo_preview|demo_live' }
+    controller: 'emsch.controller.elasticsearch::index'
+  template_static: template/api.twig
+api_scroll:
+  config:
+    path: '/api/_search/scroll'
+    method: [ GET, DELETE ]
+    requirements: { path: .* }
+    controller: 'emsch.controller.elasticsearch::scroll'
+  template_static: template/api.twig
+```
+
+Defining a `template_static` is optional, but can be used for handling authentication.
+The two methods `index` and `scroll` will first try to render the block named `preRequest`.
+In the following example we secure the api by checking if the authentication token exists in the **APP_API_TOKENS**
+env variable.
+
+```twig
+{%- block preRequest -%}
+    {%- set tokens = app.request.server.all['APP_API_TOKENS']|default('[]')|ems_json_decode -%}
+    {%- set authToken = app.request.headers.get('Authorization', '')|u.trimPrefix('Bearer ')|format -%}
+    
+    {%- if authToken not in tokens -%}{%- do emsch_http_error(403) -%}{%- endif -%}
+{%- endblock preRequest -%}
+```
 
 ## EMSCH cache (sub-request)
 

--- a/elasticms-cli/config/packages/doctrine_migrations.yaml
+++ b/elasticms-cli/config/packages/doctrine_migrations.yaml
@@ -3,4 +3,4 @@ doctrine_migrations:
         # namespace is arbitrary but should be different from App\Migrations
         # as migrations classes should NOT be autoloaded
         'DoctrineMigrations': '%kernel.project_dir%/migrations'
-    enable_profiler: '%kernel.debug%'
+    enable_profiler: false


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | y  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

The source argument is a route of an elastcicms web application.
The web application will proxy the elasticSearch. For this created a new elasticSearchController in the clientHelperBundle with 2 methods (index & scroll): 

```yaml
api_index:
    config:
        path: '/api/{index}/{path}'
        method: [GET]
        requirements: { path: .*, index: 'myapp_preview|myapp_live' }
        controller: 'emsch.controller.elasticsearch::index'
api_scroll:
    config:
        path: '/api/_search/scroll'
        method: [GET, DELETE]
        requirements: { path: .* }
        controller: 'emsch.controller.elasticsearch::scroll'
```

For the `ems:indexes:synchronize` we need to create 2 skeleton routes for allowing index queries and root scrolling (because the command does ../scroll/search. 

```bash
php bin/console ems:indexes:synchronize --source-headers='{"Authorization": "Bearer myTokenSecret"}' --  http://localhost:8882/api/myapp_preview http://localhost:9201/sync_preview

php bin/console ems:indexes:synchronize --source-headers='{"Authorization": "Bearer myTokenSecret"}' --  http://localhost:8882/api/myapp_live http://localhost:9201/sync_live
```

Optional we can define a template_static for handeling authentication. See documentation.

**This functionality is tested on elk8, without any issues**
