### PR TITLE
feat(admin/metric): add jobs pending gauge

### DIFF
--- a/EMS/core-bundle/src/Core/Metric/JobMetricCollector.php
+++ b/EMS/core-bundle/src/Core/Metric/JobMetricCollector.php
@@ -18,8 +18,9 @@ class JobMetricCollector implements MetricCollectorInterface
         ['last_created', 'Timestamp of the last created job'],
         ['last_modified', 'Timestamp of the last modified job'],
         ['count_jobs', 'Count jobs'],
-        ['count_jobs_done', 'Count jobs done'],
+        ['count_jobs_pending', 'Count jobs pending'],
         ['count_jobs_started', 'Count jobs started'],
+        ['count_jobs_done', 'Count jobs done'],
     ];
 
     public function __construct(

--- a/EMS/core-bundle/src/Repository/JobRepository.php
+++ b/EMS/core-bundle/src/Repository/JobRepository.php
@@ -113,8 +113,9 @@ class JobRepository extends EntityRepository
      *     'last_created': string,
      *     'last_modified': string,
      *     'count_jobs': int,
-     *     'count_jobs_done': int,
+     *     'count_jobs_pending': int,
      *     'count_jobs_started': int,
+     *     'count_jobs_done': int
      * }>|list<array<string, mixed>>
      */
     public function summary(): array
@@ -125,8 +126,9 @@ class JobRepository extends EntityRepository
             ->addSelect('max(created) as last_created')
             ->addSelect('max(modified) as last_modified')
             ->addSelect('count(id) as count_jobs')
+            ->addSelect('count(CASE WHEN started = FALSE AND done = FALSE THEN 1 END) AS count_jobs_pending')
+            ->addSelect('count(CASE WHEN started = TRUE AND done = FALSE THEN 1 END) AS count_jobs_started')
             ->addSelect('count(CASE WHEN done = TRUE THEN 1 END) AS count_jobs_done')
-            ->addSelect('count(CASE WHEN started = TRUE THEN 1 END) AS count_jobs_started')
             ->from('job')
             ->groupBy('tag');
 

--- a/docker/monitoring/grafana/dashboards/dashboard_ems.json
+++ b/docker/monitoring/grafana/dashboards/dashboard_ems.json
@@ -338,6 +338,21 @@
                     "legendFormat": "__auto",
                     "range": false,
                     "refId": "Done"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus_datasource"
+                    },
+                    "editorMode": "code",
+                    "exemplar": false,
+                    "expr": "emsco_job_count_jobs_pending",
+                    "format": "table",
+                    "hide": false,
+                    "instant": true,
+                    "legendFormat": "__auto",
+                    "range": false,
+                    "refId": "Pending"
                 }
             ],
             "title": "ElasticMS Jobs",
@@ -358,7 +373,8 @@
                                 "tag",
                                 "Value #Total",
                                 "Value #Started",
-                                "Value #Done"
+                                "Value #Done",
+                                "Value #Pending"
                             ]
                         }
                     }
@@ -369,44 +385,20 @@
                         "excludeByName": {},
                         "includeByName": {},
                         "indexByName": {
-                            "OnGoing": 5,
-                            "Scheduled": 4,
-                            "Value #Done": 2,
-                            "Value #Started": 3,
-                            "Value #Total": 1,
+                            "Value #Done": 3,
+                            "Value #Pending": 1,
+                            "Value #Started": 2,
+                            "Value #Total": 4,
                             "tag": 0
                         },
+                        "orderByMode": "manual",
                         "renameByName": {
                             "NotDone": "Scheduled",
                             "Value #Done": "Done",
+                            "Value #Pending": "Pending",
                             "Value #Started": "Started",
                             "Value #Total": "Total",
                             "tag": "Tag"
-                        }
-                    }
-                },
-                {
-                    "id": "calculateField",
-                    "options": {
-                        "alias": "Planned",
-                        "binary": {
-                            "left": {
-                                "matcher": {
-                                    "id": "byName",
-                                    "options": "Total"
-                                }
-                            },
-                            "operator": "-",
-                            "right": {
-                                "matcher": {
-                                    "id": "byName",
-                                    "options": "Done"
-                                }
-                            }
-                        },
-                        "mode": "binary",
-                        "reduce": {
-                            "reducer": "sum"
                         }
                     }
                 }

--- a/docker/monitoring/prometheus/prometheus.yml
+++ b/docker/monitoring/prometheus/prometheus.yml
@@ -3,5 +3,6 @@ global:
 
 scrape_configs:
     - job_name: 'admin'
+      scrape_interval: 10s
       static_configs:
           - targets: ['host.docker.internal:8881']

--- a/docs/getting-started/dev-env.md
+++ b/docs/getting-started/dev-env.md
@@ -236,6 +236,13 @@ You can see the scrape status at [http://localhost:9090/targets](http://localhos
 
 To allow Prometheus to scrape metrics, the Symfony server needs the `--allow-all-ip` option.
 
+On the admin make sure the following env variables are defined:
+
+```.dotenv
+EMS_METRIC_HOST=host.docker.internal
+EMS_METRIC_PORT=8881
+```
+
 ```bash
 cd docker/monitoring
 docker compose up -d


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  n |
| New feature?   | y  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

For jobs we the following gauge metrics grouped by job tag:
- count_jobs
- count_jobs_pending (started = false and done = false)
- count_jobs_started (started = true and done = false)
- count_jobs_done (done = true)

Also updated the example admin dashboard, and prometheus in mono repo is now scraping with an interval of 10 seconds.
