### PR TITLE
fix(admin/field): keep null attribute for filter option

### DIFF
--- a/EMS/core-bundle/src/Form/Field/FilterOptionsType.php
+++ b/EMS/core-bundle/src/Form/Field/FilterOptionsType.php
@@ -211,8 +211,7 @@ class FilterOptionsType extends AbstractType
 
                 return $tagsAsArray;
             },
-            fn ($tagsAsString) => // transform the string back to an array
-\explode(', ', (string) $tagsAsString)
+            fn ($tagsAsString) => null === $tagsAsString ? null : \explode(', ', (string) $tagsAsString)
         );
 
         $builder->get('articles')->addModelTransformer($textArea2Array);


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  |  n |
| Fixed tickets? | n  |
| Documentation? | n  |

Don't explode a null attribute into an array (might breaks the mapping)