### PR TITLE
fix(demo): title mapping, docker image and version 6.8.0

### DIFF
--- a/demo/.env
+++ b/demo/.env
@@ -1,7 +1,7 @@
 # Project namespace (defaults to the current folder name if not set)
 COMPOSE_PROJECT_NAME=elasticms_demo
 
-EMS_VERSION=6.0.0
+EMS_VERSION=6.8.0
 INSTANCE_ID='ems_demo_'
 EMS_BACKEND_URL=http://local.ems-demo-admin:9000
 EMS_ADMIN_URL=http://local.ems-demo-admin.localhost

--- a/demo/configs/admin/content-type/link.json
+++ b/demo/configs/admin/content-type/link.json
@@ -206,7 +206,7 @@
                                                             "icon": null
                                                         },
                                                         "mappingOptions": {
-                                                            "analyzer": "keyword",
+                                                            "analyzer": null,
                                                             "copy_to": "live_search"
                                                         },
                                                         "restrictionOptions": {

--- a/demo/configs/admin/content-type/page.json
+++ b/demo/configs/admin/content-type/page.json
@@ -204,7 +204,6 @@
                                                             "icon": null
                                                         },
                                                         "mappingOptions": {
-                                                            "index": null,
                                                             "analyzer": null,
                                                             "copy_to": "live_search"
                                                         },

--- a/demo/docker-elk7.yml
+++ b/demo/docker-elk7.yml
@@ -1,12 +1,12 @@
 services:
   setup_elk:
-    image: elastic/elasticsearch:${ELK7_STACK_VERSION}
+    image: elasticsearch:${ELK7_STACK_VERSION}
     command: >
       bash -c '
         echo "All done!";
       '
   es01:
-    image: elastic/elasticsearch:${ELK7_STACK_VERSION}
+    image: elasticsearch:${ELK7_STACK_VERSION}
     environment:
       - node.name=es01
       - cluster.name=es7-docker-cluster
@@ -24,7 +24,7 @@ services:
       - elk7_data01:/usr/share/elasticsearch/data
     mem_limit: ${MEM_LIMIT}
   es02:
-    image: elastic/elasticsearch:${ELK7_STACK_VERSION}
+    image: elasticsearch:${ELK7_STACK_VERSION}
     environment:
       - node.name=es02
       - cluster.name=es7-docker-cluster
@@ -42,7 +42,7 @@ services:
       - elk7_data02:/usr/share/elasticsearch/data
     mem_limit: ${MEM_LIMIT}
   es03:
-    image: elastic/elasticsearch:${ELK7_STACK_VERSION}
+    image: elasticsearch:${ELK7_STACK_VERSION}
     environment:
       - node.name=es03
       - cluster.name=es7-docker-cluster
@@ -60,7 +60,7 @@ services:
       - elk7_data03:/usr/share/elasticsearch/data
     mem_limit: ${MEM_LIMIT}
   kibana:
-    image: elastic/kibana:${ELK7_STACK_VERSION}
+    image: kibana:${ELK7_STACK_VERSION}
     environment:
       - TZ=Europe/Brussels
       - ELASTICSEARCH_HOSTS=http://es01:9200


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

 * align *.title mappings between page and link, the demo content type can't be activated in the demo
 * don't use the elastic repo that requires an authentication now
 * demo should use the version 6.8.0
