### PR TITLE
feat(admin/metrics): add failed job metrics

### DIFF
--- a/EMS/core-bundle/src/Core/Metric/JobMetricCollector.php
+++ b/EMS/core-bundle/src/Core/Metric/JobMetricCollector.php
@@ -49,7 +49,7 @@ class JobMetricCollector implements MetricCollectorInterface
                     $value = (float) $info[$name];
                 }
 
-                $gauge->set($value, [$info['tag'] ?? 'admin']);
+                $gauge->set($value, [$info['tag'] ?? '_admin']);
             }
         }
     }

--- a/EMS/core-bundle/src/Core/Metric/JobMetricCollector.php
+++ b/EMS/core-bundle/src/Core/Metric/JobMetricCollector.php
@@ -21,6 +21,7 @@ class JobMetricCollector implements MetricCollectorInterface
         ['count_jobs_pending', 'Count jobs pending'],
         ['count_jobs_started', 'Count jobs started'],
         ['count_jobs_done', 'Count jobs done'],
+        ['count_jobs_failed', 'Count jobs failed'],
     ];
 
     public function __construct(
@@ -48,7 +49,7 @@ class JobMetricCollector implements MetricCollectorInterface
                     $value = (float) $info[$name];
                 }
 
-                $gauge->set($value, [$info['tag'] ?? '']);
+                $gauge->set($value, [$info['tag'] ?? 'admin']);
             }
         }
     }

--- a/EMS/core-bundle/src/Repository/JobRepository.php
+++ b/EMS/core-bundle/src/Repository/JobRepository.php
@@ -115,7 +115,8 @@ class JobRepository extends EntityRepository
      *     'count_jobs': int,
      *     'count_jobs_pending': int,
      *     'count_jobs_started': int,
-     *     'count_jobs_done': int
+     *     'count_jobs_done': int,
+     *     'count_jobs_failed': int
      * }>|list<array<string, mixed>>
      */
     public function summary(): array
@@ -128,7 +129,8 @@ class JobRepository extends EntityRepository
             ->addSelect('count(id) as count_jobs')
             ->addSelect('count(CASE WHEN started = FALSE AND done = FALSE THEN 1 END) AS count_jobs_pending')
             ->addSelect('count(CASE WHEN started = TRUE AND done = FALSE THEN 1 END) AS count_jobs_started')
-            ->addSelect('count(CASE WHEN done = TRUE THEN 1 END) AS count_jobs_done')
+            ->addSelect('count(CASE WHEN done = TRUE and status != \'failed\' THEN 1 END) AS count_jobs_done')
+            ->addSelect('count(CASE WHEN status = \'failed\' THEN 1 END) AS count_jobs_failed')
             ->from('job')
             ->groupBy('tag');
 

--- a/docker/monitoring/grafana/dashboards/dashboard_ems.json
+++ b/docker/monitoring/grafana/dashboards/dashboard_ems.json
@@ -72,7 +72,7 @@
                 "textMode": "name",
                 "wideLayout": true
             },
-            "pluginVersion": "12.1.1",
+            "pluginVersion": "12.2.1",
             "targets": [
                 {
                     "datasource": {
@@ -146,7 +146,7 @@
                 "textMode": "name",
                 "wideLayout": true
             },
-            "pluginVersion": "12.1.1",
+            "pluginVersion": "12.2.1",
             "targets": [
                 {
                     "datasource": {
@@ -220,7 +220,7 @@
                 "textMode": "name",
                 "wideLayout": true
             },
-            "pluginVersion": "12.1.1",
+            "pluginVersion": "12.2.1",
             "targets": [
                 {
                     "datasource": {
@@ -258,6 +258,9 @@
                         "cellOptions": {
                             "type": "auto"
                         },
+                        "footer": {
+                            "reducers": []
+                        },
                         "inspect": false
                     },
                     "mappings": [],
@@ -286,17 +289,9 @@
             "id": 36,
             "options": {
                 "cellHeight": "sm",
-                "footer": {
-                    "countRows": false,
-                    "fields": "",
-                    "reducer": [
-                        "sum"
-                    ],
-                    "show": false
-                },
                 "showHeader": true
             },
-            "pluginVersion": "12.1.1",
+            "pluginVersion": "12.2.1",
             "targets": [
                 {
                     "editorMode": "code",
@@ -353,6 +348,21 @@
                     "legendFormat": "__auto",
                     "range": false,
                     "refId": "Pending"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus_datasource"
+                    },
+                    "editorMode": "code",
+                    "exemplar": false,
+                    "expr": "emsco_job_count_jobs_failed",
+                    "format": "table",
+                    "hide": false,
+                    "instant": true,
+                    "legendFormat": "__auto",
+                    "range": false,
+                    "refId": "Failed"
                 }
             ],
             "title": "ElasticMS Jobs",
@@ -374,7 +384,8 @@
                                 "Value #Total",
                                 "Value #Started",
                                 "Value #Done",
-                                "Value #Pending"
+                                "Value #Pending",
+                                "Value #Failed"
                             ]
                         }
                     }
@@ -386,15 +397,17 @@
                         "includeByName": {},
                         "indexByName": {
                             "Value #Done": 3,
+                            "Value #Failed": 4,
                             "Value #Pending": 1,
                             "Value #Started": 2,
-                            "Value #Total": 4,
+                            "Value #Total": 5,
                             "tag": 0
                         },
                         "orderByMode": "manual",
                         "renameByName": {
                             "NotDone": "Scheduled",
                             "Value #Done": "Done",
+                            "Value #Failed": "Failed",
                             "Value #Pending": "Pending",
                             "Value #Started": "Started",
                             "Value #Total": "Total",
@@ -407,7 +420,7 @@
         }
     ],
     "preload": false,
-    "schemaVersion": 41,
+    "schemaVersion": 42,
     "tags": [],
     "templating": {
         "list": []

--- a/docs/getting-started/dev-env.md
+++ b/docs/getting-started/dev-env.md
@@ -12,7 +12,6 @@
   * [Admin UI](#admin-ui)
   * [Identity provider (IDP) (Keycloak)](#identity-provider-idp-keycloak)
   * [Monitoring (Grafana and Prometheus)](#monitoring-grafana-and-prometheus)
-    * [Updating Dashboards](#updating-dashboards)
   * [About PHP configuration](#about-php-configuration)
   * [Works with the bootstrap5 theme](#works-with-the-bootstrap5-theme)
 <!-- TOC -->


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  n |
| New feature?   |  y |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Add a metrics for counting the failed jobs.
Jobs that do not have a tag defined, will now get the tag admin in the metrics. Because working with empty tags is not smooth in grafana.
