### PR TITLE
fix(admin/web/cli): fallback env is prod not dev

### DIFF
--- a/elasticms-admin/bin/console
+++ b/elasticms-admin/bin/console
@@ -13,6 +13,8 @@ $_SERVER['ELASTICMS_PATH'] = file_exists(dirname(__DIR__).'/vendor/elasticms') ?
     dirname(__DIR__).'/../EMS';
 
 $_SERVER['LOG_LEVEL'] = 400;
+
+$_SERVER['APP_ENV'] ??= 'prod';
 $_SERVER['APP_RUNTIME_OPTIONS'] = [
     'disable_dotenv' => ('true' === ($_SERVER['APP_DISABLE_DOTENV'] ?? false)),
     'prod_envs' => ['prod', 'redis', 'db', 'store_data'],

--- a/elasticms-admin/public/index.php
+++ b/elasticms-admin/public/index.php
@@ -7,6 +7,7 @@ file_exists(dirname(__DIR__).'/vendor/autoload_runtime.php') ?
     require_once dirname(__DIR__).'/vendor/autoload_runtime.php' :
     require_once dirname(__DIR__).'/../vendor/autoload_runtime.php';
 
+$_SERVER['APP_ENV'] ??= 'prod';
 $_SERVER['APP_RUNTIME_OPTIONS'] = [
     'disable_dotenv' => ('true' === ($_SERVER['APP_DISABLE_DOTENV'] ?? false)),
     'prod_envs' => ['prod', 'redis', 'db', 'store_data'],

--- a/elasticms-cli/bin/console
+++ b/elasticms-cli/bin/console
@@ -8,6 +8,7 @@ file_exists(dirname(__DIR__).'/vendor/autoload_runtime.php') ?
     require_once dirname(__DIR__).'/vendor/autoload_runtime.php' :
     require_once dirname(__DIR__).'/../vendor/autoload_runtime.php';
 
+$_SERVER['APP_ENV'] ??= 'prod';
 $_SERVER['APP_RUNTIME_OPTIONS'] = [
     'disable_dotenv' => ('true' === ($_SERVER['APP_DISABLE_DOTENV'] ?? false)),
     'prod_envs' => ['prod', 'redis'],

--- a/elasticms-cli/public/index.php
+++ b/elasticms-cli/public/index.php
@@ -10,7 +10,7 @@ file_exists(dirname(__DIR__).'/vendor/autoload_runtime.php') ?
 $_SERVER['APP_ENV'] ??= 'prod';
 $_SERVER['APP_RUNTIME_OPTIONS'] = [
     'disable_dotenv' => ('true' === ($_SERVER['APP_DISABLE_DOTENV'] ?? false)),
-    'prod_envs' => ['prod', 'redis', 'store_data'],
+    'prod_envs' => ['prod', 'redis'],
     'project_dir' => dirname(__DIR__),
 ];
 

--- a/elasticms-cli/public/index.php
+++ b/elasticms-cli/public/index.php
@@ -7,6 +7,7 @@ file_exists(dirname(__DIR__).'/vendor/autoload_runtime.php') ?
     require_once dirname(__DIR__).'/vendor/autoload_runtime.php' :
     require_once dirname(__DIR__).'/../vendor/autoload_runtime.php';
 
+$_SERVER['APP_ENV'] ??= 'prod';
 $_SERVER['APP_RUNTIME_OPTIONS'] = [
     'disable_dotenv' => ('true' === ($_SERVER['APP_DISABLE_DOTENV'] ?? false)),
     'prod_envs' => ['prod', 'redis', 'store_data'],

--- a/elasticms-web/bin/console
+++ b/elasticms-web/bin/console
@@ -9,6 +9,7 @@ file_exists(dirname(__DIR__).'/vendor/autoload_runtime.php') ?
     require_once dirname(__DIR__).'/../vendor/autoload_runtime.php';
 
 $_SERVER['LOG_LEVEL'] = 400;
+$_SERVER['APP_ENV'] ??= 'prod';
 $_SERVER['APP_RUNTIME_OPTIONS'] = [
     'disable_dotenv' => ('true' === ($_SERVER['APP_DISABLE_DOTENV'] ?? false)),
     'prod_envs' => ['prod', 'redis', 'store_data'],

--- a/elasticms-web/public/index.php
+++ b/elasticms-web/public/index.php
@@ -7,6 +7,7 @@ file_exists(dirname(__DIR__).'/vendor/autoload_runtime.php') ?
     require_once dirname(__DIR__).'/vendor/autoload_runtime.php' :
     require_once dirname(__DIR__).'/../vendor/autoload_runtime.php';
 
+$_SERVER['APP_ENV'] ??= 'prod';
 $_SERVER['APP_RUNTIME_OPTIONS'] = [
     'disable_dotenv' => ('true' === ($_SERVER['APP_DISABLE_DOTENV'] ?? false)),
     'prod_envs' => ['prod', 'redis', 'store_data'],


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | n  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

In our docker builds, if we forget to define APP_ENV, symfony will use the dev environment.
The default fallback environment should be 'prod'
