### PR TITLE
chore: prepare 6.9 release with rector

### DIFF
--- a/EMS/client-helper-bundle/src/Helper/Elasticsearch/ClientRequest.php
+++ b/EMS/client-helper-bundle/src/Helper/Elasticsearch/ClientRequest.php
@@ -220,7 +220,7 @@ final class ClientRequest implements ClientRequestInterface
             $ids = [];
             foreach ($result['hits']['hits'] ?? [] as $document) {
                 $items[\sprintf('%s:%s', $emsLink->getContentType(), $document['_id'])] = $document;
-                $ids = \array_merge($ids, \array_filter(\array_map(fn (string $a): EMSLink => EMSLink::fromText($a), $document['_source'][$childrenField] ?? []), fn (EMSLink $a): bool => $emsLink->getContentType() !== $a->getContentType()));
+                $ids = \array_merge($ids, \array_filter(\array_map(EMSLink::fromText(...), $document['_source'][$childrenField] ?? []), fn (EMSLink $a): bool => $emsLink->getContentType() !== $a->getContentType()));
             }
             $contentTypes = \array_keys(\array_reduce($ids, function (array $carry, $l): array {
                 $carry[$l->getContentType()] = $l->getContentType();

--- a/EMS/client-helper-bundle/src/Security/CoreApi/CoreApiAuthenticator.php
+++ b/EMS/client-helper-bundle/src/Security/CoreApi/CoreApiAuthenticator.php
@@ -72,7 +72,7 @@ class CoreApiAuthenticator extends AbstractAuthenticator
         return new SelfValidatingPassport(
             new UserBadge(
                 $this->coreApi->getToken(),
-                fn (string $token) => $this->coreApiUserProvider->loadUserByIdentifier($token)
+                $this->coreApiUserProvider->loadUserByIdentifier(...)
             ),
             [new CsrfTokenBadge(self::CSRF_ID, $csrfToken)]
         );

--- a/EMS/common-bundle/src/Common/Command/AbstractCommand.php
+++ b/EMS/common-bundle/src/Common/Command/AbstractCommand.php
@@ -180,7 +180,7 @@ abstract class AbstractCommand extends Command implements CommandInterface
      */
     protected function getArgumentIntArray(string $name): array
     {
-        return \array_map('\intval', $this->getArgumentStringArray($name));
+        return \array_map(\intval(...), $this->getArgumentStringArray($name));
     }
 
     protected function getOptionBool(string $name): bool
@@ -219,7 +219,7 @@ abstract class AbstractCommand extends Command implements CommandInterface
      */
     protected function getOptionIntArray(string $name): array
     {
-        return \array_map('\intval', $this->getOptionStringArray($name));
+        return \array_map(\intval(...), $this->getOptionStringArray($name));
     }
 
     protected function getOptionIntNull(string $name): ?int

--- a/EMS/common-bundle/src/Common/Converter.php
+++ b/EMS/common-bundle/src/Common/Converter.php
@@ -33,7 +33,7 @@ class Converter
         $units = ['B', 'KB', 'MB', 'GB', 'TB'];
         $bytes = \max($bytes, 0);
 
-        $pow = \floor(($bytes ? \log($bytes) : 0) / \log(1024));
+        $pow = (int) \floor(($bytes ? \log($bytes) : 0) / \log(1024));
         $pow = \min($pow, \count($units) - 1);
 
         $bytes /= 1024 ** $pow;

--- a/EMS/common-bundle/src/Common/EMSLinkCollection.php
+++ b/EMS/common-bundle/src/Common/EMSLinkCollection.php
@@ -33,7 +33,7 @@ class EMSLinkCollection
      */
     public static function fromEmsIds(array $emsIds): self
     {
-        $emsLinks = \array_map(static fn (string $emsId) => EMSLink::fromText($emsId), $emsIds);
+        $emsLinks = \array_map(EMSLink::fromText(...), $emsIds);
 
         return self::fromArray(...$emsLinks);
     }

--- a/EMS/common-bundle/src/Service/Pdf/DomPdfPrinter.php
+++ b/EMS/common-bundle/src/Service/Pdf/DomPdfPrinter.php
@@ -31,7 +31,7 @@ final class DomPdfPrinter implements PdfPrinterInterface
         $options ??= new PdfPrintOptions([]);
         $dompdf = $this->makeDomPdf($pdf, $options);
 
-        return new PdfOutput(fn (): string => $dompdf->output());
+        return new PdfOutput($dompdf->output(...));
     }
 
     #[\Override]

--- a/EMS/common-bundle/src/Storage/Archive.php
+++ b/EMS/common-bundle/src/Storage/Archive.php
@@ -155,7 +155,7 @@ class Archive implements \JsonSerializable, FileInterface
 
     private function containsByHash(string $hash): bool
     {
-        return array_any($this->files, fn($file) => $hash === $file->hash);
+        return \array_any($this->files, fn ($file) => $hash === $file->hash);
     }
 
     public function diff(?Archive $otherArchive): self

--- a/EMS/common-bundle/src/Storage/Archive.php
+++ b/EMS/common-bundle/src/Storage/Archive.php
@@ -155,13 +155,7 @@ class Archive implements \JsonSerializable, FileInterface
 
     private function containsByHash(string $hash): bool
     {
-        foreach ($this->files as $file) {
-            if ($hash === $file->hash) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($this->files, fn($file) => $hash === $file->hash);
     }
 
     public function diff(?Archive $otherArchive): self

--- a/EMS/common-bundle/src/Storage/StorageManager.php
+++ b/EMS/common-bundle/src/Storage/StorageManager.php
@@ -14,7 +14,6 @@ use EMS\CommonBundle\Storage\File\StorageFile;
 use EMS\CommonBundle\Storage\Processor\Config;
 use EMS\CommonBundle\Storage\Service\StorageInterface;
 use EMS\Helpers\File\File;
-use EMS\Helpers\File\File as FileHelper;
 use EMS\Helpers\File\TempDirectory;
 use EMS\Helpers\File\TempFile;
 use EMS\Helpers\Html\MimeTypes;
@@ -668,7 +667,7 @@ class StorageManager implements FileManagerInterface
             return $fileHash;
         }
 
-        $file = FileHelper::fromFilename($realPath);
+        $file = File::fromFilename($realPath);
         $mimeType ??= $file->mimeType;
         $filename ??= $file->name;
 

--- a/EMS/common-bundle/src/Storage/StorageManager.php
+++ b/EMS/common-bundle/src/Storage/StorageManager.php
@@ -85,13 +85,7 @@ class StorageManager implements FileManagerInterface
 
     public function head(string $hash): bool
     {
-        foreach ($this->adapters as $adapter) {
-            if ($adapter->head($hash)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($this->adapters, fn($adapter) => $adapter->head($hash));
     }
 
     #[\Override]
@@ -729,13 +723,7 @@ class StorageManager implements FileManagerInterface
 
     public function addFileInArchiveCache(string $hash, SplFileInfo $file, string $mimeType): bool
     {
-        foreach ($this->adapters as $adapter) {
-            if ($adapter->addFileInArchiveCache($hash, $file, $mimeType)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($this->adapters, fn($adapter) => $adapter->addFileInArchiveCache($hash, $file, $mimeType));
     }
 
     public function getFilesInArchive(string $hash): Archive

--- a/EMS/common-bundle/src/Storage/StorageManager.php
+++ b/EMS/common-bundle/src/Storage/StorageManager.php
@@ -85,7 +85,7 @@ class StorageManager implements FileManagerInterface
 
     public function head(string $hash): bool
     {
-        return array_any($this->adapters, fn($adapter) => $adapter->head($hash));
+        return \array_any($this->adapters, fn ($adapter) => $adapter->head($hash));
     }
 
     #[\Override]
@@ -723,7 +723,7 @@ class StorageManager implements FileManagerInterface
 
     public function addFileInArchiveCache(string $hash, SplFileInfo $file, string $mimeType): bool
     {
-        return array_any($this->adapters, fn($adapter) => $adapter->addFileInArchiveCache($hash, $file, $mimeType));
+        return \array_any($this->adapters, fn ($adapter) => $adapter->addFileInArchiveCache($hash, $file, $mimeType));
     }
 
     public function getFilesInArchive(string $hash): Archive

--- a/EMS/common-bundle/src/Twig/CommonExtension.php
+++ b/EMS/common-bundle/src/Twig/CommonExtension.php
@@ -81,7 +81,7 @@ class CommonExtension extends AbstractExtension
             new TwigFilter('ems_hash', [AssetRuntime::class, 'hash']),
             new TwigFilter('ems_preg_match', Encoder::pregMatch(...)),
             new TwigFilter('ems_color', fn ($color) => new Color($color)),
-            new TwigFilter('ems_link', fn ($emsLink) => EMSLink::fromText($emsLink)),
+            new TwigFilter('ems_link', EMSLink::fromText(...)),
             new TwigFilter('ems_valid_mail', [TextRuntime::class, 'isValidEmail']),
             new TwigFilter('ems_uuid', UuidGenerator::fromValue(...)),
             new TwigFilter('ems_date', DateTime::createFromFormat(...)),

--- a/EMS/common-bundle/src/Twig/SearchRuntime.php
+++ b/EMS/common-bundle/src/Twig/SearchRuntime.php
@@ -33,15 +33,7 @@ final class SearchRuntime implements RuntimeExtensionInterface
     {
         $choices = $this->getNestedSearchChoices($alias, $contentTypeNames, $nestedFieldName);
 
-        return \array_values(\array_filter($choices, function (array $choice) use ($search) {
-            foreach ($search as $searchKey => $searchValue) {
-                if (!isset($choice[$searchKey]) || $choice[$searchKey] !== $searchValue) {
-                    return false;
-                }
-            }
-
-            return true;
-        }));
+        return \array_values(\array_filter($choices, fn(array $choice) => array_all($search, fn($searchValue, $searchKey) => !(!isset($choice[$searchKey]) || $choice[$searchKey] !== $searchValue))));
     }
 
     /**

--- a/EMS/common-bundle/src/Twig/SearchRuntime.php
+++ b/EMS/common-bundle/src/Twig/SearchRuntime.php
@@ -33,7 +33,7 @@ final class SearchRuntime implements RuntimeExtensionInterface
     {
         $choices = $this->getNestedSearchChoices($alias, $contentTypeNames, $nestedFieldName);
 
-        return \array_values(\array_filter($choices, fn(array $choice) => array_all($search, fn($searchValue, $searchKey) => !(!isset($choice[$searchKey]) || $choice[$searchKey] !== $searchValue))));
+        return \array_values(\array_filter($choices, fn (array $choice) => \array_all($search, fn ($searchValue, $searchKey) => !(!isset($choice[$searchKey]) || $choice[$searchKey] !== $searchValue))));
     }
 
     /**

--- a/EMS/common-bundle/tests/Unit/Common/Admin/ConfigHelperAiTest.php
+++ b/EMS/common-bundle/tests/Unit/Common/Admin/ConfigHelperAiTest.php
@@ -26,7 +26,7 @@ class ConfigHelperAiTest extends TestCase
     #[\Override]
     protected function tearDown(): void
     {
-        \array_map('unlink', \glob("$this->tempDir/*.*"));
+        \array_map(unlink(...), \glob("$this->tempDir/*.*"));
         \rmdir($this->tempDir);
     }
 
@@ -52,7 +52,7 @@ class ConfigHelperAiTest extends TestCase
 
     public function testLocal(): void
     {
-        \array_map('unlink', \glob("$this->tempDir/*.*"));
+        \array_map(unlink(...), \glob("$this->tempDir/*.*"));
         \touch($this->tempDir.DIRECTORY_SEPARATOR.'config1.json');
         \touch($this->tempDir.DIRECTORY_SEPARATOR.'config2.json');
 

--- a/EMS/common-bundle/tests/Unit/Common/Cache/CacheAiTest.php
+++ b/EMS/common-bundle/tests/Unit/Common/Cache/CacheAiTest.php
@@ -31,7 +31,7 @@ class CacheAiTest extends TestCase
     #[\Override]
     protected function tearDown(): void
     {
-        \array_map('unlink', \glob("$this->cacheDir/*.*"));
+        \array_map(unlink(...), \glob("$this->cacheDir/*.*"));
         $this->removeDirectory($this->cacheDir);
     }
 

--- a/EMS/common-bundle/tests/Unit/Common/StoreData/Service/StoreDataFileSystemServiceAiTest.php
+++ b/EMS/common-bundle/tests/Unit/Common/StoreData/Service/StoreDataFileSystemServiceAiTest.php
@@ -24,7 +24,7 @@ class StoreDataFileSystemServiceAiTest extends TestCase
     #[\Override]
     protected function tearDown(): void
     {
-        \array_map('unlink', \glob($this->rootPath.DIRECTORY_SEPARATOR.'*'));
+        \array_map(unlink(...), \glob($this->rootPath.DIRECTORY_SEPARATOR.'*'));
         \rmdir($this->rootPath);
     }
 

--- a/EMS/core-bundle/src/Command/Revision/LockCommand.php
+++ b/EMS/core-bundle/src/Command/Revision/LockCommand.php
@@ -42,7 +42,7 @@ final class LockCommand extends AbstractCommand
     public const string OPTION_IF_EMPTY = 'if-empty';
     public const string OPTION_OUUID = 'ouuid';
     private bool $ifEmpty;
-    private ?string $ouuid;
+    private ?string $ouuid = null;
 
     public function __construct(
         private readonly ContentTypeService $contentTypeService,

--- a/EMS/core-bundle/src/Command/Revision/UnlockCommand.php
+++ b/EMS/core-bundle/src/Command/Revision/UnlockCommand.php
@@ -28,7 +28,7 @@ final class UnlockCommand extends AbstractCommand
     private const string ARGUMENT_CONTENT_TYPE = 'content-type';
     private const string OPTION_ALL = 'all';
     private const string OPTION_STRICT = 'strict';
-    private ?string $contentTypeName;
+    private ?string $contentTypeName = null;
     private string $username;
     private ?bool $all = null;
 

--- a/EMS/core-bundle/src/Controller/Views/CriteriaController.php
+++ b/EMS/core-bundle/src/Controller/Views/CriteriaController.php
@@ -716,13 +716,7 @@ class CriteriaController extends AbstractController
 
         $found = false;
         foreach ($rawData[$criteriaField] as &$criteriaSet) {
-            $found = true;
-            foreach ($filters as $criterion => $value) {
-                if ($criterion != $multipleField && $value != $criteriaSet[$criterion]) {
-                    $found = false;
-                    break;
-                }
-            }
+            $found = array_all($filters, fn($value, $criterion) => !($criterion != $multipleField && $value != $criteriaSet[$criterion]));
             if ($found) {
                 if ($multipleField && false === \array_search($filters[$multipleField], $criteriaSet[$multipleField])) {
                     $criteriaSet[$multipleField][] = $filters[$multipleField];
@@ -973,13 +967,7 @@ class CriteriaController extends AbstractController
 
         $found = false;
         foreach ($rawData[$criteriaField] as $index => $criteriaSet) {
-            $found = true;
-            foreach ($filters as $criterion => $value) {
-                if ($criterion != $multipleField && $value != $criteriaSet[$criterion]) {
-                    $found = false;
-                    break;
-                }
-            }
+            $found = array_all($filters, fn($value, $criterion) => !($criterion != $multipleField && $value != $criteriaSet[$criterion]));
             if ($found) {
                 if ($multipleField) {
                     $indexKey = \array_search($filters[$multipleField], $criteriaSet[$multipleField]);

--- a/EMS/core-bundle/src/Controller/Views/CriteriaController.php
+++ b/EMS/core-bundle/src/Controller/Views/CriteriaController.php
@@ -716,7 +716,7 @@ class CriteriaController extends AbstractController
 
         $found = false;
         foreach ($rawData[$criteriaField] as &$criteriaSet) {
-            $found = array_all($filters, fn($value, $criterion) => !($criterion != $multipleField && $value != $criteriaSet[$criterion]));
+            $found = \array_all($filters, fn ($value, $criterion) => !($criterion != $multipleField && $value != $criteriaSet[$criterion]));
             if ($found) {
                 if ($multipleField && false === \array_search($filters[$multipleField], $criteriaSet[$multipleField])) {
                     $criteriaSet[$multipleField][] = $filters[$multipleField];
@@ -967,7 +967,7 @@ class CriteriaController extends AbstractController
 
         $found = false;
         foreach ($rawData[$criteriaField] as $index => $criteriaSet) {
-            $found = array_all($filters, fn($value, $criterion) => !($criterion != $multipleField && $value != $criteriaSet[$criterion]));
+            $found = \array_all($filters, fn ($value, $criterion) => !($criterion != $multipleField && $value != $criteriaSet[$criterion]));
             if ($found) {
                 if ($multipleField) {
                     $indexKey = \array_search($filters[$multipleField], $criteriaSet[$multipleField]);

--- a/EMS/core-bundle/src/Core/Document/DataLinksFactory.php
+++ b/EMS/core-bundle/src/Core/Document/DataLinksFactory.php
@@ -52,7 +52,7 @@ final readonly class DataLinksFactory
     private function handleType(DataLinks $dataLinks, string $type): void
     {
         $types = \array_filter(\explode(',', $type));
-        $contentTypes = \array_map(fn (string $type) => $this->contentTypeService->giveByName($type), $types);
+        $contentTypes = \array_map($this->contentTypeService->giveByName(...), $types);
         $dataLinks->addContentTypes(...$contentTypes);
 
         if (1 !== \count($contentTypes)) {

--- a/EMS/core-bundle/src/Core/Environment/EnvironmentsRevision.php
+++ b/EMS/core-bundle/src/Core/Environment/EnvironmentsRevision.php
@@ -35,7 +35,7 @@ class EnvironmentsRevision
             $publishEnvironments = $userPublishEnvironments->filter(fn (Environment $e) => $e->getManaged() && $e !== $this->default);
 
             $this->publish = $publishEnvironments->filter(fn (Environment $e) => !$environments->contains($e));
-            $this->unpublish = $publishEnvironments->filter(fn (Environment $e) => $environments->contains($e));
+            $this->unpublish = $publishEnvironments->filter($environments->contains(...));
         }
     }
 }

--- a/EMS/core-bundle/src/DataTable/Type/Release/ReleaseRevisionsUnpublishDataTableType.php
+++ b/EMS/core-bundle/src/DataTable/Type/Release/ReleaseRevisionsUnpublishDataTableType.php
@@ -141,7 +141,7 @@ class ReleaseRevisionsUnpublishDataTableType extends AbstractTableType implement
         }
 
         $resultSet = $this->elasticaService->search($search);
-        $documents = \array_map(static fn (Result $result) => Document::fromResult($result), $resultSet->getResults());
+        $documents = \array_map(Document::fromResult(...), $resultSet->getResults());
         $documentLinks = \array_map(static fn (Document $document) => $document->getEmsLink(), $documents);
         $infos = $this->revisionService->getDocumentsInfo(...$documentLinks);
 

--- a/EMS/core-bundle/src/DataTable/Type/Release/ReleaseRevisionsUnpublishDataTableType.php
+++ b/EMS/core-bundle/src/DataTable/Type/Release/ReleaseRevisionsUnpublishDataTableType.php
@@ -9,7 +9,6 @@ use Elastica\Query\MatchQuery;
 use Elastica\Query\QueryString;
 use Elastica\Query\Terms;
 use Elastica\Query\Wildcard;
-use Elastica\Result;
 use EMS\CommonBundle\Elasticsearch\Document\Document;
 use EMS\CommonBundle\Elasticsearch\QueryStringEscaper;
 use EMS\CommonBundle\Search\Search;

--- a/EMS/core-bundle/src/Entity/Helper/JsonDeserializer.php
+++ b/EMS/core-bundle/src/Entity/Helper/JsonDeserializer.php
@@ -64,13 +64,6 @@ abstract class JsonDeserializer
         }
 
         $keys = [JsonClass::CLASS_INDEX, JsonClass::CONSTRUCTOR_ARGUMENTS_INDEX, JsonClass::PROPERTIES_INDEX];
-
-        foreach ($keys as $key) {
-            if (!\array_key_exists($key, $array)) {
-                return false;
-            }
-        }
-
-        return true;
+        return array_all($keys, fn($key) => \array_key_exists($key, $array));
     }
 }

--- a/EMS/core-bundle/src/Entity/Helper/JsonDeserializer.php
+++ b/EMS/core-bundle/src/Entity/Helper/JsonDeserializer.php
@@ -64,6 +64,7 @@ abstract class JsonDeserializer
         }
 
         $keys = [JsonClass::CLASS_INDEX, JsonClass::CONSTRUCTOR_ARGUMENTS_INDEX, JsonClass::PROPERTIES_INDEX];
-        return array_all($keys, fn($key) => \array_key_exists($key, $array));
+
+        return \array_all($keys, fn ($key) => \array_key_exists($key, $array));
     }
 }

--- a/EMS/core-bundle/src/Entity/Task.php
+++ b/EMS/core-bundle/src/Entity/Task.php
@@ -197,7 +197,7 @@ class Task implements EntityInterface
      */
     public function getLogs(): array
     {
-        return \array_map(static fn (array $log) => TaskLog::fromData($log), $this->logs);
+        return \array_map(TaskLog::fromData(...), $this->logs);
     }
 
     public function isOpen(): bool

--- a/EMS/core-bundle/src/Form/Data/TableColumn.php
+++ b/EMS/core-bundle/src/Form/Data/TableColumn.php
@@ -243,7 +243,7 @@ class TableColumn
      */
     public function valid($objectOrArray): bool
     {
-        return array_all($this->conditions, fn($condition) => $condition->valid($objectOrArray));
+        return \array_all($this->conditions, fn ($condition) => $condition->valid($objectOrArray));
     }
 
     public function setOrderField(string $orderField): TableColumn

--- a/EMS/core-bundle/src/Form/Data/TableColumn.php
+++ b/EMS/core-bundle/src/Form/Data/TableColumn.php
@@ -243,13 +243,7 @@ class TableColumn
      */
     public function valid($objectOrArray): bool
     {
-        foreach ($this->conditions as $condition) {
-            if (!$condition->valid($objectOrArray)) {
-                return false;
-            }
-        }
-
-        return true;
+        return array_all($this->conditions, fn($condition) => $condition->valid($objectOrArray));
     }
 
     public function setOrderField(string $orderField): TableColumn

--- a/EMS/core-bundle/src/Form/Data/TableItemAction.php
+++ b/EMS/core-bundle/src/Form/Data/TableItemAction.php
@@ -153,6 +153,6 @@ final class TableItemAction
      */
     public function valid($objectOrArray): bool
     {
-        return array_all($this->conditions, fn($condition) => $condition->valid($objectOrArray));
+        return \array_all($this->conditions, fn ($condition) => $condition->valid($objectOrArray));
     }
 }

--- a/EMS/core-bundle/src/Form/Data/TableItemAction.php
+++ b/EMS/core-bundle/src/Form/Data/TableItemAction.php
@@ -153,12 +153,6 @@ final class TableItemAction
      */
     public function valid($objectOrArray): bool
     {
-        foreach ($this->conditions as $condition) {
-            if (!$condition->valid($objectOrArray)) {
-                return false;
-            }
-        }
-
-        return true;
+        return array_all($this->conditions, fn($condition) => $condition->valid($objectOrArray));
     }
 }

--- a/EMS/core-bundle/src/Security/Ldap/LdapAuthTokenLoginAuthenticator.php
+++ b/EMS/core-bundle/src/Security/Ldap/LdapAuthTokenLoginAuthenticator.php
@@ -49,7 +49,7 @@ class LdapAuthTokenLoginAuthenticator extends AbstractAuthenticator
         }
 
         return new Passport(
-            new UserBadge($username, fn ($userIdentifier) => $this->ldapUserProvider->loadUserByIdentifier($userIdentifier)),
+            new UserBadge($username, $this->ldapUserProvider->loadUserByIdentifier(...)),
             new PasswordCredentials($password),
             [
                 new LdapBadge(

--- a/EMS/core-bundle/src/Security/Ldap/LdapFormLoginAuthenticator.php
+++ b/EMS/core-bundle/src/Security/Ldap/LdapFormLoginAuthenticator.php
@@ -55,7 +55,7 @@ class LdapFormLoginAuthenticator extends AbstractLoginFormAuthenticator
         $request->getSession()->set(SecurityRequestAttributes::LAST_USERNAME, $username);
 
         return new Passport(
-            new UserBadge($username, fn ($userIdentifier) => $this->ldapUserProvider->loadUserByIdentifier($userIdentifier)),
+            new UserBadge($username, $this->ldapUserProvider->loadUserByIdentifier(...)),
             new PasswordCredentials($password),
             [
                 new CsrfTokenBadge('authenticate', $csrfToken),

--- a/EMS/core-bundle/src/Service/AliasService.php
+++ b/EMS/core-bundle/src/Service/AliasService.php
@@ -360,6 +360,7 @@ class AliasService
             $alias['countIndexes'] = \count($alias['indexes']);
 
             $this->aliases[$name] = $alias;
+
             return;
         }
 

--- a/EMS/core-bundle/src/Service/AliasService.php
+++ b/EMS/core-bundle/src/Service/AliasService.php
@@ -21,7 +21,15 @@ use Psr\Log\LoggerInterface;
 class AliasService
 {
     private const string COUNTER_AGGREGATION = 'counter_aggregation';
-    /** @var array<string, array{name: string, total: int, indexes: Index[], environment: string, managed: bool}> */
+    /** @var array<string, array{
+     *     name: string,
+     *     countIndexes: int,
+     *     total: int,
+     *     indexes: Index[],
+     *     environment: string,
+     *     managed: bool
+     * }>
+     */
     private array $aliases = [];
     /** @var Index[] */
     private array $orphanIndexes = [];
@@ -347,9 +355,11 @@ class AliasService
     private function addAlias(string $name, string $index, array $env = [], bool $managed = false): void
     {
         if ($this->hasAlias($name)) {
-            $this->aliases[$name]['indexes'][$index] = $this->getIndex($index);
-            $this->aliases[$name]['countIndexes'] = \count($this->aliases[$name]['indexes']);
+            $alias = $this->getAlias($name);
+            $alias['indexes'][$index] = $this->getIndex($index);
+            $alias['countIndexes'] = \count($alias['indexes']);
 
+            $this->aliases[$name] = $alias;
             return;
         }
 

--- a/EMS/core-bundle/src/Service/DataService.php
+++ b/EMS/core-bundle/src/Service/DataService.php
@@ -1076,13 +1076,7 @@ class DataService
             if (empty($userCircles)) {
                 throw new HasNotCircleException($environment);
             }
-            $found = false;
-            foreach ($userCircles as $userCircle) {
-                if (\in_array($userCircle, $environmentCircles)) {
-                    $found = true;
-                    break;
-                }
-            }
+            $found = array_any($userCircles, fn($userCircle) => \in_array($userCircle, $environmentCircles));
             if (!$found) {
                 throw new HasNotCircleException($environment);
             }

--- a/EMS/core-bundle/src/Service/DataService.php
+++ b/EMS/core-bundle/src/Service/DataService.php
@@ -1076,7 +1076,7 @@ class DataService
             if (empty($userCircles)) {
                 throw new HasNotCircleException($environment);
             }
-            $found = array_any($userCircles, fn($userCircle) => \in_array($userCircle, $environmentCircles));
+            $found = \array_any($userCircles, fn ($userCircle) => \in_array($userCircle, $environmentCircles));
             if (!$found) {
                 throw new HasNotCircleException($environment);
             }

--- a/EMS/core-bundle/src/Service/ReleaseService.php
+++ b/EMS/core-bundle/src/Service/ReleaseService.php
@@ -129,7 +129,7 @@ final readonly class ReleaseService implements EntityServiceInterface
      */
     public function removeRevisions(Release $release, array $ids): void
     {
-        $revisionIds = \array_map('intval', $ids);
+        $revisionIds = \array_map(intval(...), $ids);
 
         foreach ($release->getRevisions() as $releaseRevision) {
             if (\in_array($releaseRevision->getId(), $revisionIds, true)) {

--- a/EMS/core-bundle/src/Service/SearchService.php
+++ b/EMS/core-bundle/src/Service/SearchService.php
@@ -10,7 +10,6 @@ use Elastica\Query\BoolQuery;
 use Elastica\Query\Term;
 use EMS\CommonBundle\Common\EMSLink;
 use EMS\CommonBundle\Elasticsearch\Document\Document;
-use EMS\CommonBundle\Elasticsearch\Document\Document as ElasticsearchDocument;
 use EMS\CommonBundle\Search\Search as CommonSearch;
 use EMS\CommonBundle\Service\ElasticaService;
 use EMS\CoreBundle\Core\ContentType\Version\VersionFields;
@@ -117,7 +116,7 @@ class SearchService
         return $commonSearch;
     }
 
-    public function getDocument(ContentType $contentType, string $ouuid, ?Environment $environment = null): ElasticsearchDocument
+    public function getDocument(ContentType $contentType, string $ouuid, ?Environment $environment = null): Document
     {
         $index = $environment?->getAlias() ?? $contentType->giveEnvironment()->getAlias();
         $searchQuery = null;
@@ -137,7 +136,7 @@ class SearchService
         return $this->elasticaService->getDocument($index, $contentType->getName(), $ouuid, [], [], $searchQuery);
     }
 
-    public function getDocumentByEmsLink(EMSLink $emsLink): ElasticsearchDocument
+    public function getDocumentByEmsLink(EMSLink $emsLink): Document
     {
         $contentType = $this->contentTypeService->giveByName($emsLink->getContentType());
 

--- a/EMS/core-bundle/src/Service/SearchService.php
+++ b/EMS/core-bundle/src/Service/SearchService.php
@@ -60,7 +60,7 @@ class SearchService
     public function generateSearch(Search $search): CommonSearch
     {
         $environments = \array_filter(
-            \array_map(fn (string $name) => $this->environmentService->giveByName($name), $search->getEnvironments()),
+            \array_map($this->environmentService->giveByName(...), $search->getEnvironments()),
             fn (Environment $e) => $this->elasticaService->hasIndex($e->getAlias())
         );
 

--- a/EMS/core-bundle/src/Service/UserService.php
+++ b/EMS/core-bundle/src/Service/UserService.php
@@ -224,15 +224,7 @@ class UserService implements EntityServiceInterface
             return $users;
         }
 
-        return \array_filter($users, function (User $user) use ($roles) {
-            foreach ($roles as $role) {
-                if ($user->hasRole($role)) {
-                    return true;
-                }
-            }
-
-            return false;
-        });
+        return \array_filter($users, fn(User $user) => array_any($roles, $user->hasRole(...)));
     }
 
     #[\Override]

--- a/EMS/core-bundle/src/Service/UserService.php
+++ b/EMS/core-bundle/src/Service/UserService.php
@@ -224,7 +224,7 @@ class UserService implements EntityServiceInterface
             return $users;
         }
 
-        return \array_filter($users, fn(User $user) => array_any($roles, $user->hasRole(...)));
+        return \array_filter($users, fn (User $user) => \array_any($roles, $user->hasRole(...)));
     }
 
     #[\Override]

--- a/EMS/core-bundle/src/Twig/AppExtension.php
+++ b/EMS/core-bundle/src/Twig/AppExtension.php
@@ -985,7 +985,8 @@ class AppExtension extends AbstractExtension
         if ($super && !$this->isSuper()) {
             return false;
         }
-        return array_all($roles, fn($role) => $this->authorizationChecker->isGranted($role));
+
+        return \array_all($roles, fn ($role) => $this->authorizationChecker->isGranted($role));
     }
 
     /**
@@ -1159,7 +1160,8 @@ class AppExtension extends AbstractExtension
         if ($super && !$this->isSuper()) {
             return false;
         }
-        return array_any($roles, fn($role) => $this->authorizationChecker->isGranted($role));
+
+        return \array_any($roles, fn ($role) => $this->authorizationChecker->isGranted($role));
     }
 
     private function contrastRatio(string $c1, string $c2): float

--- a/EMS/core-bundle/src/Twig/AppExtension.php
+++ b/EMS/core-bundle/src/Twig/AppExtension.php
@@ -985,13 +985,7 @@ class AppExtension extends AbstractExtension
         if ($super && !$this->isSuper()) {
             return false;
         }
-        foreach ($roles as $role) {
-            if (!$this->authorizationChecker->isGranted($role)) {
-                return false;
-            }
-        }
-
-        return true;
+        return array_all($roles, fn($role) => $this->authorizationChecker->isGranted($role));
     }
 
     /**
@@ -1165,13 +1159,7 @@ class AppExtension extends AbstractExtension
         if ($super && !$this->isSuper()) {
             return false;
         }
-        foreach ($roles as $role) {
-            if ($this->authorizationChecker->isGranted($role)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($roles, fn($role) => $this->authorizationChecker->isGranted($role));
     }
 
     private function contrastRatio(string $c1, string $c2): float

--- a/EMS/core-bundle/src/Twig/RevisionRuntime.php
+++ b/EMS/core-bundle/src/Twig/RevisionRuntime.php
@@ -88,7 +88,7 @@ class RevisionRuntime implements RuntimeExtensionInterface
      */
     public function getDocumentsInfo(array $documentLinks): array
     {
-        $documentLinks = \array_map(static fn (string $documentLink) => EMSLink::fromText($documentLink), $documentLinks);
+        $documentLinks = \array_map(EMSLink::fromText(...), $documentLinks);
 
         return $this->revisionService->getDocumentsInfo(...$documentLinks);
     }

--- a/EMS/form-bundle/src/Components/Constraint/IsRequiredIfValidator.php
+++ b/EMS/form-bundle/src/Components/Constraint/IsRequiredIfValidator.php
@@ -61,13 +61,6 @@ class IsRequiredIfValidator extends ConstraintValidator
         if (!\is_array($value)) {
             return false;
         }
-
-        foreach ($value as $subValue) {
-            if (!$this->isEmpty($subValue)) {
-                return false;
-            }
-        }
-
-        return true;
+        return array_all($value, $this->isEmpty(...));
     }
 }

--- a/EMS/form-bundle/src/Components/Constraint/IsRequiredIfValidator.php
+++ b/EMS/form-bundle/src/Components/Constraint/IsRequiredIfValidator.php
@@ -61,6 +61,7 @@ class IsRequiredIfValidator extends ConstraintValidator
         if (!\is_array($value)) {
             return false;
         }
-        return array_all($value, $this->isEmpty(...));
+
+        return \array_all($value, $this->isEmpty(...));
     }
 }

--- a/EMS/form-bundle/src/Components/Field/AbstractField.php
+++ b/EMS/form-bundle/src/Components/Field/AbstractField.php
@@ -43,7 +43,7 @@ abstract class AbstractField implements FieldInterface
 
     private function isRequired(): bool
     {
-        return array_any($this->validations, fn($validation) => 'required' === $validation->getHtml5AttributeName());
+        return \array_any($this->validations, fn ($validation) => 'required' === $validation->getHtml5AttributeName());
     }
 
     private function createValidation(ValidationConfig $config): ValidationInterface

--- a/EMS/form-bundle/src/Components/Field/AbstractField.php
+++ b/EMS/form-bundle/src/Components/Field/AbstractField.php
@@ -43,13 +43,7 @@ abstract class AbstractField implements FieldInterface
 
     private function isRequired(): bool
     {
-        foreach ($this->validations as $validation) {
-            if ('required' === $validation->getHtml5AttributeName()) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($this->validations, fn($validation) => 'required' === $validation->getHtml5AttributeName());
     }
 
     private function createValidation(ValidationConfig $config): ValidationInterface

--- a/EMS/form-bundle/src/FormConfig/FormConfigFactory.php
+++ b/EMS/form-bundle/src/FormConfig/FormConfigFactory.php
@@ -294,7 +294,7 @@ class FormConfigFactory
      */
     private function getElements(array $emsLinks): array
     {
-        $emsLinks = \array_map(fn ($emsLink) => EMSLink::fromText($emsLink), $emsLinks);
+        $emsLinks = \array_map(EMSLink::fromText(...), $emsLinks);
 
         $documentIds = \array_reduce($emsLinks, function (array $carry, EMSLink $emsLink) {
             $carry[$emsLink->getContentType()][] = $emsLink->getOuuid();

--- a/EMS/helpers/src/Html/Sanitizer/HtmlSanitizerClass.php
+++ b/EMS/helpers/src/Html/Sanitizer/HtmlSanitizerClass.php
@@ -32,7 +32,7 @@ class HtmlSanitizerClass implements AttributeSanitizerInterface
     public function sanitizeAttribute(string $element, string $attribute, string $value, HtmlSanitizerConfig $config): ?string
     {
         $classes = \explode(' ', $value);
-        $classNames = \array_filter(\array_map('trim', $classes));
+        $classNames = \array_filter(\array_map(trim(...), $classes));
 
         if (\count($this->settings['replace']) > 0) {
             $classNames = \array_map(fn (string $className) => $this->settings['replace'][$className] ?? $className, $classNames);

--- a/EMS/helpers/src/Standard/Number.php
+++ b/EMS/helpers/src/Standard/Number.php
@@ -18,7 +18,7 @@ class Number
         $units = ['B', 'KB', 'MB', 'GB', 'TB'];
         $bytes = \max($bytes, 0);
 
-        $pow = \floor(($bytes ? \log($bytes) : 0) / \log(1024));
+        $pow = (int) \floor(($bytes ? \log($bytes) : 0) / \log(1024));
         $pow = \min($pow, \count($units) - 1);
 
         $bytes /= 1024 ** $pow;

--- a/EMS/helpers/src/Standard/Text.php
+++ b/EMS/helpers/src/Standard/Text.php
@@ -33,7 +33,7 @@ class Text
             throw new \RuntimeException('Humanize failed!');
         }
 
-        $str = \array_map('ucwords', $str);
+        $str = \array_map(ucwords(...), $str);
 
         return \implode(' ', $str);
     }

--- a/EMS/submission-bundle/src/Request/DatabaseRequest.php
+++ b/EMS/submission-bundle/src/Request/DatabaseRequest.php
@@ -105,7 +105,7 @@ final readonly class DatabaseRequest
             $fileResolver = new OptionsResolver();
             $fileResolver->setRequired(['filename', 'mimeType', 'base64', 'size', 'form_field']);
 
-            $resolvedDatabaseRecord['files'] = \array_map(fn (array $file) => $fileResolver->resolve($file), $resolvedDatabaseRecord['files']);
+            $resolvedDatabaseRecord['files'] = \array_map($fileResolver->resolve(...), $resolvedDatabaseRecord['files']);
 
             return $resolvedDatabaseRecord;
         } catch (ExceptionInterface $e) {

--- a/composer.lock
+++ b/composer.lock
@@ -62,16 +62,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.356.27",
+            "version": "3.357.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "6f6b8cfdc1a1555b7a749395a79bda51910646e0"
+                "reference": "0325c653b022aedb38f397cf559ab4d0f7967901"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/6f6b8cfdc1a1555b7a749395a79bda51910646e0",
-                "reference": "6f6b8cfdc1a1555b7a749395a79bda51910646e0",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/0325c653b022aedb38f397cf559ab4d0f7967901",
+                "reference": "0325c653b022aedb38f397cf559ab4d0f7967901",
                 "shasum": ""
             },
             "require": {
@@ -153,9 +153,9 @@
             "support": {
                 "forum": "https://github.com/aws/aws-sdk-php/discussions",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.356.27"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.357.0"
             },
-            "time": "2025-09-26T18:12:38+00:00"
+            "time": "2025-10-22T19:43:07+00:00"
         },
         {
             "name": "bacon/bacon-qr-code",
@@ -685,16 +685,16 @@
         },
         {
             "name": "doctrine/dbal",
-            "version": "4.3.3",
+            "version": "4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "231959669bb2173194c95636eae7f1b41b2a8b19"
+                "reference": "1a2fbd0e93b8dec7c3d1ac2b6396a7b929b130dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/231959669bb2173194c95636eae7f1b41b2a8b19",
-                "reference": "231959669bb2173194c95636eae7f1b41b2a8b19",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/1a2fbd0e93b8dec7c3d1ac2b6396a7b929b130dc",
+                "reference": "1a2fbd0e93b8dec7c3d1ac2b6396a7b929b130dc",
                 "shasum": ""
             },
             "require": {
@@ -704,15 +704,15 @@
                 "psr/log": "^1|^2|^3"
             },
             "require-dev": {
-                "doctrine/coding-standard": "13.0.1",
+                "doctrine/coding-standard": "14.0.0",
                 "fig/log-test": "^1",
                 "jetbrains/phpstorm-stubs": "2023.2",
-                "phpstan/phpstan": "2.1.22",
-                "phpstan/phpstan-phpunit": "2.0.6",
+                "phpstan/phpstan": "2.1.30",
+                "phpstan/phpstan-phpunit": "2.0.7",
                 "phpstan/phpstan-strict-rules": "^2",
                 "phpunit/phpunit": "11.5.23",
-                "slevomat/coding-standard": "8.16.2",
-                "squizlabs/php_codesniffer": "3.13.1",
+                "slevomat/coding-standard": "8.24.0",
+                "squizlabs/php_codesniffer": "4.0.0",
                 "symfony/cache": "^6.3.8|^7.0",
                 "symfony/console": "^5.4|^6.3|^7.0"
             },
@@ -771,7 +771,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/dbal/issues",
-                "source": "https://github.com/doctrine/dbal/tree/4.3.3"
+                "source": "https://github.com/doctrine/dbal/tree/4.3.4"
             },
             "funding": [
                 {
@@ -787,7 +787,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-04T23:52:42+00:00"
+            "time": "2025-10-09T09:11:36+00:00"
         },
         {
             "name": "doctrine/deprecations",
@@ -839,20 +839,21 @@
         },
         {
             "name": "doctrine/doctrine-bundle",
-            "version": "2.16.2",
+            "version": "2.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/DoctrineBundle.git",
-                "reference": "1c10de0fe995f01eca6b073d1c2549ef0b603a7f"
+                "reference": "cd5d4da6a5f7cf3d8708e17211234657b5eb4e95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/DoctrineBundle/zipball/1c10de0fe995f01eca6b073d1c2549ef0b603a7f",
-                "reference": "1c10de0fe995f01eca6b073d1c2549ef0b603a7f",
+                "url": "https://api.github.com/repos/doctrine/DoctrineBundle/zipball/cd5d4da6a5f7cf3d8708e17211234657b5eb4e95",
+                "reference": "cd5d4da6a5f7cf3d8708e17211234657b5eb4e95",
                 "shasum": ""
             },
             "require": {
                 "doctrine/dbal": "^3.7.0 || ^4.0",
+                "doctrine/deprecations": "^1.0",
                 "doctrine/persistence": "^3.1 || ^4",
                 "doctrine/sql-formatter": "^1.0.1",
                 "php": "^8.1",
@@ -860,7 +861,6 @@
                 "symfony/config": "^6.4 || ^7.0",
                 "symfony/console": "^6.4 || ^7.0",
                 "symfony/dependency-injection": "^6.4 || ^7.0",
-                "symfony/deprecation-contracts": "^2.1 || ^3",
                 "symfony/doctrine-bridge": "^6.4.3 || ^7.0.3",
                 "symfony/framework-bundle": "^6.4 || ^7.0",
                 "symfony/service-contracts": "^2.5 || ^3"
@@ -875,14 +875,13 @@
             "require-dev": {
                 "doctrine/annotations": "^1 || ^2",
                 "doctrine/cache": "^1.11 || ^2.0",
-                "doctrine/coding-standard": "^13",
-                "doctrine/deprecations": "^1.0",
+                "doctrine/coding-standard": "^14",
                 "doctrine/orm": "^2.17 || ^3.1",
                 "friendsofphp/proxy-manager-lts": "^1.0",
                 "phpstan/phpstan": "2.1.1",
                 "phpstan/phpstan-phpunit": "2.0.3",
                 "phpstan/phpstan-strict-rules": "^2",
-                "phpunit/phpunit": "^10.5.53",
+                "phpunit/phpunit": "^10.5.53 || ^12.3.10",
                 "psr/log": "^1.1.4 || ^2.0 || ^3.0",
                 "symfony/doctrine-messenger": "^6.4 || ^7.0",
                 "symfony/expression-language": "^6.4 || ^7.0",
@@ -896,7 +895,7 @@
                 "symfony/var-exporter": "^6.4.1 || ^7.0.1",
                 "symfony/web-profiler-bundle": "^6.4 || ^7.0",
                 "symfony/yaml": "^6.4 || ^7.0",
-                "twig/twig": "^2.13 || ^3.0.4"
+                "twig/twig": "^2.14.7 || ^3.0.4"
             },
             "suggest": {
                 "doctrine/orm": "The Doctrine ORM integration is optional in the bundle.",
@@ -941,7 +940,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/DoctrineBundle/issues",
-                "source": "https://github.com/doctrine/DoctrineBundle/tree/2.16.2"
+                "source": "https://github.com/doctrine/DoctrineBundle/tree/2.18.0"
             },
             "funding": [
                 {
@@ -957,24 +956,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-10T19:14:48+00:00"
+            "time": "2025-10-11T04:43:27+00:00"
         },
         {
             "name": "doctrine/doctrine-migrations-bundle",
-            "version": "3.4.2",
+            "version": "3.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/DoctrineMigrationsBundle.git",
-                "reference": "5a6ac7120c2924c4c070a869d08b11ccf9e277b9"
+                "reference": "71c81279ca0e907c3edc718418b93fd63074856c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/DoctrineMigrationsBundle/zipball/5a6ac7120c2924c4c070a869d08b11ccf9e277b9",
-                "reference": "5a6ac7120c2924c4c070a869d08b11ccf9e277b9",
+                "url": "https://api.github.com/repos/doctrine/DoctrineMigrationsBundle/zipball/71c81279ca0e907c3edc718418b93fd63074856c",
+                "reference": "71c81279ca0e907c3edc718418b93fd63074856c",
                 "shasum": ""
             },
             "require": {
-                "doctrine/doctrine-bundle": "^2.4",
+                "doctrine/doctrine-bundle": "^2.4 || ^3.0",
                 "doctrine/migrations": "^3.2",
                 "php": "^7.2 || ^8.0",
                 "symfony/deprecation-contracts": "^2.1 || ^3",
@@ -982,7 +981,7 @@
             },
             "require-dev": {
                 "composer/semver": "^3.0",
-                "doctrine/coding-standard": "^12",
+                "doctrine/coding-standard": "^12 || ^14",
                 "doctrine/orm": "^2.6 || ^3",
                 "phpstan/phpstan": "^1.4 || ^2",
                 "phpstan/phpstan-deprecation-rules": "^1 || ^2",
@@ -1026,7 +1025,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/DoctrineMigrationsBundle/issues",
-                "source": "https://github.com/doctrine/DoctrineMigrationsBundle/tree/3.4.2"
+                "source": "https://github.com/doctrine/DoctrineMigrationsBundle/tree/3.5.0"
             },
             "funding": [
                 {
@@ -1042,7 +1041,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-11T17:36:26+00:00"
+            "time": "2025-10-12T17:06:40+00:00"
         },
         {
             "name": "doctrine/event-manager",
@@ -1567,16 +1566,16 @@
         },
         {
             "name": "doctrine/persistence",
-            "version": "4.1.0",
+            "version": "4.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/persistence.git",
-                "reference": "dcbdfe4b211ae09478e192289cae7ab0987b29a4"
+                "reference": "b9c49ad3558bb77ef973f4e173f2e9c2eca9be09"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/persistence/zipball/dcbdfe4b211ae09478e192289cae7ab0987b29a4",
-                "reference": "dcbdfe4b211ae09478e192289cae7ab0987b29a4",
+                "url": "https://api.github.com/repos/doctrine/persistence/zipball/b9c49ad3558bb77ef973f4e173f2e9c2eca9be09",
+                "reference": "b9c49ad3558bb77ef973f4e173f2e9c2eca9be09",
                 "shasum": ""
             },
             "require": {
@@ -1585,11 +1584,11 @@
                 "psr/cache": "^1.0 || ^2.0 || ^3.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^12",
-                "phpstan/phpstan": "1.12.7",
-                "phpstan/phpstan-phpunit": "^1",
-                "phpstan/phpstan-strict-rules": "^1.6",
-                "phpunit/phpunit": "^9.6",
+                "doctrine/coding-standard": "^14",
+                "phpstan/phpstan": "2.1.30",
+                "phpstan/phpstan-phpunit": "^2",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "^10.5.58 || ^12",
                 "symfony/cache": "^4.4 || ^5.4 || ^6.0 || ^7.0",
                 "symfony/finder": "^4.4 || ^5.4 || ^6.0 || ^7.0"
             },
@@ -1640,7 +1639,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/persistence/issues",
-                "source": "https://github.com/doctrine/persistence/tree/4.1.0"
+                "source": "https://github.com/doctrine/persistence/tree/4.1.1"
             },
             "funding": [
                 {
@@ -1656,7 +1655,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-21T16:00:31+00:00"
+            "time": "2025-10-16T20:13:18+00:00"
         },
         {
             "name": "doctrine/sql-formatter",
@@ -1715,16 +1714,16 @@
         },
         {
             "name": "dompdf/dompdf",
-            "version": "v3.1.2",
+            "version": "v3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dompdf/dompdf.git",
-                "reference": "b3493e35d31a5e76ec24c3b64a29b0034b2f32a6"
+                "reference": "baed300e4fb8226359c04395518059a136e2a2e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dompdf/dompdf/zipball/b3493e35d31a5e76ec24c3b64a29b0034b2f32a6",
-                "reference": "b3493e35d31a5e76ec24c3b64a29b0034b2f32a6",
+                "url": "https://api.github.com/repos/dompdf/dompdf/zipball/baed300e4fb8226359c04395518059a136e2a2e2",
+                "reference": "baed300e4fb8226359c04395518059a136e2a2e2",
                 "shasum": ""
             },
             "require": {
@@ -1773,9 +1772,9 @@
             "homepage": "https://github.com/dompdf/dompdf",
             "support": {
                 "issues": "https://github.com/dompdf/dompdf/issues",
-                "source": "https://github.com/dompdf/dompdf/tree/v3.1.2"
+                "source": "https://github.com/dompdf/dompdf/tree/v3.1.3"
             },
-            "time": "2025-09-23T03:06:41+00:00"
+            "time": "2025-10-14T13:10:17+00:00"
         },
         {
             "name": "dompdf/php-font-lib",
@@ -2383,20 +2382,20 @@
         },
         {
             "name": "ezyang/htmlpurifier",
-            "version": "v4.18.0",
+            "version": "v4.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ezyang/htmlpurifier.git",
-                "reference": "cb56001e54359df7ae76dc522d08845dc741621b"
+                "reference": "b287d2a16aceffbf6e0295559b39662612b77fcf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/cb56001e54359df7ae76dc522d08845dc741621b",
-                "reference": "cb56001e54359df7ae76dc522d08845dc741621b",
+                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/b287d2a16aceffbf6e0295559b39662612b77fcf",
+                "reference": "b287d2a16aceffbf6e0295559b39662612b77fcf",
                 "shasum": ""
             },
             "require": {
-                "php": "~5.6.0 || ~7.0.0 || ~7.1.0 || ~7.2.0 || ~7.3.0 || ~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+                "php": "~5.6.0 || ~7.0.0 || ~7.1.0 || ~7.2.0 || ~7.3.0 || ~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
             },
             "require-dev": {
                 "cerdic/css-tidy": "^1.7 || ^2.0",
@@ -2438,9 +2437,9 @@
             ],
             "support": {
                 "issues": "https://github.com/ezyang/htmlpurifier/issues",
-                "source": "https://github.com/ezyang/htmlpurifier/tree/v4.18.0"
+                "source": "https://github.com/ezyang/htmlpurifier/tree/v4.19.0"
             },
-            "time": "2024-11-01T03:51:45+00:00"
+            "time": "2025-10-17T16:34:55+00:00"
         },
         {
             "name": "firebase/php-jwt",
@@ -3050,22 +3049,22 @@
         },
         {
             "name": "lcobucci/jwt",
-            "version": "5.5.0",
+            "version": "5.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lcobucci/jwt.git",
-                "reference": "a835af59b030d3f2967725697cf88300f579088e"
+                "reference": "bb3e9f21e4196e8afc41def81ef649c164bca25e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/a835af59b030d3f2967725697cf88300f579088e",
-                "reference": "a835af59b030d3f2967725697cf88300f579088e",
+                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/bb3e9f21e4196e8afc41def81ef649c164bca25e",
+                "reference": "bb3e9f21e4196e8afc41def81ef649c164bca25e",
                 "shasum": ""
             },
             "require": {
                 "ext-openssl": "*",
                 "ext-sodium": "*",
-                "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
                 "psr/clock": "^1.0"
             },
             "require-dev": {
@@ -3107,7 +3106,7 @@
             ],
             "support": {
                 "issues": "https://github.com/lcobucci/jwt/issues",
-                "source": "https://github.com/lcobucci/jwt/tree/5.5.0"
+                "source": "https://github.com/lcobucci/jwt/tree/5.6.0"
             },
             "funding": [
                 {
@@ -3119,20 +3118,20 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2025-01-26T21:29:45+00:00"
+            "time": "2025-10-17T11:30:53+00:00"
         },
         {
             "name": "league/flysystem",
-            "version": "3.30.0",
+            "version": "3.30.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "2203e3151755d874bb2943649dae1eb8533ac93e"
+                "reference": "c139fd65c1f796b926f4aec0df37f6caa959a8da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/2203e3151755d874bb2943649dae1eb8533ac93e",
-                "reference": "2203e3151755d874bb2943649dae1eb8533ac93e",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/c139fd65c1f796b926f4aec0df37f6caa959a8da",
+                "reference": "c139fd65c1f796b926f4aec0df37f6caa959a8da",
                 "shasum": ""
             },
             "require": {
@@ -3200,9 +3199,9 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem/issues",
-                "source": "https://github.com/thephpleague/flysystem/tree/3.30.0"
+                "source": "https://github.com/thephpleague/flysystem/tree/3.30.1"
             },
-            "time": "2025-06-25T13:29:59+00:00"
+            "time": "2025-10-20T15:35:26+00:00"
         },
         {
             "name": "league/flysystem-local",
@@ -4470,16 +4469,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.46",
+            "version": "3.0.47",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "56483a7de62a6c2a6635e42e93b8a9e25d4f0ec6"
+                "reference": "9d6ca36a6c2dd434765b1071b2644a1c683b385d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/56483a7de62a6c2a6635e42e93b8a9e25d4f0ec6",
-                "reference": "56483a7de62a6c2a6635e42e93b8a9e25d4f0ec6",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/9d6ca36a6c2dd434765b1071b2644a1c683b385d",
+                "reference": "9d6ca36a6c2dd434765b1071b2644a1c683b385d",
                 "shasum": ""
             },
             "require": {
@@ -4560,7 +4559,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.46"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.47"
             },
             "funding": [
                 {
@@ -4576,7 +4575,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-26T16:29:55+00:00"
+            "time": "2025-10-06T01:07:24+00:00"
         },
         {
             "name": "promphp/prometheus_client_php",
@@ -12022,28 +12021,28 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.11.0",
+            "version": "1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "11cb2199493b2f8a3b53e7f19068fc6aac760991"
+                "reference": "541057574806f942c94662b817a50f63f7345360"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/11cb2199493b2f8a3b53e7f19068fc6aac760991",
-                "reference": "11cb2199493b2f8a3b53e7f19068fc6aac760991",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/541057574806f942c94662b817a50f63f7345360",
+                "reference": "541057574806f942c94662b817a50f63f7345360",
                 "shasum": ""
             },
             "require": {
                 "ext-ctype": "*",
+                "ext-date": "*",
+                "ext-filter": "*",
                 "php": "^7.2 || ^8.0"
             },
-            "conflict": {
-                "phpstan/phpstan": "<0.12.20",
-                "vimeo/psalm": "<4.6.1 || 4.6.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^8.5.13"
+            "suggest": {
+                "ext-intl": "",
+                "ext-simplexml": "",
+                "ext-spl": ""
             },
             "type": "library",
             "extra": {
@@ -12074,9 +12073,9 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.11.0"
+                "source": "https://github.com/webmozarts/assert/tree/1.12.0"
             },
-            "time": "2022-06-03T18:03:27+00:00"
+            "time": "2025-10-20T12:43:39+00:00"
         }
     ],
     "packages-dev": [
@@ -12532,16 +12531,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.88.2",
+            "version": "v3.89.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "a8d15584bafb0f0d9d938827840060fd4a3ebc99"
+                "reference": "4dd6768cb7558440d27d18f54909eee417317ce9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/a8d15584bafb0f0d9d938827840060fd4a3ebc99",
-                "reference": "a8d15584bafb0f0d9d938827840060fd4a3ebc99",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/4dd6768cb7558440d27d18f54909eee417317ce9",
+                "reference": "4dd6768cb7558440d27d18f54909eee417317ce9",
                 "shasum": ""
             },
             "require": {
@@ -12556,7 +12555,6 @@
                 "php": "^7.4 || ^8.0",
                 "react/child-process": "^0.6.6",
                 "react/event-loop": "^1.5",
-                "react/promise": "^3.3",
                 "react/socket": "^1.16",
                 "react/stream": "^1.4",
                 "sebastian/diff": "^4.0.6 || ^5.1.1 || ^6.0.2 || ^7.0",
@@ -12624,7 +12622,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.88.2"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.89.0"
             },
             "funding": [
                 {
@@ -12632,7 +12630,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-27T00:24:15+00:00"
+            "time": "2025-10-18T19:30:16+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -13036,16 +13034,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.6.1",
+            "version": "v5.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2"
+                "reference": "3a454ca033b9e06b63282ce19562e892747449bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
-                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/3a454ca033b9e06b63282ce19562e892747449bb",
+                "reference": "3a454ca033b9e06b63282ce19562e892747449bb",
                 "shasum": ""
             },
             "require": {
@@ -13088,9 +13086,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.2"
             },
-            "time": "2025-08-13T20:13:15+00:00"
+            "time": "2025-10-21T19:32:17+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -13919,16 +13917,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.29",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpstan/phpstan-phar-composer-source.git",
-                "reference": "git"
-            },
+            "version": "2.1.31",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d618573eed4a1b6b75e37b2e0b65ac65c885d88e",
-                "reference": "d618573eed4a1b6b75e37b2e0b65ac65c885d88e",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ead89849d879fe203ce9292c6ef5e7e76f867b96",
+                "reference": "ead89849d879fe203ce9292c6ef5e7e76f867b96",
                 "shasum": ""
             },
             "require": {
@@ -13973,7 +13966,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-25T06:58:18+00:00"
+            "time": "2025-10-10T14:14:11+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",
@@ -14024,16 +14017,16 @@
         },
         {
             "name": "phpstan/phpstan-doctrine",
-            "version": "2.0.6",
+            "version": "2.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-doctrine.git",
-                "reference": "934f5734812341358fc41c44006b30fa00c785f0"
+                "reference": "5eaf37b87288474051469aee9f937fc9d862f330"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-doctrine/zipball/934f5734812341358fc41c44006b30fa00c785f0",
-                "reference": "934f5734812341358fc41c44006b30fa00c785f0",
+                "url": "https://api.github.com/repos/phpstan/phpstan-doctrine/zipball/5eaf37b87288474051469aee9f937fc9d862f330",
+                "reference": "5eaf37b87288474051469aee9f937fc9d862f330",
                 "shasum": ""
             },
             "require": {
@@ -14067,7 +14060,8 @@
                 "phpstan/phpstan-strict-rules": "^2.0",
                 "phpunit/phpunit": "^9.6.20",
                 "ramsey/uuid": "^4.2",
-                "symfony/cache": "^5.4"
+                "symfony/cache": "^5.4",
+                "symfony/uid": "^5.4 || ^6.4 || ^7.3"
             },
             "type": "phpstan-extension",
             "extra": {
@@ -14090,9 +14084,9 @@
             "description": "Doctrine extensions for PHPStan",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-doctrine/issues",
-                "source": "https://github.com/phpstan/phpstan-doctrine/tree/2.0.6"
+                "source": "https://github.com/phpstan/phpstan-doctrine/tree/2.0.10"
             },
-            "time": "2025-09-10T07:06:30+00:00"
+            "time": "2025-10-06T10:01:02+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -15117,21 +15111,21 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.1.7",
+            "version": "2.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "c34cc07c4698f007a20dc5c99ff820089ae413ce"
+                "reference": "fb9418af7777dfb1c87a536dc58398b5b07c74b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/c34cc07c4698f007a20dc5c99ff820089ae413ce",
-                "reference": "c34cc07c4698f007a20dc5c99ff820089ae413ce",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/fb9418af7777dfb1c87a536dc58398b5b07c74b9",
+                "reference": "fb9418af7777dfb1c87a536dc58398b5b07c74b9",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4|^8.0",
-                "phpstan/phpstan": "^2.1.18"
+                "phpstan/phpstan": "^2.1.26"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -15165,7 +15159,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.1.7"
+                "source": "https://github.com/rectorphp/rector/tree/2.2.5"
             },
             "funding": [
                 {
@@ -15173,7 +15167,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-10T11:13:58+00:00"
+            "time": "2025-10-23T11:22:37+00:00"
         },
         {
             "name": "roave/security-advisories",
@@ -15181,18 +15175,18 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "684ef27cdce62b6562f77a92dc76bdfb46542a2d"
+                "reference": "785bf86a070e8e21eb07b875d8790a960984d6ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/684ef27cdce62b6562f77a92dc76bdfb46542a2d",
-                "reference": "684ef27cdce62b6562f77a92dc76bdfb46542a2d",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/785bf86a070e8e21eb07b875d8790a960984d6ca",
+                "reference": "785bf86a070e8e21eb07b875d8790a960984d6ca",
                 "shasum": ""
             },
             "conflict": {
                 "3f/pygmentize": "<1.2",
                 "adaptcms/adaptcms": "<=1.3",
-                "admidio/admidio": "<4.3.12",
+                "admidio/admidio": "<=4.3.16",
                 "adodb/adodb-php": "<=5.22.9",
                 "aheinze/cockpit": "<2.2",
                 "aimeos/ai-admin-graphql": ">=2022.04.1,<2022.10.10|>=2023.04.1,<2023.10.6|>=2024.04.1,<2024.07.2",
@@ -15205,6 +15199,7 @@
                 "akaunting/akaunting": "<2.1.13",
                 "akeneo/pim-community-dev": "<5.0.119|>=6,<6.0.53",
                 "alextselegidis/easyappointments": "<1.5.2.0-beta1",
+                "alt-design/alt-redirect": "<1.6.4",
                 "alterphp/easyadmin-extension-bundle": ">=1.2,<1.2.11|>=1.3,<1.3.1",
                 "amazing/media2click": ">=1,<1.3.3",
                 "ameos/ameos_tarteaucitron": "<1.2.23",
@@ -15228,10 +15223,10 @@
                 "athlon1600/php-proxy-app": "<=3",
                 "athlon1600/youtube-downloader": "<=4",
                 "austintoddj/canvas": "<=3.4.2",
-                "auth0/auth0-php": ">=8.0.0.0-beta1,<8.14",
-                "auth0/login": "<7.17",
-                "auth0/symfony": "<5.4",
-                "auth0/wordpress": "<5.3",
+                "auth0/auth0-php": ">=3.3,<=8.16",
+                "auth0/login": "<=7.18",
+                "auth0/symfony": "<=5.4.1",
+                "auth0/wordpress": "<=5.3",
                 "automad/automad": "<2.0.0.0-alpha5",
                 "automattic/jetpack": "<9.8",
                 "awesome-support/awesome-support": "<=6.0.7",
@@ -15243,7 +15238,7 @@
                 "backpack/filemanager": "<2.0.2|>=3,<3.0.9",
                 "bacula-web/bacula-web": "<9.7.1",
                 "badaso/core": "<=2.9.11",
-                "bagisto/bagisto": "<2.1",
+                "bagisto/bagisto": "<=2.3.7",
                 "barrelstrength/sprout-base-email": "<1.2.7",
                 "barrelstrength/sprout-forms": "<3.9",
                 "barryvdh/laravel-translation-manager": "<0.6.8",
@@ -15294,6 +15289,7 @@
                 "clickstorm/cs-seo": ">=6,<6.8|>=7,<7.5|>=8,<8.4|>=9,<9.3",
                 "co-stack/fal_sftp": "<0.2.6",
                 "cockpit-hq/cockpit": "<2.11.4",
+                "code16/sharp": "<9.7",
                 "codeception/codeception": "<3.1.3|>=4,<4.1.22",
                 "codeigniter/framework": "<3.1.10",
                 "codeigniter4/framework": "<4.6.2",
@@ -15348,9 +15344,10 @@
                 "doctrine/mongodb-odm": "<1.0.2",
                 "doctrine/mongodb-odm-bundle": "<3.0.1",
                 "doctrine/orm": ">=1,<1.2.4|>=2,<2.4.8|>=2.5,<2.5.1|>=2.8.3,<2.8.4",
-                "dolibarr/dolibarr": "<=21.0.2",
+                "dolibarr/dolibarr": "<21.0.3",
                 "dompdf/dompdf": "<2.0.4",
                 "doublethreedigital/guest-entries": "<3.1.2",
+                "drupal-pattern-lab/unified-twig-extensions": "<=0.1",
                 "drupal/admin_audit_trail": "<1.0.5",
                 "drupal/ai": "<1.0.5",
                 "drupal/alogin": "<2.0.6",
@@ -15399,7 +15396,7 @@
                 "ezsystems/ezdemo-ls-extension": ">=5.4,<5.4.2.1-dev",
                 "ezsystems/ezfind-ls": ">=5.3,<5.3.6.1-dev|>=5.4,<5.4.11.1-dev|>=2017.12,<2017.12.0.1-dev",
                 "ezsystems/ezplatform": "<=1.13.6|>=2,<=2.5.24",
-                "ezsystems/ezplatform-admin-ui": ">=1.3,<1.3.5|>=1.4,<1.4.6|>=1.5,<1.5.29|>=2.3,<2.3.38|>=3.3,<3.3.39",
+                "ezsystems/ezplatform-admin-ui": ">=1.3,<1.3.5|>=1.4,<1.4.6|>=1.5,<1.5.29|>=2.3,<2.3.39|>=3.3,<3.3.39",
                 "ezsystems/ezplatform-admin-ui-assets": ">=4,<4.2.1|>=5,<5.0.1|>=5.1,<5.1.1|>=5.3.0.0-beta1,<5.3.5",
                 "ezsystems/ezplatform-graphql": ">=1.0.0.0-RC1-dev,<1.0.13|>=2.0.0.0-beta1,<2.3.12",
                 "ezsystems/ezplatform-http-cache": "<2.3.16",
@@ -15493,15 +15490,15 @@
                 "hov/jobfair": "<1.0.13|>=2,<2.0.2",
                 "httpsoft/http-message": "<1.0.12",
                 "hyn/multi-tenant": ">=5.6,<5.7.2",
-                "ibexa/admin-ui": ">=4.2,<4.2.3|>=4.6,<4.6.21",
+                "ibexa/admin-ui": ">=4.2,<4.2.3|>=4.6,<4.6.25|>=5,<5.0.3",
                 "ibexa/admin-ui-assets": ">=4.6.0.0-alpha1,<4.6.21",
                 "ibexa/core": ">=4,<4.0.7|>=4.1,<4.1.4|>=4.2,<4.2.3|>=4.5,<4.5.6|>=4.6,<4.6.2",
-                "ibexa/fieldtype-richtext": ">=4.6,<4.6.21",
+                "ibexa/fieldtype-richtext": ">=4.6,<4.6.25|>=5,<5.0.3",
                 "ibexa/graphql": ">=2.5,<2.5.31|>=3.3,<3.3.28|>=4.2,<4.2.3",
                 "ibexa/http-cache": ">=4.6,<4.6.14",
                 "ibexa/post-install": "<1.0.16|>=4.6,<4.6.14",
                 "ibexa/solr": ">=4.5,<4.5.4",
-                "ibexa/user": ">=4,<4.4.3",
+                "ibexa/user": ">=4,<4.4.3|>=5,<5.0.3",
                 "icecoder/icecoder": "<=8.1",
                 "idno/known": "<=1.3.1",
                 "ilicmiljan/secure-props": ">=1.2,<1.2.2",
@@ -15537,7 +15534,7 @@
                 "joomla/archive": "<1.1.12|>=2,<2.0.1",
                 "joomla/database": ">=1,<2.2|>=3,<3.4",
                 "joomla/filesystem": "<1.6.2|>=2,<2.0.1",
-                "joomla/filter": "<1.4.4|>=2,<2.0.1",
+                "joomla/filter": "<2.0.6|>=3,<3.0.5|==4",
                 "joomla/framework": "<1.5.7|>=2.5.4,<=3.8.12",
                 "joomla/input": ">=2,<2.0.2",
                 "joomla/joomla-cms": "<3.9.12|>=4,<4.4.13|>=5,<5.2.6",
@@ -15598,7 +15595,7 @@
                 "luyadev/yii-helpers": "<1.2.1",
                 "macropay-solutions/laravel-crud-wizard-free": "<3.4.17",
                 "maestroerror/php-heic-to-jpg": "<1.0.5",
-                "magento/community-edition": "<=2.4.5.0-patch14|==2.4.6|>=2.4.6.0-patch1,<=2.4.6.0-patch12|>=2.4.7.0-beta1,<=2.4.7.0-patch7|>=2.4.8.0-beta1,<=2.4.8.0-patch2|>=2.4.9.0-alpha1,<=2.4.9.0-alpha2|==2.4.9",
+                "magento/community-edition": "<2.4.6.0-patch13|>=2.4.7.0-beta1,<2.4.7.0-patch8|>=2.4.8.0-beta1,<2.4.8.0-patch3|>=2.4.9.0-alpha1,<2.4.9.0-alpha3|==2.4.9",
                 "magento/core": "<=1.9.4.5",
                 "magento/magento1ce": "<1.9.4.3-dev",
                 "magento/magento1ee": ">=1,<1.14.4.3-dev",
@@ -15619,14 +15616,16 @@
                 "maximebf/debugbar": "<1.19",
                 "mdanter/ecc": "<2",
                 "mediawiki/abuse-filter": "<1.39.9|>=1.40,<1.41.3|>=1.42,<1.42.2",
-                "mediawiki/cargo": "<3.6.1",
+                "mediawiki/cargo": "<3.8.3",
                 "mediawiki/core": "<1.39.5|==1.40",
                 "mediawiki/data-transfer": ">=1.39,<1.39.11|>=1.41,<1.41.3|>=1.42,<1.42.2",
                 "mediawiki/matomo": "<2.4.3",
                 "mediawiki/semantic-media-wiki": "<4.0.2",
                 "mehrwert/phpmyadmin": "<3.2",
                 "melisplatform/melis-asset-manager": "<5.0.1",
-                "melisplatform/melis-cms": "<5.0.1",
+                "melisplatform/melis-cms": "<5.3.4",
+                "melisplatform/melis-cms-slider": "<5.3.1",
+                "melisplatform/melis-core": "<5.3.11",
                 "melisplatform/melis-front": "<5.0.1",
                 "mezzio/mezzio-swoole": "<3.7|>=4,<4.3",
                 "mgallegos/laravel-jqgrid": "<=1.3",
@@ -15677,7 +15676,7 @@
                 "notrinos/notrinos-erp": "<=0.7",
                 "noumo/easyii": "<=0.9",
                 "novaksolutions/infusionsoft-php-sdk": "<1",
-                "novosga/novosga": "<=2.2.9",
+                "novosga/novosga": "<=2.2.12",
                 "nukeviet/nukeviet": "<4.5.02",
                 "nyholm/psr7": "<1.6.1",
                 "nystudio107/craft-seomatic": "<3.4.12",
@@ -15692,7 +15691,7 @@
                 "omeka/omeka-s": "<4.0.3",
                 "onelogin/php-saml": "<2.10.4",
                 "oneup/uploader-bundle": ">=1,<1.9.3|>=2,<2.1.5",
-                "open-web-analytics/open-web-analytics": "<1.7.4",
+                "open-web-analytics/open-web-analytics": "<1.8.1",
                 "opencart/opencart": ">=0",
                 "openid/php-openid": "<2.3",
                 "openmage/magento-lts": "<20.12.3",
@@ -15771,12 +15770,13 @@
                 "prestashop/gamification": "<2.3.2",
                 "prestashop/prestashop": "<8.2.3",
                 "prestashop/productcomments": "<5.0.2",
+                "prestashop/ps_checkout": "<4.4.1|>=5,<5.0.5",
                 "prestashop/ps_contactinfo": "<=3.3.2",
                 "prestashop/ps_emailsubscription": "<2.6.1",
                 "prestashop/ps_facetedsearch": "<3.4.1",
                 "prestashop/ps_linklist": "<3.1",
                 "privatebin/privatebin": "<1.4|>=1.5,<1.7.4",
-                "processwire/processwire": "<=3.0.229",
+                "processwire/processwire": "<=3.0.246",
                 "propel/propel": ">=2.0.0.0-alpha1,<=2.0.0.0-alpha7",
                 "propel/propel1": ">=1,<=1.7.1",
                 "pterodactyl/panel": "<=1.11.10",
@@ -15819,8 +15819,8 @@
                 "setasign/fpdi": "<2.6.4",
                 "sfroemken/url_redirect": "<=1.2.1",
                 "sheng/yiicms": "<1.2.1",
-                "shopware/core": "<6.5.8.18-dev|>=6.6,<6.6.10.3-dev|>=6.7,<6.7.2.1-dev",
-                "shopware/platform": "<=6.6.10.4|>=6.7.0.0-RC1-dev,<6.7.0.0-RC2-dev",
+                "shopware/core": "<6.6.10.7-dev|>=6.7,<6.7.3.1-dev",
+                "shopware/platform": "<6.6.10.7-dev|>=6.7,<6.7.3.1-dev",
                 "shopware/production": "<=6.3.5.2",
                 "shopware/shopware": "<=5.7.17|>=6.7,<6.7.2.1-dev",
                 "shopware/storefront": "<=6.4.8.1|>=6.5.8,<6.5.8.7-dev",
@@ -15877,7 +15877,7 @@
                 "spoonity/tcpdf": "<6.2.22",
                 "squizlabs/php_codesniffer": ">=1,<2.8.1|>=3,<3.0.1",
                 "ssddanbrown/bookstack": "<24.05.1",
-                "starcitizentools/citizen-skin": ">=1.9.4,<3.4",
+                "starcitizentools/citizen-skin": ">=1.9.4,<3.9",
                 "starcitizentools/short-description": ">=4,<4.0.1",
                 "starcitizentools/tabber-neue": ">=1.9.1,<2.7.2|>=3,<3.1.1",
                 "starcitizenwiki/embedvideo": "<=4",
@@ -15955,7 +15955,7 @@
                 "thelia/thelia": ">=2.1,<2.1.3",
                 "theonedemon/phpwhois": "<=4.2.5",
                 "thinkcmf/thinkcmf": "<6.0.8",
-                "thorsten/phpmyfaq": "<=4.0.1",
+                "thorsten/phpmyfaq": "<=4.0.1|>=4.0.7,<4.0.13",
                 "tikiwiki/tiki-manager": "<=17.1",
                 "timber/timber": ">=0.16.6,<1.23.1|>=1.24,<1.24.1|>=2,<2.1",
                 "tinymce/tinymce": "<7.2",
@@ -15971,7 +15971,7 @@
                 "tribalsystems/zenario": "<=9.7.61188",
                 "truckersmp/phpwhois": "<=4.3.1",
                 "ttskch/pagination-service-provider": "<1",
-                "twbs/bootstrap": "<3.4.1|>=4,<=4.6.2",
+                "twbs/bootstrap": "<3.4.1|>=4,<4.3.1",
                 "twig/twig": "<3.11.2|>=3.12,<3.14.1|>=3.16,<3.19",
                 "typo3/cms": "<9.5.29|>=10,<10.4.35|>=11,<11.5.23|>=12,<12.2",
                 "typo3/cms-backend": "<4.1.14|>=4.2,<4.2.15|>=4.3,<4.3.7|>=4.4,<4.4.4|>=7,<=7.6.50|>=8,<=8.7.39|>=9,<9.5.55|>=10,<10.4.54|>=11,<11.5.48|>=12,<12.4.37|>=13,<13.4.18",
@@ -16035,6 +16035,7 @@
                 "webklex/laravel-imap": "<5.3",
                 "webklex/php-imap": "<5.3",
                 "webpa/webpa": "<3.1.2",
+                "webreinvent/vaahcms": "<=2.3.1",
                 "wikibase/wikibase": "<=1.39.3",
                 "wikimedia/parsoid": "<0.12.2",
                 "willdurand/js-translation-bundle": "<2.1.1",
@@ -16147,7 +16148,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-24T21:05:21+00:00"
+            "time": "2025-10-22T17:05:47+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/elasticms-cli/src/Client/File/ImportConfig.php
+++ b/elasticms-cli/src/Client/File/ImportConfig.php
@@ -78,7 +78,7 @@ class ImportConfig
                     ->setAllowedTypes('source', 'string')
                     ->setAllowedTypes('target', 'string');
 
-                return \array_map(static fn (mixed $item) => $alignEnvironment->resolve($item), $value);
+                return \array_map($alignEnvironment->resolve(...), $value);
             })
         ;
 

--- a/elasticms-cli/src/Client/HttpClient/HttpResult.php
+++ b/elasticms-cli/src/Client/HttpClient/HttpResult.php
@@ -79,12 +79,6 @@ class HttpResult
 
     public function isHtml(): bool
     {
-        foreach (['text/html', 'application/xhtml+xml'] as $mimeType) {
-            if (\str_starts_with($this->getMimetype(), $mimeType)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(['text/html', 'application/xhtml+xml'], fn($mimeType) => \str_starts_with($this->getMimetype(), (string) $mimeType));
     }
 }

--- a/elasticms-cli/src/Client/HttpClient/HttpResult.php
+++ b/elasticms-cli/src/Client/HttpClient/HttpResult.php
@@ -79,6 +79,6 @@ class HttpResult
 
     public function isHtml(): bool
     {
-        return array_any(['text/html', 'application/xhtml+xml'], fn($mimeType) => \str_starts_with($this->getMimetype(), (string) $mimeType));
+        return \array_any(['text/html', 'application/xhtml+xml'], fn ($mimeType) => \str_starts_with($this->getMimetype(), (string) $mimeType));
     }
 }

--- a/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySync.php
+++ b/elasticms-cli/src/Client/MediaLibrary/MediaLibrarySync.php
@@ -264,7 +264,7 @@ final class MediaLibrarySync
         $metadataFilePath = $this->options->hashMetaDataFile ? $this->getFileByHash($metadataFile) : $metadataFile;
 
         $rows = $this->fileReader->getData($metadataFilePath);
-        $header = \array_map('trim', $rows[0] ?? []);
+        $header = \array_map(trim(...), $rows[0] ?? []);
         $this->metadatas = [];
         foreach ($rows as $rowIndex => $value) {
             if (0 === $rowIndex) {

--- a/elasticms-cli/src/Client/WebToElasticms/Config/ConfigManager.php
+++ b/elasticms-cli/src/Client/WebToElasticms/Config/ConfigManager.php
@@ -451,7 +451,7 @@ class ConfigManager
         $this->expressionLanguage->register(
             'split',
             fn ($pattern, $str, $limit = -1, $flags = PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY) => \sprintf('((null === %1$s || null === %2$s) ? null : \\preg_split(%1$s, %2$s, %3$d, %4$d))', $pattern, $str, $limit, $flags),
-            fn ($arguments, $pattern, $str, $limit = -1, $flags = PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY) => (null === $pattern || null === $str) ? null : \preg_split($pattern, (string) $str, $limit, $flags)
+            fn ($arguments, $pattern, $str, $limit = -1, $flags = PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY) => (null === $pattern || null === $str) ? null : \preg_split($pattern, (string) $str, (int) $limit, $flags)
         );
 
         $this->expressionLanguage->register(

--- a/elasticms-cli/src/Client/WebToElasticms/Config/Document.php
+++ b/elasticms-cli/src/Client/WebToElasticms/Config/Document.php
@@ -62,13 +62,7 @@ class Document
 
     public function hasResourceFor(string $locale): bool
     {
-        foreach ($this->resources as $resource) {
-            if ($resource->getLocale() === $locale) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($this->resources, fn($resource) => $resource->getLocale() === $locale);
     }
 
     public function getResourceFor(string $locale): ?string

--- a/elasticms-cli/src/Client/WebToElasticms/Config/Document.php
+++ b/elasticms-cli/src/Client/WebToElasticms/Config/Document.php
@@ -62,7 +62,7 @@ class Document
 
     public function hasResourceFor(string $locale): bool
     {
-        return array_any($this->resources, fn($resource) => $resource->getLocale() === $locale);
+        return \array_any($this->resources, fn ($resource) => $resource->getLocale() === $locale);
     }
 
     public function getResourceFor(string $locale): ?string

--- a/elasticms-cli/tests/Data/Column/DataColumnBusinessIdTest.php
+++ b/elasticms-cli/tests/Data/Column/DataColumnBusinessIdTest.php
@@ -75,11 +75,11 @@ final class DataColumnBusinessIdTest extends TestCase
         ]);
 
         $scroll = $this->createMock(Scroll::class);
-        $scroll->expects($this->any())->method('current')->willReturnCallback(fn () => $iterator->current());
-        $scroll->expects($this->any())->method('next')->willReturnCallback(fn () => $iterator->next());
-        $scroll->expects($this->any())->method('rewind')->willReturnCallback(fn () => $iterator->rewind());
-        $scroll->expects($this->any())->method('valid')->willReturnCallback(fn () => $iterator->valid());
-        $scroll->expects($this->any())->method('key')->willReturnCallback(fn () => $iterator->key());
+        $scroll->expects($this->any())->method('current')->willReturnCallback($iterator->current(...));
+        $scroll->expects($this->any())->method('next')->willReturnCallback($iterator->next(...));
+        $scroll->expects($this->any())->method('rewind')->willReturnCallback($iterator->rewind(...));
+        $scroll->expects($this->any())->method('valid')->willReturnCallback($iterator->valid(...));
+        $scroll->expects($this->any())->method('key')->willReturnCallback($iterator->key(...));
 
         $search = $this->createMock(Search::class);
         $search


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  n |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

A lot of foreach are refactored by  rector with new \array_any and \array_all

## \array_any(array $array, callable $callback): bool
Checks if at least one element in the array satisfies the callback.

- Returns true as soon as one element returns true.
- Returns false if no elements satisfy the callback.

## \array_all(array $array, callable $callback): bool
Checks if all elements in the array satisfy the callback.

- Returns false as soon as one element returns false.
- Returns true only if every element satisfies the callback.

And also replaced the inline arrow function with a strict callable for cleaner, more idiomatic, and slightly more efficient code.
