### PR TITLE
fix(admin/contentType): edit structure $id is not an int anymore

### DIFF
--- a/EMS/core-bundle/src/Controller/ContentManagement/ContentTypeController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/ContentTypeController.php
@@ -442,6 +442,7 @@ class ContentTypeController extends AbstractController
     public function editStructure(ContentType $id, Request $request): Response
     {
         $contentType = $id;
+        $id = $contentType->getId();
 
         $inputContentType = $request->request->all('content_type_structure');
 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  |  n |
| Fixed tickets? |  n |
| Documentation? | n  |

Causing issues when editing the content type's structure