### PR TITLE
fix(admin/media-lib): deprecated nested_path for parent_field

### DIFF
--- a/EMS/core-bundle/src/Core/Component/MediaLibrary/Config/MediaLibraryConfigFactory.php
+++ b/EMS/core-bundle/src/Core/Component/MediaLibrary/Config/MediaLibraryConfigFactory.php
@@ -71,8 +71,8 @@ class MediaLibraryConfigFactory extends AbstractConfigFactory
                 'fieldFile' => 'media_file',
                 'sort' => [
                     ['id' => 'name', 'field' => 'media_path.alpha_order', 'defaultOrder' => 'asc'],
-                    ['id' => 'type', 'field' => 'media_file.mimetype', 'nested_path' => 'media_file'],
-                    ['id' => 'size', 'field' => 'media_file.filesize', 'nested_path' => 'media_file'],
+                    ['id' => 'type', 'field' => 'media_file.mimetype', 'parent_field' => 'media_file'],
+                    ['id' => 'size', 'field' => 'media_file.filesize', 'parent_field' => 'media_file'],
                 ],
                 'defaultValue' => [],
                 'searchSize' => MediaLibraryConfig::DEFAULT_SEARCH_SIZE,
@@ -105,11 +105,16 @@ class MediaLibraryConfigFactory extends AbstractConfigFactory
                 $sorts = [];
 
                 foreach ($definitions as $definition) {
+                    if (isset($definition['nested_path'])) {
+                        @\trigger_error('The "nested_path" option is deprecated and will be removed in ems 7. Please use "parent_field" instead.', E_USER_DEPRECATED);
+                        $definition['parent_field'] = $definition['nested_path'];
+                    }
+
                     $sorts[$definition['id']] = new MediaLibraryConfigSort(
                         id: $definition['id'],
                         field: $definition['field'],
                         defaultOrder: $definition['defaultOrder'] ?? null,
-                        nestedPath: $definition['nested_path'] ?? null
+                        parentField: $definition['parent_field'] ?? null
                     );
                 }
 

--- a/EMS/core-bundle/src/Core/Component/MediaLibrary/Config/MediaLibraryConfigSort.php
+++ b/EMS/core-bundle/src/Core/Component/MediaLibrary/Config/MediaLibraryConfigSort.php
@@ -7,15 +7,15 @@ namespace EMS\CoreBundle\Core\Component\MediaLibrary\Config;
 class MediaLibraryConfigSort
 {
     public function __construct(
-        public readonly string  $id,
-        public readonly string  $field,
+        public readonly string $id,
+        public readonly string $field,
         public readonly ?string $defaultOrder,
         public readonly ?string $parentField,
     ) {
     }
 
     /**
-     * @return array<string, array{order: string, nested?: array{path: string}>
+     * @return array<string, array{order: string, nested?: array{path: string}}>
      */
     public function getQuery(string $order): array
     {

--- a/EMS/core-bundle/src/Core/Component/MediaLibrary/Config/MediaLibraryConfigSort.php
+++ b/EMS/core-bundle/src/Core/Component/MediaLibrary/Config/MediaLibraryConfigSort.php
@@ -7,22 +7,22 @@ namespace EMS\CoreBundle\Core\Component\MediaLibrary\Config;
 class MediaLibraryConfigSort
 {
     public function __construct(
-        public readonly string $id,
-        public readonly string $field,
+        public readonly string  $id,
+        public readonly string  $field,
         public readonly ?string $defaultOrder,
-        public readonly ?string $nestedPath,
+        public readonly ?string $parentField,
     ) {
     }
 
     /**
-     * @return array<string, array{order: string, nested_path?: string}>
+     * @return array<string, array{order: string, nested?: array{path: string}>
      */
     public function getQuery(string $order): array
     {
         $query = ['order' => $order];
 
-        if ($this->nestedPath) {
-            $query['nested_path'] = $this->nestedPath;
+        if ($this->parentField) {
+            $query['nested'] = ['path' => $this->parentField];
         }
 
         return [$this->field => $query];

--- a/demo/skeleton/template_ems/dashboard/media_library.twig
+++ b/demo/skeleton/template_ems/dashboard/media_library.twig
@@ -5,10 +5,10 @@
         'searchType': 'prefix',
         "sort": [
             { "id": "name", "field": "media_path.alpha_order", "defaultOrder": "asc" },
-            { "id": "type", "field": "media_file.mimetype", "nested_path": "media_file" },
+            { "id": "type", "field": "media_file.mimetype", "parent_field": "media_file" },
             { "id": "user", "field": "_finalized_by" },
             { "id": "created", "field": "date_creation" },
-            { "id": "size", "field": "media_file.filesize", "nested_path": "media_file" }
+            { "id": "size", "field": "media_file.filesize", "parent_field": "media_file" }
         ]
     }) }}
 {% endblock body %}

--- a/docs/dev/core-bundle/twig/component.md
+++ b/docs/dev/core-bundle/twig/component.md
@@ -187,11 +187,13 @@ Default value:
 {
   "sort": [
     { "id": "name", "field": "media_path.alpha_order", "defaultOrder": "asc" },
-    { "id": "type", "field": "media_file.mimetype", "nested_path": "media_file" },
-    { "id": "size", "field": "media_file.filesize", "nested_path": "media_file" }
+    { "id": "type", "field": "media_file.mimetype", "parent_field": "media_file" },
+    { "id": "size", "field": "media_file.filesize", "parent_field": "media_file" }
   ]
 }
 ```
+
+!> Since 6.9.2 `nested_path` is deprecated and should be replaced by `parent_field`.
 
 ### Templating (media-library)
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -3,7 +3,8 @@
 <!-- TOC -->
 * [Upgrade](#upgrade)
   * [General remarks](#general-remarks)
-  * [version 6.9.0](#version-649)
+  * [version 6.9.2](#version-692)
+  * [version 6.9.0](#version-690)
   * [version 6.5.0](#version-650)
   * [version 6.4.1](#version-641)
   * [version 6.4.0](#version-640)
@@ -44,6 +45,10 @@
 ## General remarks
 
  * It's always a good idea to rebuild indexes on upgrade: `emsco:environment:rebuild --all`
+
+## version 6.9.2
+
+* Media library: the "nested_path" option for sorting is deprecated, use "parent_field" instead.
 
 ## version 6.9.0
 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

In es8 'nested_path' will not work anymore. We should have used: 'nested': { 'path': 'value' }, this also works in es7.
To not use 'nested_path' in our twig, we change from nested_path to parent_field.
This way we can search existing project twig files for `nested_path`
