### PR TITLE
fix(admin/contentType): getSortOrder -> getOrderKey

### DIFF
--- a/EMS/core-bundle/src/Service/ContentTypeService.php
+++ b/EMS/core-bundle/src/Service/ContentTypeService.php
@@ -523,7 +523,7 @@ class ContentTypeService implements EntityServiceInterface
         $contentTypeRepository = $em->getRepository(ContentType::class);
         if ($mustBeReset) {
             $contentType->reset($contentTypeRepository->nextOrderKey());
-        } elseif (null === $contentType->getSortOrder()) {
+        } elseif (null === $contentType->getOrderKey()) {
             $contentType->setOrderKey($contentTypeRepository->nextOrderKey());
         }
         $contentTypeRepository->save($contentType);


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Fix typpo getOrderKey instead of getSortOrder.
After updating a contentType the orderKey was set to the next order key. 
