### PR TITLE
fix(web/search): deprecated nested_path for parent_field

### DIFF
--- a/EMS/client-helper-bundle/src/Helper/Search/Filter.php
+++ b/EMS/client-helper-bundle/src/Helper/Search/Filter.php
@@ -21,7 +21,7 @@ final class Filter
     private readonly string $type;
     private string $field;
     private ?string $secondaryField = null;
-    private ?string $nestedPath = null;
+    private ?string $parentField = null;
 
     private ?string $sortField = null;
     private readonly string $sortOrder;
@@ -69,6 +69,7 @@ final class Filter
      *     'field'?: string,
      *     'secondary_field'?: string,
      *     'nested_path'?: string,
+     *     'parent_field'?: string,
      *     'clause'?: string,
      *     'public'?: bool,
      *     'active'?: bool,
@@ -89,7 +90,13 @@ final class Filter
         $this->type = $options['type'];
         $this->field = $options['field'] ?? $name;
         $this->secondaryField = $options['secondary_field'] ?? null;
-        $this->nestedPath = $options['nested_path'] ?? null;
+
+        if (isset($options['nested_path'])) {
+            @\trigger_error('The "nested_path" option is deprecated and will be removed in ems 7. Please use "parent_field" instead.', E_USER_DEPRECATED);
+            $options['parent_field'] = $options['nested_path'];
+        }
+
+        $this->parentField = $options['parent_field'] ?? null;
         $this->clause = $options['clause'] ?? 'must';
 
         $this->public = (bool) ($options['public'] ?? true);
@@ -129,7 +136,7 @@ final class Filter
 
     public function getField(): string
     {
-        return $this->isNested() ? $this->nestedPath.'.'.$this->field : $this->field;
+        return $this->isNested() ? $this->parentField.'.'.$this->field : $this->field;
     }
 
     public function getValue(): mixed
@@ -257,12 +264,12 @@ final class Filter
 
     public function isNested(): bool
     {
-        return null !== $this->nestedPath;
+        return null !== $this->parentField;
     }
 
     public function getNestedPath(): ?string
     {
-        return $this->nestedPath;
+        return $this->parentField;
     }
 
     public function isReversedNested(): bool

--- a/docs/dev/client-helper-bundle/search.md
+++ b/docs/dev/client-helper-bundle/search.md
@@ -196,7 +196,7 @@ If facets depends on facets, we can create a nested collection for filtering.
   "filters": {
     "personTags": {
       "type": "terms",
-      "nested_path": "tags",
+      "parent_field": "tags",
       "field": "type",
       "aggs_size": 50,
       "sort_field": "_term",
@@ -204,7 +204,7 @@ If facets depends on facets, we can create a nested collection for filtering.
     },
     "personValues": {
       "type": "terms",
-      "nested_path": "tags",
+      "parent_field": "tags",
       "field": "values",
       "aggs_size": 50,
       "sort_field": "_term",
@@ -213,6 +213,8 @@ If facets depends on facets, we can create a nested collection for filtering.
   }
 }
 ````
+
+!> Since 6.9.2 `nested_path` is deprecated and should be replaced by `parent_field`.
 
 ## Synonyms
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -49,6 +49,9 @@
 ## version 6.9.2
 
 * Media library: the "nested_path" option for sorting is deprecated, use "parent_field" instead.
+* Skeleton search config: filters "nested_path" option is deprecated, use "parent_field" instead.
+* If you use "nested_path" inside es queries it should be replaced by `{ "nested": { "path": "..." } }`, this is why
+  elasticms is not using `nested_path` as option key anymore.
 
 ## version 6.9.0
 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | y  |
| Fixed tickets? | n  |
| Documentation? | n  |

Deprecate the 'nested_path' option use 'parent_field'. This way we can do a quick find for problems in twig files.
