### PR TITLE
fix(admin/view): hierarchical reorder clears children

### DIFF
--- a/EMS/admin-ui-bundle/templates/bootstrap5/view/custom/hierarchical_add_item.html.twig
+++ b/EMS/admin-ui-bundle/templates/bootstrap5/view/custom/hierarchical_add_item.html.twig
@@ -27,7 +27,7 @@
 	{% if contentType.name == view.contentType.name %}
 		<ol data-parent-id="{{ child }}">
             {% include "@EMSAdminUI/bootstrap5/view/custom/hierarchical_item.html.twig" with {
-        		parent: data,
+				parent: data.source,
             	view: view,
         	} %}
 		</ol>

--- a/EMS/core-bundle/src/Controller/Views/HierarchicalController.php
+++ b/EMS/core-bundle/src/Controller/Views/HierarchicalController.php
@@ -18,8 +18,7 @@ class HierarchicalController extends AbstractController
         private readonly ContentTypeService $contentTypeService,
         private readonly SearchService $searchService,
         private readonly string $templateNamespace
-    )
-    {
+    ) {
     }
 
     public function item(View $view, string $key): Response

--- a/EMS/core-bundle/src/Controller/Views/HierarchicalController.php
+++ b/EMS/core-bundle/src/Controller/Views/HierarchicalController.php
@@ -14,17 +14,19 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class HierarchicalController extends AbstractController
 {
-    public function __construct(private readonly ContentTypeService $contentTypeService, private readonly SearchService $searchService, private readonly string $templateNamespace)
+    public function __construct(
+        private readonly ContentTypeService $contentTypeService,
+        private readonly SearchService $searchService,
+        private readonly string $templateNamespace
+    )
     {
     }
 
     public function item(View $view, string $key): Response
     {
         $ouuid = \explode(':', $key);
-        $contentType = $this->contentTypeService->getByName($ouuid[0]);
-        if (false === $contentType) {
-            throw new NotFoundHttpException(\sprintf('Content type %s not found', $ouuid[0]));
-        }
+        $contentType = $this->contentTypeService->giveByName($ouuid[0]);
+
         try {
             $document = $this->searchService->getDocument($contentType, $ouuid[1]);
         } catch (NotFoundException) {
@@ -32,7 +34,7 @@ class HierarchicalController extends AbstractController
         }
 
         return $this->render("@$this->templateNamespace/view/custom/hierarchical_add_item.html.twig", [
-            'data' => $document->getSource(),
+            'data' => $document,
             'view' => $view,
             'contentType' => $contentType,
             'key' => $ouuid,

--- a/EMS/core-bundle/templates/view/custom/hierarchical_add_item.html.twig
+++ b/EMS/core-bundle/templates/view/custom/hierarchical_add_item.html.twig
@@ -27,7 +27,7 @@
 	{% if contentType.name == view.contentType.name %}
 		<ol style="display:none;" data-parent-id="{{ child }}">
             {% include "@EMSCore/view/custom/hierarchical_item.html.twig" with {
-        		parent: data,
+        		parent: data.source,
             	view: view,
         	} %}
 		</ol>


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Because we are not passing the correct parent. Parent should be the source array not a document instance.

The data is not a source array anymore but an Document object.
Changed in: https://github.com/ems-project/elasticms/pull/715/files#diff-e45eef9f64bea82bcdabddf2dd47d4565f0477dc8e922e87750fca1ac50d66ac
