### PR TITLE
fix(admin/contentType): remove cascade delete contentType environment

### DIFF
--- a/EMS/core-bundle/config/doctrine/ContentType.orm.xml
+++ b/EMS/core-bundle/config/doctrine/ContentType.orm.xml
@@ -54,9 +54,6 @@
       <join-column name="field_types_id"/>
     </one-to-one>
     <many-to-one field="environment" target-entity="EMS\CoreBundle\Entity\Environment" inversed-by="contentTypesHavingThisAsDefault">
-      <cascade>
-        <cascade-remove/>
-      </cascade>
       <join-column name="environment_id"/>
     </many-to-one>
     <one-to-many field="templates" target-entity="EMS\CoreBundle\Entity\Template" mapped-by="contentType">


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

This PR fixes an issue occurring when running the emsco:contenttype:clean command.

Previously, the command attempted to delete content types that were not marked for deletion. However, when a content type shared the same default environment as another content type that actually was flagged for deletion, a foreign key constraint error could occur:

```sql
An exception occurred while executing a query:
SQLSTATE[23503]: Foreign key violation: 7 ERROR: update or delete on table "content_type" violates foreign key constraint "fk_6d6315cc1a445520" on table "revision"
DETAIL: Key (id) = (16) is still referenced from table "revision".
````

The underlying cause was the presence of <cascade-remove/> in the ContentType Doctrine mapping. Because of this, Doctrine tried to remove related Revision entities when a ContentType was removed, even when the content type itself was not flagged for deletion.

This PR removes the <cascade-remove/> directive from the mapping, ensuring that only content types explicitly marked for deletion are processed and preventing Doctrine from performing unintended cascading deletes.

Important note

Removing <cascade-remove/> only affects Doctrine’s runtime behavior.
It does not produce any database schema changes and has no effect on existing data or constraints.