### PR TITLE
fix(admin/icons): load only legacy icon sets

### DIFF
--- a/EMS/core-bundle/config/form.xml
+++ b/EMS/core-bundle/config/form.xml
@@ -381,6 +381,12 @@
             <argument type="service" id="ems.service.contenttype" />
             <tag name="form.type"/>
         </service>
+        <service id="ems.form.field.icon_picker_type" class="EMS\CoreBundle\Form\Field\IconPickerType">
+            <call method="setTemplateNamespace">
+                <argument>%ems_core.template_namespace%</argument>
+            </call>
+            <tag name="form.type"/>
+        </service>
         <service id="ems.form.fieldtype.fieldtypetype" class="EMS\CoreBundle\Form\FieldType\FieldTypeType">
             <argument type="service" id="ems.form.field.datafieldtypepickertype" />
             <argument type="service" id="form.registry" />

--- a/EMS/core-bundle/src/Form/Field/IconPickerType.php
+++ b/EMS/core-bundle/src/Form/Field/IconPickerType.php
@@ -9,8 +9,22 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class IconPickerType extends Select2Type
 {
+    private ?string $templateNamespace = null;
+
+    public function setTemplateNamespace(string $namespace): void
+    {
+        $this->templateNamespace = $namespace;
+    }
+
     /**
-     * @var array<string, array<string, string>|null>
+     * @var array{
+     *     'icon.not-defined': null,
+     *     'icon.elasticms-icons': array<string,string>,
+     *     'icon.fa6-icons': array<string,string>,
+     *     'icon.fa6-brands-icons': array<string,string>,
+     *     'icon.fa4-icons': array<string,string>,
+     *     'icon.glyphicon-bs3-icons': array<string,string>
+     * }
      */
     private array $choices = [
         'icon.not-defined' => null,
@@ -3294,8 +3308,19 @@ class IconPickerType extends Select2Type
     #[\Override]
     public function configureOptions(OptionsResolver $resolver): void
     {
+        if ('EMSAdminUI/bootstrap5' === $this->templateNamespace) {
+            $choices = $this->choices;
+        } else {
+            $choices = [
+                'icon.not-defined' => null,
+                ...$this->choices['icon.elasticms-icons'],
+                ...$this->choices['icon.fa4-icons'],
+                ...$this->choices['icon.glyphicon-bs3-icons'],
+            ];
+        }
+
         $resolver->setDefaults([
-            'choices' => $this->choices,
+            'choices' => $choices,
             'attr' => [
                 'data-live-search' => true,
             ],


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

If adminUI bundle is not loaded we should only load the legacy icons
