### PR TITLE
fix(admin/field): JSONFieldType allow null value

### DIFF
--- a/EMS/core-bundle/src/Form/DataField/JSONFieldType.php
+++ b/EMS/core-bundle/src/Form/DataField/JSONFieldType.php
@@ -47,11 +47,15 @@ class JSONFieldType extends DataFieldType
     }
 
     /**
-     * @return array{'value': string}
+     * @return array{'value': ?string}
      */
     #[\Override]
     public function viewTransform(DataField $dataField): array
     {
+        if (null === $dataField->getRawData()) {
+            return ['value' => null];
+        }
+
         $prettyPrint = (bool) $dataField->giveFieldType()->getDisplayOption('prettyPrint', false);
 
         return ['value' => Json::encode($dataField->getRawData(), $prettyPrint)];


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

If the json value is null we are encoding it resulting in 'null' string, which raises an error in the decode.