### PR TITLE
fix(admin/revision): locking skip granted checks when a username is pass

### DIFF
--- a/EMS/core-bundle/src/Service/DataService.php
+++ b/EMS/core-bundle/src/Service/DataService.php
@@ -141,10 +141,10 @@ class DataService
      */
     public function lockRevision(Revision $revision, ?Environment $publishEnv = null, bool $super = false, ?string $username = null, ?\DateTime $lockTime = null): string
     {
-        if (null !== $publishEnv && !$this->authorizationChecker->isGranted($revision->giveContentType()->role(ContentTypeRoles::PUBLISH))) {
+        if (null === $username && null !== $publishEnv && !$this->authorizationChecker->isGranted($revision->giveContentType()->role(ContentTypeRoles::PUBLISH))) {
             throw new PrivilegeException($revision, 'You don\'t have publisher role for this content');
         }
-        if (null !== $publishEnv && !empty($publishEnv->getCircles()) && !$this->authorizationChecker->isGranted('ROLE_USER_MANAGEMENT') && !$this->userService->inMyCircles($publishEnv->getCircles())) {
+        if (null === $username && null !== $publishEnv && !empty($publishEnv->getCircles()) && !$this->authorizationChecker->isGranted('ROLE_USER_MANAGEMENT') && !$this->userService->inMyCircles($publishEnv->getCircles())) {
             throw new PrivilegeException($revision, 'You don\'t share any circle with this content');
         }
         if (null === $username && null === $publishEnv && !empty($revision->giveContentType()->getCirclesField()) && !empty($revision->getRawData()[$revision->giveContentType()->getCirclesField()])) {

--- a/EMS/core-bundle/src/Service/PublishService.php
+++ b/EMS/core-bundle/src/Service/PublishService.php
@@ -222,9 +222,7 @@ class PublishService
             return 0;
         }
 
-        if (null === $commandUser) {
-            $this->dataService->lockRevision($revision, $environment);
-        }
+        $this->dataService->lockRevision(revision: $revision, publishEnv: $environment, username: $commandUser);
         $revision = $this->dataService->recomputeOnPublish($revision, $environment);
 
         $this->publishVersion($revision, $environment, $commandUser);
@@ -237,10 +235,10 @@ class PublishService
             $already = true;
             $this->logger->notice('service.publish.already_published', $logContext);
         } elseif ($item) {
-            $this->dataService->lockRevision($item, $environment);
+            $this->dataService->lockRevision(revision: $item, publishEnv: $environment, username: $commandUser);
             $item->removeEnvironment($environment, $username);
             $this->revRepository->save($item);
-            $this->dataService->unlockRevision($item);
+            $this->dataService->unlockRevision($item, $commandUser);
         }
 
         $this->dataService->sign($revision, true);
@@ -263,9 +261,7 @@ class PublishService
             ], ...$logContext]);
         }
 
-        if (null === $commandUser) {
-            $this->dataService->unlockRevision($revision);
-        }
+        $this->dataService->unlockRevision($revision, $commandUser);
 
         return $already ? 0 : 1;
     }


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  |  n |
| Fixed tickets? | n  |
| Documentation? | n  |

When we  pass a username like 'SYSTEM_RELEASE' to the lockRevision, we should call the isGranted.
Broken with https://github.com/ems-project/elasticms/pull/1364, because we are passing a $environment to the lockRevision which executes the isGranted. 
