### PR TITLE
fix(admin/form-submissions): remove confirm key for download and export

### DIFF
--- a/EMS/core-bundle/src/DataTable/Type/FormSubmissionDataTableType.php
+++ b/EMS/core-bundle/src/DataTable/Type/FormSubmissionDataTableType.php
@@ -33,8 +33,8 @@ class FormSubmissionDataTableType extends AbstractEntityTableType
         $table->addItemPostAction('form.submissions.process', 'form-submission.form-submissions.process', 'check', 'form-submission.form-submissions.confirm');
 
         $table->addTableAction(TableAbstract::DELETE_ACTION, 'fa fa-trash', 'form-submission.index.delete_selected', 'form-submission.form-submissions.delete_selected_confirm');
-        $table->addTableAction(TableAbstract::DOWNLOAD_ACTION, 'fa fa-download', 'form-submission.form-submissions.download_selected', 'form-submission.form-submissions.download_selected_confirm');
-        $table->addTableAction(TableAbstract::EXPORT_ACTION, 'fa fa-file-excel-o', 'form-submission.form-submissions.export_selected', 'form-submission.form-submissions.export_selected_confirm');
+        $table->addTableAction(TableAbstract::DOWNLOAD_ACTION, 'fa fa-download', 'form-submission.form-submissions.download_selected');
+        $table->addTableAction(TableAbstract::EXPORT_ACTION, 'fa fa-file-excel-o', 'form-submission.form-submissions.export_selected');
         $table->setDefaultOrder('created', 'desc');
     }
 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

The confirm translation keys `form-submission.form-submissions.download_selected_confirm` and `form-submission.form-submissions.export_selected_confirm`  are not defined. Confirm is only required at a danger action like delete, for export or download confirmation it is not needed.
