### PR TITLE
fix(docker): upgrade traefik v2.2 to v3.6 (issue with docker API version >= 1.52)

### DIFF
--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -3,7 +3,7 @@ version: "2.4"
 services:
 
   traefik:
-    image: "traefik:v2.2"
+    image: "traefik:v3.6"
     command:
       - "--log.level=WARNING"
       - "--api.insecure=true"


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? |  n |
| Documentation? | n  |

Time to upgrade Traefik