### PR TITLE
fix(admin/api): finalize draft without rawData

### DIFF
--- a/EMS/core-bundle/src/Controller/ContentManagement/CrudController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/CrudController.php
@@ -147,7 +147,8 @@ class CrudController extends AbstractController
             $contentType = $this->giveContentType($name)->validate();
             $revision = $this->dataService->getRevisionById($id, $contentType);
 
-            $rawData = Json::decode(Type::string($request->getContent()));
+            $content = $request->getContent();
+            $rawData = \strlen($content) > 0 ? Json::decode(Type::string($content)) : [];
             if (\count($rawData) > 0) {
                 $this->revisionService->autoSave($revision, $rawData);
             }


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

With the implementation of the bridge we broke the api finalization without sending rawData.
This used by the deprecated user_api inside the clientHelperBundle
