### PR TITLE
fix(admin/wysiwyg): style set check hash exists

### DIFF
--- a/EMS/core-bundle/src/Form/DataField/WysiwygFieldType.php
+++ b/EMS/core-bundle/src/Form/DataField/WysiwygFieldType.php
@@ -83,7 +83,7 @@ class WysiwygFieldType extends DataFieldType
             if (null !== $assets && \is_string($hash) && null !== $saveDir) {
                 $this->assetRuntime->unzip($hash, $saveDir);
             }
-            if (null === $saveDir && $contentCss) {
+            if ($hash && null === $saveDir && $contentCss) {
                 $contentCss = $this->router->generate('ems_asset_in_archive', [
                     'hash' => $hash,
                     'path' => $contentCss,

--- a/demo/configs/admin/wysiwyg-style-set/test.json
+++ b/demo/configs/admin/wysiwyg-style-set/test.json
@@ -1,0 +1,16 @@
+{
+    "class": "EMS\\CoreBundle\\Entity\\WysiwygStylesSet",
+    "arguments": [],
+    "properties": {
+        "name": "test",
+        "config": "[\r\n  {\r\n    \"name\": \"Pie Table\",\r\n    \"element\": \"table\",\r\n    \"attributes\": {\r\n      \"class\": \"highcharts-pie table highcharts\"\r\n    }\r\n  },\r\n  {\r\n    \"name\": \"Column data\",\r\n    \"element\": \"th\",\r\n    \"attributes\": {\r\n      \"class\": \"highcharts-data-column\"\r\n    }\r\n  },\r\n  {\r\n    \"name\": \"Image mobile\",\r\n    \"type\": \"widget\",\r\n    \"widget\": \"image\",\r\n    \"attributes\": {\r\n      \"class\": \"d-block d-sm-none\"\r\n    }\r\n  },\r\n  {\r\n    \"name\": \"Image desktop\",\r\n    \"type\": \"widget\",\r\n    \"widget\": \"image\",\r\n    \"attributes\": {\r\n      \"class\": \"d-none d-sm-block\"\r\n    }\r\n  }\r\n]",
+        "orderKey": 101,
+        "formatTags": "p;h1;h2;h3;h4;h5;h6;pre;address;div",
+        "tableDefaultCss": "table table-border",
+        "contentCss": null,
+        "contentJs": null,
+        "assets": null,
+        "saveDir": null
+    },
+    "replaced": []
+}


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Before creating the ems_asset_in_archive we should check that the hash is not null.
