### PR TITLE
fix(admin/twig): alternative twig filter emco_src_path

### DIFF
--- a/EMS/core-bundle/src/Twig/AppExtension.php
+++ b/EMS/core-bundle/src/Twig/AppExtension.php
@@ -214,6 +214,7 @@ class AppExtension extends AbstractExtension
             new TwigFilter('emsco_display_name', $this->displayName(...)),
             new TwigFilter('emsco_date_difference', $this->dateDifference(...)),
             new TwigFilter('emsco_debug', $this->debug(...)),
+            new TwigFilter('emsco_src_path', $this->srcPath(...)),
             new TwigFilter('emsco_search', $this->search(...)),
             new TwigFilter('emsco_search_query', $this->searchQuery(...)),
             new TwigFilter('emsco_call_user_func', $this->callUserFunc(...)),
@@ -303,7 +304,7 @@ class AppExtension extends AbstractExtension
                 'deprecation_info' => new DeprecatedCallableInfo('elasticms/core-bundle', '6.0.0', 'emsco_internal_links'),
             ]),
             new TwigFilter('src_path', $this->srcPath(...), [
-                'deprecation_info' => new DeprecatedCallableInfo('elasticms/core-bundle', '6.0.0'),
+                'deprecation_info' => new DeprecatedCallableInfo('elasticms/core-bundle', '6.0.0', 'emsco_src_path'),
             ]),
             new TwigFilter('get_user', $this->getUser(...), [
                 'deprecation_info' => new DeprecatedCallableInfo('elasticms/core-bundle', '6.0.0', 'emsco_get_user'),


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

The core twig filter 'src_path' is still is use, we just provide an alternative called 'emsco_src_path'
