### PR TITLE
fix(admin/publish): load all version environment revisions

### DIFF
--- a/EMS/core-bundle/src/Repository/RevisionRepository.php
+++ b/EMS/core-bundle/src/Repository/RevisionRepository.php
@@ -11,6 +11,7 @@ use Doctrine\DBAL\Query\QueryBuilder as DBALQueryBuilder;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\NonUniqueResultException;
+use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\Query\Parameter;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\Tools\Pagination\Paginator;
@@ -925,15 +926,22 @@ class RevisionRepository extends EntityRepository
     {
         $qb = $this->createQueryBuilder('r');
         $qb
-            ->addSelect('er')
+            ->addSelect('er_all')
             ->join('r.contentType', 'c')
-            ->join('r.environmentRevisions', 'er')
-            ->andWhere($qb->expr()->eq('er.environment', ':environment'))
+            ->leftJoin('r.environmentRevisions', 'er_all')
+            ->join(
+                'r.environmentRevisions',
+                'er_env',
+                Join::WITH,
+                $qb->expr()->andX(
+                    $qb->expr()->eq('er_env.environment', ':environment'),
+                    $qb->expr()->isNull('er_env.deleted')
+                )
+            )
             ->andWhere($qb->expr()->eq('r.versionUuid', ':version_uuid'))
             ->andWhere($qb->expr()->eq('c.deleted', $qb->expr()->literal(false)))
             ->andWhere($qb->expr()->eq('c.active', $qb->expr()->literal(true)))
             ->andWhere($qb->expr()->eq('r.deleted', $qb->expr()->literal(false)))
-            ->andWhere($qb->expr()->isNull('er.deleted'))
             ->setParameters(new ArrayCollection([
                 new Parameter('version_uuid', $versionUuid),
                 new Parameter('environment', $defaultEnvironment),


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

When a document had multiple versions and one of the older versions was already published, the query failed to find that previously published revision.  
This happened because the join on `environmentRevisions` filtered directly on the target environment, causing Doctrine to return only a single matching revision per document. 

This PR updates the query to:

- Load all environmentRevisions via a LEFT JOIN
- Apply the environment filter using a separate joined alias
- Ensure the revision collection remains complete while still selecting the correct revision for the target environment

This resolves the issue where older published revisions were not found when publishing a new version.
