### PR TITLE
fix(admin/publish): excluded deleted environment revisions

### DIFF
--- a/EMS/core-bundle/src/Repository/RevisionRepository.php
+++ b/EMS/core-bundle/src/Repository/RevisionRepository.php
@@ -928,7 +928,7 @@ class RevisionRepository extends EntityRepository
         $qb
             ->addSelect('er_all')
             ->join('r.contentType', 'c')
-            ->leftJoin('r.environmentRevisions', 'er_all')
+            ->leftJoin('r.environmentRevisions', 'er_all', Join::WITH, $qb->expr()->isNull('er_all.deleted'))
             ->join(
                 'r.environmentRevisions',
                 'er_env',


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Follow up pr of https://github.com/ems-project/elasticms/pull/1484
We should not load deleted environment revisions
