### PR TITLE
fix(web): rollback asset path must take the baseUrl

### DIFF
--- a/EMS/client-helper-bundle/config/services.xml
+++ b/EMS/client-helper-bundle/config/services.xml
@@ -111,7 +111,6 @@
             <argument type="service" id="emsch.manager.client_request" />
             <argument type="service" id="ems_common.twig.runtime.asset"/>
             <argument type="service" id="ems.vite"/>
-            <argument type="service" id="request_stack"/>
             <argument type="string">%kernel.project_dir%</argument>
             <argument type="string">%emsch.asset_local_folder%</argument>
             <tag name="twig.runtime" />

--- a/EMS/client-helper-bundle/src/Helper/Asset/AssetHelperRuntime.php
+++ b/EMS/client-helper-bundle/src/Helper/Asset/AssetHelperRuntime.php
@@ -11,7 +11,6 @@ use EMS\CommonBundle\Helper\EmsFields;
 use EMS\CommonBundle\Storage\StorageManager;
 use EMS\CommonBundle\Twig\AssetRuntime;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Extension\RuntimeExtensionInterface;
 
 final class AssetHelperRuntime implements RuntimeExtensionInterface
@@ -26,7 +25,6 @@ final class AssetHelperRuntime implements RuntimeExtensionInterface
         private readonly ClientRequestManager $manager,
         private readonly AssetRuntime $commonAssetRuntime,
         private readonly ViteService $viteService,
-        private readonly RequestStack $requestStack,
         string $projectDir,
         private readonly ?string $localFolder
     ) {
@@ -159,17 +157,10 @@ final class AssetHelperRuntime implements RuntimeExtensionInterface
 
     private function getBasePath(): string
     {
-        $request = $this->requestStack->getCurrentRequest();
-        if (null === $request) {
-            $baseUrl = '';
-        } else {
-            $baseUrl = $request->getBaseUrl();
-        }
-
         return match (true) {
             !empty($this->localFolder) => $this->localFolder,
-            null === $this->versionSaveDir => \sprintf('%s/bundles/%s', $baseUrl, $this->getVersionHash()),
-            default => \sprintf('%s/%s/%s', $this->getVersionSaveDir(), $baseUrl, $this->getVersionHash())
+            null === $this->versionSaveDir => \sprintf('bundles/%s', $this->getVersionHash()),
+            default => \sprintf('%s/%s', $this->versionSaveDir, $this->getVersionHash())
         };
     }
 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   |  n |
| BC breaks?     |  n |
| Deprecations?  |  n |
| Fixed tickets? |  n |
| Documentation? | n  |

Rollback the PR #1459 , it was more an issue in the apache vhost when a alias is defined
