### PR TITLE
feat(core/api): add meta findAll drafts endpoint

### DIFF
--- a/EMS/common-bundle/src/Common/CoreApi/Endpoint/Meta/Meta.php
+++ b/EMS/common-bundle/src/Common/CoreApi/Endpoint/Meta/Meta.php
@@ -32,4 +32,13 @@ final readonly class Meta implements MetaInterface
 
         return $data['info'] ?? [];
     }
+
+    #[\Override]
+    public function getDrafts(bool $includeRawData = false, array $circles = []): array
+    {
+        return $this->client->get('/api/meta/drafts', [
+            'includeRawData' => $includeRawData,
+            'circles' => $circles,
+        ])->getData();
+    }
 }

--- a/EMS/common-bundle/src/Contracts/CoreApi/Endpoint/Admin/MetaInterface.php
+++ b/EMS/common-bundle/src/Contracts/CoreApi/Endpoint/Admin/MetaInterface.php
@@ -20,4 +20,18 @@ interface MetaInterface
      *  }>
      */
     public function getInfoDocuments(array $environments, array $emsLinks): array;
+
+    /**
+     * @param string[] $circles
+     *
+     * @return array<int, array{
+     *     id: string,
+     *     ouuid: ?string,
+     *     circles: string[],
+     *     save_date: string,
+     *     created: string,
+     *     raw_data?: array<mixed>
+     * }>
+     */
+    public function getDrafts(bool $includeRawData = false, array $circles = []): array;
 }

--- a/EMS/core-bundle/config/routing/api/meta.xml
+++ b/EMS/core-bundle/config/routing/api/meta.xml
@@ -4,6 +4,13 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://symfony.com/schema/routing https://symfony.com/schema/routing/routing-1.0.xsd">
 
+    <route id="emsco_api_meta_drafts" path="/drafts"
+           controller="EMS\CoreBundle\Controller\Api\Admin\MetaController::drafts"
+           methods="GET"
+           format="json">
+        <option key="openapi">true</option>
+    </route>
+
     <route id="emsco_api_meta_info_documents" path="/info/documents"
            controller="EMS\CoreBundle\Controller\Api\Admin\MetaController::infoDocuments"
            methods="POST"

--- a/EMS/core-bundle/src/Controller/Api/Admin/MetaController.php
+++ b/EMS/core-bundle/src/Controller/Api/Admin/MetaController.php
@@ -56,4 +56,29 @@ class MetaController
 
         return new JsonResponse($contentTypes);
     }
+
+    public function drafts(Request $request): Response
+    {
+        $drafts = [];
+        $includeRawData = $request->query->getBoolean('includeRawData', false);
+        $circles = $request->query->all('circles');
+
+        foreach ($this->revisionService->findAllDrafts($circles) as $revision) {
+            $draft = [
+                'id' => (string) $revision->getId(),
+                'ouuid' => $revision->getOuuid(),
+                'circles' => $revision->getCircles(),
+                'save_date' => $revision->getDraftSaveDate()?->format(\DATE_ATOM),
+                'created' => $revision->getCreated()->format(\DATE_ATOM),
+            ];
+
+            if ($includeRawData) {
+                $draft['raw_data'] = $revision->getRawData();
+            }
+
+            $drafts[] = $draft;
+        }
+
+        return new JsonResponse($drafts);
+    }
 }

--- a/EMS/core-bundle/src/Repository/RevisionRepository.php
+++ b/EMS/core-bundle/src/Repository/RevisionRepository.php
@@ -797,11 +797,24 @@ class RevisionRepository extends EntityRepository
     }
 
     /**
+     * @param string[] $circles
+     *
      * @return Revision[]
      */
-    public function findAllDrafts(): array
+    public function findAllDrafts(array $circles = []): array
     {
-        return $this->makeQueryBuilder(isDraft: true)->orderBy('r.id', 'asc')->getQuery()->execute();
+        $qb = $this->makeQueryBuilder(isDraft: true)->orderBy('r.id', 'asc');
+
+        if (\count($circles) > 0) {
+            $inCircles = $qb->expr()->orX();
+            foreach ($circles as $counter => $circle) {
+                $inCircles->add($qb->expr()->like('r.circles', ':circle'.$counter));
+                $qb->setParameter('circle'.$counter, '%'.$circle.'%');
+            }
+            $qb->andWhere($inCircles);
+        }
+
+        return $qb->getQuery()->execute();
     }
 
     /**

--- a/EMS/core-bundle/src/Service/Revision/RevisionService.php
+++ b/EMS/core-bundle/src/Service/Revision/RevisionService.php
@@ -212,6 +212,16 @@ class RevisionService implements RevisionServiceInterface
     }
 
     /**
+     * @param string[] $circles
+     *
+     * @return iterable<Revision>
+     */
+    public function findAllDrafts(array $circles = []): iterable
+    {
+        return yield from $this->revisionRepository->findAllDrafts($circles);
+    }
+
+    /**
      * @return iterable|Revision[]
      */
     public function findAllDraftsByContentTypeName(string $contentTypeName): iterable


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | n  |
| New feature?   | y  |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Add a new /api/meta/drafts for getting all drafts in the admin
Support filtering by circles
