### PR TITLE
fix(core/api): job status return status value

### DIFF
--- a/EMS/common-bundle/src/Common/CoreApi/Endpoint/Admin/Admin.php
+++ b/EMS/common-bundle/src/Common/CoreApi/Endpoint/Admin/Admin.php
@@ -23,13 +23,10 @@ class Admin implements AdminInterface
         return new Config($this->client, $typeName);
     }
 
-    /**
-     * @return array{id: string, created: string, modified: string, command: string, user: string, started: bool, done: bool, output: ?string}
-     */
     #[\Override]
     public function getJobStatus(string $jobId): array
     {
-        /** @var array{id: string, created: string, modified: string, command: string, user: string, started: bool, done: bool, output: ?string} $status */
+        /** @var array{id: string, created: string, modified: string, command: string, user: string,started: bool, done: bool, status: string, output: ?string } $status */
         $status = $this->client->get(\implode('/', ['api', 'admin', 'job-status', $jobId]))->getData();
 
         return $status;

--- a/EMS/common-bundle/src/Contracts/CoreApi/Endpoint/Admin/AdminInterface.php
+++ b/EMS/common-bundle/src/Contracts/CoreApi/Endpoint/Admin/AdminInterface.php
@@ -12,7 +12,17 @@ interface AdminInterface
     public function getConfig(string $typeName): ConfigInterface;
 
     /**
-     * @return array{id: string, created: string, modified: string, command: string, user: string, started: bool, done: bool, output: ?string}
+     * @return array{
+     *     id: string,
+     *     created: string,
+     *     modified: string,
+     *     command: string,
+     *     user: string,
+     *     started: bool,
+     *     done: bool,
+     *     status: string,
+     *     output: ?string
+     * }
      */
     public function getJobStatus(string $jobId): array;
 

--- a/EMS/core-bundle/src/Controller/Api/Admin/EntitiesController.php
+++ b/EMS/core-bundle/src/Controller/Api/Admin/EntitiesController.php
@@ -129,6 +129,7 @@ class EntitiesController
             'done' => $job->getDone(),
             'output' => $job->getOutput(),
             'started' => $job->getStarted(),
+            'status' => $job->getStatus(),
         ]);
     }
 

--- a/EMS/core-bundle/src/Service/JobService.php
+++ b/EMS/core-bundle/src/Service/JobService.php
@@ -205,10 +205,7 @@ class JobService implements EntityServiceInterface
         $job->setStarted(true);
         $this->repository->save($job);
 
-        $output = $this->getJobOutput($job);
-        $output->writeln('Job ready to be launch');
-
-        return $output;
+        return $this->getJobOutput($job);
     }
 
     public function finish(int $jobId, ?string $errorMessage = null): void


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  n |
| New feature?   | y  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

The api call job status should also return the status value.
Plus removed the default job status output 'Job ready to be launch'.
