### PR TITLE
feat(core/api): add meta get environments endpoint

### DIFF
--- a/EMS/common-bundle/src/Common/CoreApi/Endpoint/Meta/Meta.php
+++ b/EMS/common-bundle/src/Common/CoreApi/Endpoint/Meta/Meta.php
@@ -41,4 +41,15 @@ final readonly class Meta implements MetaInterface
             'circles' => $circles,
         ])->getData();
     }
+
+    #[\Override]
+    public function getEnvironments(?bool $managed = null, ?bool $snapshot = null): array
+    {
+        $query = \array_filter([
+            'managed' => $managed,
+            'snapshot' => $snapshot,
+        ], static fn ($value) => null !== $value);
+
+        return $this->client->get('/api/meta/environments', $query)->getData();
+    }
 }

--- a/EMS/common-bundle/src/Contracts/CoreApi/Endpoint/Admin/MetaInterface.php
+++ b/EMS/common-bundle/src/Contracts/CoreApi/Endpoint/Admin/MetaInterface.php
@@ -34,4 +34,9 @@ interface MetaInterface
      * }>
      */
     public function getDrafts(bool $includeRawData = false, array $circles = []): array;
+
+    /**
+     * @return array<int, array{ name: string, managed: bool, snapshot: bool}>
+     */
+    public function getEnvironments(?bool $managed = null, ?bool $snapshot = null): array;
 }

--- a/EMS/core-bundle/config/controllers.xml
+++ b/EMS/core-bundle/config/controllers.xml
@@ -111,6 +111,7 @@
         <service id="EMS\CoreBundle\Controller\Api\Admin\MetaController">
             <argument type="service" id="ems.service.contenttype" />
             <argument type="service" id="ems.service.revision" />
+            <argument type="service" id="EMS\CoreBundle\Service\EnvironmentService" />
             <tag name="controller.service_arguments"/>
         </service>
         <service id="EMS\CoreBundle\Controller\Api\Admin\InfoController">

--- a/EMS/core-bundle/config/routing/api/meta.xml
+++ b/EMS/core-bundle/config/routing/api/meta.xml
@@ -10,7 +10,12 @@
            format="json">
         <option key="openapi">true</option>
     </route>
-
+    <route id="emsco_api_meta_environments" path="/environments"
+           controller="EMS\CoreBundle\Controller\Api\Admin\MetaController::environments"
+           methods="GET"
+           format="json">
+        <option key="openapi">true</option>
+    </route>
     <route id="emsco_api_meta_info_documents" path="/info/documents"
            controller="EMS\CoreBundle\Controller\Api\Admin\MetaController::infoDocuments"
            methods="POST"

--- a/EMS/core-bundle/src/Controller/Api/Admin/MetaController.php
+++ b/EMS/core-bundle/src/Controller/Api/Admin/MetaController.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace EMS\CoreBundle\Controller\Api\Admin;
 
 use EMS\CommonBundle\Common\EMSLinkCollection;
+use EMS\CoreBundle\Entity\Environment;
 use EMS\CoreBundle\Service\ContentTypeService;
+use EMS\CoreBundle\Service\EnvironmentService;
 use EMS\CoreBundle\Service\Revision\RevisionService;
 use EMS\Helpers\Standard\Json;
 use EMS\Helpers\Standard\Type;
@@ -19,6 +21,7 @@ class MetaController
     public function __construct(
         private readonly ContentTypeService $contentTypeService,
         private readonly RevisionService $revisionService,
+        private readonly EnvironmentService $environmentService,
     ) {
     }
 
@@ -80,5 +83,19 @@ class MetaController
         }
 
         return new JsonResponse($drafts);
+    }
+
+    public function environments(Request $request): Response
+    {
+        $environments = $this->environmentService->findEnvironments(
+            managed: $request->query->has('managed') ? $request->query->getBoolean('managed') : null,
+            snapshot: $request->query->has('snapshot') ? $request->query->getBoolean('snapshot') : null,
+        );
+
+        return new JsonResponse(\array_map(fn (Environment $environment) => [
+            'name' => $environment->getName(),
+            'managed' => $environment->getManaged(),
+            'snapshot' => $environment->getSnapshot(),
+        ], $environments));
     }
 }

--- a/EMS/core-bundle/src/Service/EnvironmentService.php
+++ b/EMS/core-bundle/src/Service/EnvironmentService.php
@@ -92,6 +92,19 @@ class EnvironmentService implements EntityServiceInterface
     }
 
     /**
+     * @return array<Environment>
+     */
+    public function findEnvironments(?bool $managed = null, ?bool $snapshot = null): array
+    {
+        $criteria = \array_filter([
+            'managed' => $managed,
+            'snapshot' => $snapshot,
+        ], static fn ($value) => null !== $value);
+
+        return $this->environmentRepository->findBy($criteria, ['orderKey' => 'ASC']);
+    }
+
+    /**
      * @return Environment[]
      */
     public function getEnvironments(): array


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  n |
| New feature?   |  y |
| BC breaks?     |  n |
| Deprecations?  |  n |
| Fixed tickets? |  n |
| Documentation? | n  |

Add a new meta endpoint for getting all environments names.
