### PR TITLE
feat(core/api): new meta attach alias to environment endpoint

### DIFF
--- a/EMS/common-bundle/src/Common/CoreApi/Endpoint/Admin/Admin.php
+++ b/EMS/common-bundle/src/Common/CoreApi/Endpoint/Admin/Admin.php
@@ -89,7 +89,7 @@ class Admin implements AdminInterface
     }
 
     #[\Override]
-    public function runCommand(string $command, ?OutputInterface $output = null): void
+    public function runCommand(string $command, ?OutputInterface $output = null): string
     {
         $job = [
             'class' => 'EMS\CoreBundle\Entity\Job',
@@ -103,6 +103,8 @@ class Admin implements AdminInterface
         if (null !== $output) {
             $this->writeJobOutput($jobId, $output);
         }
+
+        return $jobId;
     }
 
     #[\Override]

--- a/EMS/common-bundle/src/Common/CoreApi/Endpoint/Meta/Meta.php
+++ b/EMS/common-bundle/src/Common/CoreApi/Endpoint/Meta/Meta.php
@@ -52,4 +52,12 @@ final readonly class Meta implements MetaInterface
 
         return $this->client->get('/api/meta/environments', $query)->getData();
     }
+
+    public function aliasAttachEnvironment(string $alias, string $environment): bool
+    {
+        return $this->client->post(\implode('/', ['api', 'meta', 'alias-attach-environment']), [
+            'alias' => $alias,
+            'environment' => $environment,
+        ])->isSuccess();
+    }
 }

--- a/EMS/common-bundle/src/Contracts/CoreApi/Endpoint/Admin/AdminInterface.php
+++ b/EMS/common-bundle/src/Contracts/CoreApi/Endpoint/Admin/AdminInterface.php
@@ -40,7 +40,7 @@ interface AdminInterface
 
     public function writeJobOutput(string $jobId, OutputInterface $output): void;
 
-    public function runCommand(string $command, OutputInterface $output): void;
+    public function runCommand(string $command, OutputInterface $output): string;
 
     public function getNextJob(string $tag, ?string $jobId): ?Job;
 

--- a/EMS/common-bundle/src/Contracts/CoreApi/Endpoint/Admin/MetaInterface.php
+++ b/EMS/common-bundle/src/Contracts/CoreApi/Endpoint/Admin/MetaInterface.php
@@ -39,4 +39,6 @@ interface MetaInterface
      * @return array<int, array{ name: string, managed: bool, snapshot: bool}>
      */
     public function getEnvironments(?bool $managed = null, ?bool $snapshot = null): array;
+
+    public function aliasAttachEnvironment(string $alias, string $environment): bool;
 }

--- a/EMS/core-bundle/config/routing/api/meta.xml
+++ b/EMS/core-bundle/config/routing/api/meta.xml
@@ -16,13 +16,18 @@
            format="json">
         <option key="openapi">true</option>
     </route>
+    <route id="emsco_api_meta_alias_attach_environment" path="/alias-attach-environment"
+           controller="EMS\CoreBundle\Controller\Api\Admin\MetaController::aliasAttachEnvironment"
+           methods="POST"
+           format="json">
+        <option key="openapi">true</option>
+    </route>
     <route id="emsco_api_meta_info_documents" path="/info/documents"
            controller="EMS\CoreBundle\Controller\Api\Admin\MetaController::infoDocuments"
            methods="POST"
            format="json">
         <option key="openapi">true</option>
     </route>
-
     <route id="emsco_api_meta_content_type" path="/content-type/{contentTypeName}"
            controller="EMS\CoreBundle\Controller\Api\Admin\MetaController::contentType"
            methods="GET"

--- a/EMS/core-bundle/src/Controller/Api/Admin/MetaController.php
+++ b/EMS/core-bundle/src/Controller/Api/Admin/MetaController.php
@@ -13,7 +13,6 @@ use EMS\Helpers\Standard\Json;
 use EMS\Helpers\Standard\Type;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class MetaController
@@ -35,7 +34,7 @@ class MetaController
         return new JsonResponse(['info' => $this->revisionService->getInfos($environments, $emsLinks)]);
     }
 
-    public function contentType(string $contentTypeName): Response
+    public function contentType(string $contentTypeName): JsonResponse
     {
         $contentType = $this->contentTypeService->getByName($contentTypeName);
         if (false === $contentType) {
@@ -48,7 +47,7 @@ class MetaController
         ]);
     }
 
-    public function contentTypes(): Response
+    public function contentTypes(): JsonResponse
     {
         $contentTypes = [];
         foreach ($this->contentTypeService->getAll() as $contentType) {
@@ -60,7 +59,7 @@ class MetaController
         return new JsonResponse($contentTypes);
     }
 
-    public function drafts(Request $request): Response
+    public function drafts(Request $request): JsonResponse
     {
         $drafts = [];
         $includeRawData = $request->query->getBoolean('includeRawData', false);
@@ -85,7 +84,7 @@ class MetaController
         return new JsonResponse($drafts);
     }
 
-    public function environments(Request $request): Response
+    public function environments(Request $request): JsonResponse
     {
         $environments = $this->environmentService->findEnvironments(
             managed: $request->query->has('managed') ? $request->query->getBoolean('managed') : null,
@@ -97,5 +96,13 @@ class MetaController
             'managed' => $environment->getManaged(),
             'snapshot' => $environment->getSnapshot(),
         ], $environments));
+    }
+
+    public function aliasAttachEnvironment(Request $request): JsonResponse
+    {
+        $content = Json::decode(Type::string($request->getContent()));
+        $this->environmentService->attachToAlias($content['environment'], $content['alias']);
+
+        return new JsonResponse(['success' => true]);
     }
 }

--- a/EMS/core-bundle/src/Service/EnvironmentService.php
+++ b/EMS/core-bundle/src/Service/EnvironmentService.php
@@ -16,6 +16,7 @@ use EMS\CommonBundle\Helper\EmsFields;
 use EMS\CommonBundle\Service\ElasticaService;
 use EMS\CoreBundle\Core\ContentType\ContentTypeRoles;
 use EMS\CoreBundle\Core\Environment\EnvironmentsRevision;
+use EMS\CoreBundle\Core\Environment\Index;
 use EMS\CoreBundle\Entity\Analyzer;
 use EMS\CoreBundle\Entity\ContentType;
 use EMS\CoreBundle\Entity\Environment;
@@ -27,6 +28,7 @@ use EMS\CoreBundle\Repository\EnvironmentRepository;
 use EMS\CoreBundle\Repository\EnvironmentRevisionRepository;
 use EMS\CoreBundle\Repository\FilterRepository;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 class EnvironmentService implements EntityServiceInterface
@@ -55,6 +57,24 @@ class EnvironmentService implements EntityServiceInterface
             throw new \RuntimeException('Not found repository');
         }
         $this->environmentRepository = $environmentRepository;
+    }
+
+    public function attachToAlias(string $environmentName, string $targetAlias): void
+    {
+        $aliases = $this->aliasService->getAliases();
+
+        $environment = $this->giveByName($environmentName);
+        $indexes = $aliases[$environment->getAlias()]['indexes'] ?? [];
+        $index = \array_shift($indexes);
+
+        if (!$index instanceof Index) {
+            throw new \RuntimeException(\sprintf('Could not find index for environment %s', $environment->getName()));
+        }
+        if (!isset($aliases[$targetAlias])) {
+            throw new NotFoundHttpException(\sprintf('Alias "%s" does not exist', $targetAlias));
+        }
+
+        $this->aliasService->updateAlias($targetAlias, ['add' => [$index->name]]);
     }
 
     public function createEnvironment(string $name, string $color = 'default', bool $updateReferrers = false): Environment


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | n  |
| New feature?   | y  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Added a new endpoint /api/meta/alias-attach-environment  for attach an environment to an alias.
