### PR TITLE
fix(core/api): run command output can be null

### DIFF
--- a/EMS/common-bundle/src/Contracts/CoreApi/Endpoint/Admin/AdminInterface.php
+++ b/EMS/common-bundle/src/Contracts/CoreApi/Endpoint/Admin/AdminInterface.php
@@ -40,7 +40,7 @@ interface AdminInterface
 
     public function writeJobOutput(string $jobId, OutputInterface $output): void;
 
-    public function runCommand(string $command, OutputInterface $output): string;
+    public function runCommand(string $command, ?OutputInterface $output = null): string;
 
     public function getNextJob(string $tag, ?string $jobId): ?Job;
 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

The implementation runCommand had already nullable support for $output. But the interface not.
