### PR TITLE
feat(core/api): add data environments endpoint

### DIFF
--- a/EMS/common-bundle/src/Common/CoreApi/Endpoint/Data/Data.php
+++ b/EMS/common-bundle/src/Common/CoreApi/Endpoint/Data/Data.php
@@ -76,6 +76,12 @@ final readonly class Data implements DataInterface
     }
 
     #[\Override]
+    public function getEnvironments(string $ouuid): array
+    {
+        return $this->client->get($this->makeResource('environments', $ouuid))->getData();
+    }
+
+    #[\Override]
     public function getDraft(int $revisionId): array
     {
         $resource = $this->makeResource('draft', (string) $revisionId);

--- a/EMS/common-bundle/src/Contracts/CoreApi/Endpoint/Data/DataInterface.php
+++ b/EMS/common-bundle/src/Contracts/CoreApi/Endpoint/Data/DataInterface.php
@@ -64,6 +64,11 @@ interface DataInterface
     public function get(string $ouuid): RevisionInterface;
 
     /**
+     * @return array<int, array{ name: string, label: string, snapshot: bool }>
+     */
+    public function getEnvironments(string $ouuid): array;
+
+    /**
      * @throws CoreApiExceptionInterface
      */
     public function head(string $ouuid): bool;

--- a/EMS/core-bundle/config/controllers.xml
+++ b/EMS/core-bundle/config/controllers.xml
@@ -220,6 +220,7 @@
             <argument type="service" id="ems.service.contenttype" />
             <argument type="service" id="ems_core.core_ui.flash_message_logger" />
             <argument type="service" id="ems.service.revision" />
+            <argument type="service" id="EMS\CoreBundle\Service\EnvironmentService" />
             <call method="setContainer"/>
             <tag name="container.service_subscriber"/>
         </service>

--- a/EMS/core-bundle/config/routing/interface.xml
+++ b/EMS/core-bundle/config/routing/interface.xml
@@ -76,6 +76,14 @@
         <default key="interface">api</default>
         <requirement key="interface">api|json</requirement>
     </route>
+    <route id="emsco_interface_document_environments" path="/{interface}/data/{name}/environments/{ouuid}"
+           controller="EMS\CoreBundle\Controller\ContentManagement\CrudController::environments"
+           methods="GET"
+           format="json">
+        <option key="openapi">true</option>
+        <default key="interface">api</default>
+        <requirement key="interface">api|json</requirement>
+    </route>
     <route id="emsco_interface_document_delete" path="/{interface}/data/{name}/delete/{ouuid}"
            controller="EMS\CoreBundle\Controller\ContentManagement\CrudController::delete"
            methods="POST"

--- a/EMS/core-bundle/src/Controller/ContentManagement/CrudController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/CrudController.php
@@ -8,10 +8,12 @@ use EMS\CommonBundle\Helper\EmsFields;
 use EMS\CoreBundle\Core\ContentType\ContentTypeRoles;
 use EMS\CoreBundle\Core\UI\FlashMessageLogger;
 use EMS\CoreBundle\Entity\ContentType;
+use EMS\CoreBundle\Entity\Environment;
 use EMS\CoreBundle\Entity\User;
 use EMS\CoreBundle\Exception\DataStateException;
 use EMS\CoreBundle\Service\ContentTypeService;
 use EMS\CoreBundle\Service\DataService;
+use EMS\CoreBundle\Service\EnvironmentService;
 use EMS\CoreBundle\Service\Revision\RevisionService;
 use EMS\CoreBundle\Service\UserService;
 use EMS\Helpers\Standard\Json;
@@ -35,6 +37,7 @@ class CrudController extends AbstractController
         private readonly ContentTypeService $contentTypeService,
         private readonly FlashMessageLogger $flashMessageLogger,
         private readonly RevisionService $revisionService,
+        private readonly EnvironmentService $environmentService,
     ) {
     }
 
@@ -120,6 +123,18 @@ class CrudController extends AbstractController
             'ouuid' => $revision->getOuuid(),
             'id' => $revision->getId(),
         ]);
+    }
+
+    public function environments(string $name, string $ouuid): JsonResponse
+    {
+        $revision = $this->dataService->getNewestRevision($name, $ouuid);
+        $environments = $this->environmentService->getPublishedForRevision($revision, true);
+
+        return new JsonResponse($environments->map(fn (Environment $e) => [
+            'name' => $e->getName(),
+            'label' => $e->getLabel(),
+            'snapshot' => $e->getSnapshot(),
+        ])->toArray());
     }
 
     public function getDraft(int $revisionId): JsonResponse


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | n  |
| New feature?   | y  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Get the published environment on the data endpoint by getEnvironments($ouuid)
