### PR TITLE
feat(core/cli): create environment new role and color option

### DIFF
--- a/EMS/core-bundle/src/Command/CreateEnvironmentCommand.php
+++ b/EMS/core-bundle/src/Command/CreateEnvironmentCommand.php
@@ -6,6 +6,7 @@ namespace EMS\CoreBundle\Command;
 
 use EMS\CommonBundle\Common\Command\AbstractCommand;
 use EMS\CoreBundle\Commands;
+use EMS\CoreBundle\Roles;
 use EMS\CoreBundle\Service\DataService;
 use EMS\CoreBundle\Service\EnvironmentService;
 use Psr\Log\LoggerInterface;
@@ -27,6 +28,8 @@ class CreateEnvironmentCommand extends AbstractCommand
     final public const string OPTION_STRICT = 'strict';
     final public const string OPTION_UPDATE_REFERRERS = 'update-referrers';
     final public const string OPTION_POSITION = 'position';
+    final public const string OPTION_ROLE_PUBLISH = 'role-publish';
+    final public const string OPTION_COLOR = 'color';
 
     public function __construct(
         private readonly LoggerInterface $logger,
@@ -63,6 +66,18 @@ class CreateEnvironmentCommand extends AbstractCommand
                 InputOption::VALUE_REQUIRED,
                 'Specifies the position at which the environment should be created'
             )
+            ->addOption(
+                self::OPTION_COLOR,
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Specifies the color of the environment'
+            )
+            ->addOption(
+                self::OPTION_ROLE_PUBLISH,
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Sets the publishing role for the environment (use false to disable publishing)'
+            )
         ;
     }
 
@@ -91,8 +106,10 @@ class CreateEnvironmentCommand extends AbstractCommand
             $updateReferrers = (bool) $input->getOption(self::OPTION_UPDATE_REFERRERS);
             $environment = $this->environmentService->createEnvironment(
                 name: $environmentName,
+                color: $this->getOptionStringNull(self::OPTION_COLOR) ?? 'default',
                 updateReferrers: $updateReferrers,
-                position: $this->getOptionIntNull(self::OPTION_POSITION)
+                position: $this->getOptionIntNull(self::OPTION_POSITION),
+                rolePublish: $this->getRolePublish(),
             );
         } catch (\Exception $e) {
             $this->io->error($e->getMessage());
@@ -140,6 +157,17 @@ class CreateEnvironmentCommand extends AbstractCommand
             $this->setEnvironmentNameArgument($input, $message);
             $this->checkEnvironmentNameArgument($input);
         }
+    }
+
+    private function getRolePublish(): ?string
+    {
+        $rolePublish = $this->input->getOption(self::OPTION_ROLE_PUBLISH);
+
+        return match (true) {
+            'false' === $rolePublish => Roles::NOT_DEFINED,
+            \is_string($rolePublish) => $rolePublish,
+            default => null,
+        };
     }
 
     private function setEnvironmentNameArgument(InputInterface $input, string $message): string

--- a/EMS/core-bundle/src/Command/CreateEnvironmentCommand.php
+++ b/EMS/core-bundle/src/Command/CreateEnvironmentCommand.php
@@ -70,7 +70,8 @@ class CreateEnvironmentCommand extends AbstractCommand
                 self::OPTION_COLOR,
                 null,
                 InputOption::VALUE_REQUIRED,
-                'Specifies the color of the environment'
+                'Specifies the color of the environment',
+                'default'
             )
             ->addOption(
                 self::OPTION_ROLE_PUBLISH,
@@ -106,7 +107,7 @@ class CreateEnvironmentCommand extends AbstractCommand
             $updateReferrers = (bool) $input->getOption(self::OPTION_UPDATE_REFERRERS);
             $environment = $this->environmentService->createEnvironment(
                 name: $environmentName,
-                color: $this->getOptionStringNull(self::OPTION_COLOR) ?? 'default',
+                color: $this->getOptionString(self::OPTION_COLOR),
                 updateReferrers: $updateReferrers,
                 position: $this->getOptionIntNull(self::OPTION_POSITION),
                 rolePublish: $this->getRolePublish(),

--- a/EMS/core-bundle/src/Service/EnvironmentService.php
+++ b/EMS/core-bundle/src/Service/EnvironmentService.php
@@ -77,7 +77,7 @@ class EnvironmentService implements EntityServiceInterface
         $this->aliasService->updateAlias($targetAlias, ['add' => [$index->name]]);
     }
 
-    public function createEnvironment(string $name, string $color = 'default', bool $updateReferrers = false, ?int $position = null): Environment
+    public function createEnvironment(string $name, string $color = 'default', bool $updateReferrers = false, ?int $position = null, ?string $rolePublish = null): Environment
     {
         if (!$this->validateEnvironmentName($name)) {
             throw new \Exception('An environment name must respects the following regex /^[a-z][a-z0-9\-_]*$/');
@@ -90,6 +90,7 @@ class EnvironmentService implements EntityServiceInterface
         $environment->setManaged(true);
         $environment->setUpdateReferrers($updateReferrers);
         $environment->setOrderKey($this->count(context: ['managed' => true]));
+        $environment->setRolePublish($rolePublish);
 
         if (null !== $position) {
             $max = $this->environmentRepository->getMaxOrder();

--- a/docs/elasticms-admin/commands/commands.md
+++ b/docs/elasticms-admin/commands/commands.md
@@ -126,14 +126,16 @@ Description:
 
 Usage:
   emsco:environment:create [options] [--] <name>
-  
+
 Arguments:
-  name                     The environment name
+  name                             The environment name
 
 Options:
-      --strict             If set, the check failed will throw an exception
-      --update-referrers   If set, update referrers is true
-      --position=POSITION  Pass a position number, 1 for first position
+      --strict                     If set, the check failed will throw an exception
+      --update-referrers           If set, update referrers is true
+      --position=POSITION          Specifies the position at which the environment should be created
+      --color=COLOR                Specifies the color of the environment
+      --role-publish=ROLE-PUBLISH  Sets the publishing role for the environment (use false to disable publishing).
 ```
 
 #### Environment align


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  n |
| New feature?   | y  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n |
| Documentation? | y  |

Make it possible to define the publish role and color on creation environment via CLI
