### PR TITLE
fix(admin/view): calendar,criteria gallery findChildByName

### DIFF
--- a/EMS/core-bundle/src/Form/View/CalendarViewType.php
+++ b/EMS/core-bundle/src/Form/View/CalendarViewType.php
@@ -82,9 +82,12 @@ class CalendarViewType extends ViewType
 
         $form->handleRequest($request);
 
+        $fieldType = $view->getContentType()->getFieldType();
+        $dateRangeField = $view->getOptions()['dateRangeField'] ?? null;
+
         return [
             'view' => $view,
-            'field' => $view->getContentType()->getFieldType()->get('ems_'.$view->getOptions()['dateRangeField']),
+            'field' => $dateRangeField ? $fieldType->findChildByName($dateRangeField) : null,
             'contentType' => $view->getContentType(),
             'environment' => $view->getContentType()->getEnvironment(),
             'form' => $form->createView(),

--- a/EMS/core-bundle/src/Form/View/CriteriaViewType.php
+++ b/EMS/core-bundle/src/Form/View/CriteriaViewType.php
@@ -92,16 +92,21 @@ class CriteriaViewType extends ViewType
 
         $categoryField = false;
         if ($view->getContentType()->getCategoryField()) {
-            $categoryField = $view->getContentType()->getFieldType()->get('ems_'.$view->getContentType()->getCategoryField());
+            $categoryField = $view->getContentType()->getFieldType()->findChildByName($view->getContentType()->getCategoryField());
+        }
+
+        $criteriaField = $view->getOptions()['criteriaField'] ?? null;
+        if ($criteriaField) {
+            $criterionList = $view->getContentType()->getFieldType()->findChildByName($criteriaField);
         }
 
         return [
-            'criteriaField' => $view->getOptions()['criteriaField'],
+            'criteriaField' => $criteriaField,
             'categoryField' => $categoryField,
             'view' => $view,
             'contentType' => $view->getContentType(),
             'environment' => $view->getContentType()->getEnvironment(),
-            'criterionList' => $view->getContentType()->getFieldType()->get('ems_'.$view->getOptions()['criteriaField']),
+            'criterionList' => $criterionList ?? null,
             'form' => $form->createView(),
         ];
     }

--- a/EMS/core-bundle/src/Form/View/GalleryViewType.php
+++ b/EMS/core-bundle/src/Form/View/GalleryViewType.php
@@ -101,10 +101,14 @@ class GalleryViewType extends ViewType
         }
         $resultSet = $this->elasticaService->search($elasticaSearch);
 
+        $fieldType = $view->getContentType()->getFieldType();
+        $imageAssetConfigIdentifier = $view->getOptions()['imageAssetConfigIdentifier'] ?? null;
+        $imageField = $view->getOptions()['imageField'] ?? null;
+
         return [
             'view' => $view,
-            'field' => $view->getContentType()->getFieldType()->get('ems_'.$view->getOptions()['imageField']),
-            'imageAssetConfigIdentifier' => $view->getContentType()->getFieldType()->get('ems_'.$view->getOptions()['imageAssetConfigIdentifier']),
+            'field' => $imageField ? $fieldType->findChildByName($imageField) : null,
+            'imageAssetConfigIdentifier' => $imageAssetConfigIdentifier ? $fieldType->findChildByName($imageAssetConfigIdentifier) : null,
             'contentType' => $view->getContentType(),
             'environment' => $view->getContentType()->getEnvironment(),
             'form' => $form->createView(),


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  |  n |
| Fixed tickets? | n  |
| Documentation? | n  |

In this old PR: https://github.com/ems-project/elasticms/pull/708
We removed the __get method on the FieldType entity. But the __get method was returning null on  not found. Now we throw exceptions. So we should not use get but the findChildByName method.
