### PR TITLE
fix(admin/webalize): align regex with web

### DIFF
--- a/elasticms-admin/config/packages/ems_common.yaml
+++ b/elasticms-admin/config/packages/ems_common.yaml
@@ -35,8 +35,8 @@ parameters:
     env(EMS_METRIC_ENABLED): false
     env(EMS_METRIC_HOST): ''
     env(EMS_METRIC_PORT): ~
-    env(EMS_WEBALIZE_REMOVABLE_REGEX): '/([^a-zA-Z0-9_| \-.''\/])|(\.$)/'
-    env(EMS_WEBALIZE_DASHABLE_REGEX): '/[\/| '']+/'
+    env(EMS_WEBALIZE_REMOVABLE_REGEX): '/([^a-zA-Z0-9\_\|\ \-\.])|(\.$)/'
+    env(EMS_WEBALIZE_DASHABLE_REGEX): '/[\/\_\|\ \-]+/'
     env(EMS_EXCLUDED_CONTENT_TYPES): '[]'
     env(EMS_SLUG_SYMBOL_MAP): ~
     env(EMS_TRUSTED_IPS): '[]'


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Align the removable and dashable regex with the web config. Because now by default the admin webalize does not work the same as the webalize in the frontend.
