### PR TITLE
fix(common/encoding): ems_anti_spam handle multiple phone numbers

### DIFF
--- a/EMS/common-bundle/src/Helper/Text/Encoder.php
+++ b/EMS/common-bundle/src/Helper/Text/Encoder.php
@@ -43,8 +43,8 @@ class Encoder
      */
     private function encodePhone(string $text): string
     {
-        $telRegex = '/"tel:(?P<tel>.*)"/i';
-        $encodedText = \preg_replace_callback($telRegex, fn ($match) => \sprintf('"tel:%s"', $this->htmlEncode($match['tel'])), $text);
+        $telRegex = '~href\s*=\s*["\']tel:(?P<tel>[^"\']+)["\']~i';
+        $encodedText = \preg_replace_callback($telRegex, fn ($match) => \sprintf('href="tel:%s"', $this->htmlEncode($match['tel'])), $text);
 
         if (null === $encodedText) {
             return $text;

--- a/EMS/common-bundle/tests/Unit/Helper/Text/EncoderTest.php
+++ b/EMS/common-bundle/tests/Unit/Helper/Text/EncoderTest.php
@@ -58,9 +58,11 @@ class EncoderTest extends TestCase
             ['<', '<'],
             ['mailto:example@example.com', \sprintf('mailto:%s', $email)],
             ['<a href="mailto:example@example.com">example@example.com</a>', \sprintf('<a href="mailto:%s">%s</a>', $email, $email)],
-            ['"tel:02/345.67.89"', '"tel:&#48;&#50;&#47;&#51;&#52;&#53;&#46;&#54;&#55;&#46;&#56;&#57;"'],
+            ['href="tel:02/345.67.89"', 'href="tel:&#48;&#50;&#47;&#51;&#52;&#53;&#46;&#54;&#55;&#46;&#56;&#57;"'],
             ['<a href="tel:+3221234523">02/123.45.23</a>', '<a href="tel:&#43;&#51;&#50;&#50;&#49;&#50;&#51;&#52;&#53;&#50;&#51;">02/123.45.23</a>'],
             ['<span class="pii">example</span>', $example],
+            ['<a href="tel:+3221234523">02/123.45.23</a> and another phone <a href="tel:+3221234523">02/123.45.23</a>', '<a href="tel:&#43;&#51;&#50;&#50;&#49;&#50;&#51;&#52;&#53;&#50;&#51;">02/123.45.23</a> and another phone <a href="tel:&#43;&#51;&#50;&#50;&#49;&#50;&#51;&#52;&#53;&#50;&#51;">02/123.45.23</a>'],
+            ['<a href="/index.html">Homepage</a> and a phone <a href="tel:+3221234123">02/123.41.23</a> and another phone <a href="tel:+3221234523">02/123.45.23</a>.', '<a href="/index.html">Homepage</a> and a phone <a href="tel:&#43;&#51;&#50;&#50;&#49;&#50;&#51;&#52;&#49;&#50;&#51;">02/123.41.23</a> and another phone <a href="tel:&#43;&#51;&#50;&#50;&#49;&#50;&#51;&#52;&#53;&#50;&#51;">02/123.45.23</a>.'],
         ];
     }
 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  |  n |
| Fixed tickets? |  n |
| Documentation? | n  |

If the html was containing more than 2 tel: links all texte between those attributes was encoded.
