### PR TITLE
chore(lincense): use LGPL-3.0-or-later

### DIFF
--- a/EMS/admin-ui-bundle/assets/package-lock.json
+++ b/EMS/admin-ui-bundle/assets/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "vite",
       "version": "0.0.0",
-      "license": "LGPL-3.0",
+      "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@a2lix/symfony-collection": "^0.6.1",
         "@elasticms/file-uploader": "^1.0.2",

--- a/EMS/admin-ui-bundle/assets/package.json
+++ b/EMS/admin-ui-bundle/assets/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "license": "LGPL-3.0",
+  "license": "LGPL-3.0-or-later",
   "scripts": {
     "build": "tsc && vite build",
     "dev": "vite",

--- a/EMS/admin-ui-bundle/composer.json
+++ b/EMS/admin-ui-bundle/composer.json
@@ -7,7 +7,7 @@
         "admin",
         "ui"
     ],
-    "license": "LGPL-3.0",
+    "license": "LGPL-3.0-or-later",
     "authors": [
         {
             "name": "EMS Community",

--- a/EMS/client-helper-bundle/composer.json
+++ b/EMS/client-helper-bundle/composer.json
@@ -5,7 +5,7 @@
     "keywords": [
         "elasticms"
     ],
-    "license": "LGPL-3.0",
+    "license": "LGPL-3.0-or-later",
     "authors": [
         {
             "name": "EMS Community",

--- a/EMS/common-bundle/composer.json
+++ b/EMS/common-bundle/composer.json
@@ -5,7 +5,7 @@
     "keywords": [
         "elasticms"
     ],
-    "license": "LGPL-3.0",
+    "license": "LGPL-3.0-or-later",
     "authors": [
         {
             "name": "EMS Community",

--- a/EMS/core-bundle/composer.json
+++ b/EMS/core-bundle/composer.json
@@ -5,7 +5,7 @@
     "keywords": [
         "elasticms"
     ],
-    "license": "LGPL-3.0",
+    "license": "LGPL-3.0-or-later",
     "authors": [
         {
             "name": "EMS Community",

--- a/EMS/core-bundle/package-lock.json
+++ b/EMS/core-bundle/package-lock.json
@@ -4,7 +4,7 @@
   "requires": true,
   "packages": {
     "": {
-      "license": "LGPL-3.0",
+      "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@a2lix/symfony-collection": "^0.4.0",
         "@elasticms/file-uploader": "^1.0.1",

--- a/EMS/core-bundle/package.json
+++ b/EMS/core-bundle/package.json
@@ -32,7 +32,7 @@
     "type": "git",
     "url": "https://github.com/ems-project/EMSCoreBundle.git"
   },
-  "license": "LGPL-3.0",
+  "license": "LGPL-3.0-or-later",
   "scripts": {
     "build": "webpack --mode=production",
     "dev": "webpack --mode=development",

--- a/EMS/form-bundle/composer.json
+++ b/EMS/form-bundle/composer.json
@@ -5,7 +5,7 @@
     "keywords": [
         "elasticms"
     ],
-    "license": "LGPL-3.0",
+    "license": "LGPL-3.0-or-later",
     "authors": [
         {
             "name": "EMS Community",

--- a/EMS/form-bundle/package-lock.json
+++ b/EMS/form-bundle/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "form-bundle",
       "version": "1.0.0",
-      "license": "LGPL-3.0",
+      "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
         "bootstrap": "^5.3.8",

--- a/EMS/form-bundle/package.json
+++ b/EMS/form-bundle/package.json
@@ -16,7 +16,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "LGPL-3.0",
+  "license": "LGPL-3.0-or-later",
   "bugs": {
     "url": "https://github.com/ems-project/EMSFormBundle/issues"
   },

--- a/EMS/helpers/composer.json
+++ b/EMS/helpers/composer.json
@@ -7,7 +7,7 @@
         "phpstan",
         "helpers"
     ],
-    "license": "LGPL-3.0",
+    "license": "LGPL-3.0-or-later",
     "authors": [
         {
             "name": "EMS Community",

--- a/EMS/submission-bundle/composer.json
+++ b/EMS/submission-bundle/composer.json
@@ -5,7 +5,7 @@
     "keywords": [
         "elasticms"
     ],
-    "license": "LGPL-3.0",
+    "license": "LGPL-3.0-or-later",
     "authors": [
         {
             "name": "EMS Community",

--- a/EMS/xliff/composer.json
+++ b/EMS/xliff/composer.json
@@ -7,7 +7,7 @@
         "phpstan",
         "xliff"
     ],
-    "license": "LGPL-3.0",
+    "license": "LGPL-3.0-or-later",
     "authors": [
         {
             "name": "EMS Community",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
             "homepage": "https://github.com/ems-project/elasticms/contributors"
         }
     ],
-    "license": "LGPL-3.0",
+    "license": "LGPL-3.0-or-later",
     "minimum-stability": "stable",
     "prefer-stable": true,
     "require": {

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "demo-website",
       "version": "2.0.0",
-      "license": "LGPL-3.0",
+      "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@elasticms/admin-menu": "^1.0.1",
         "@fontsource/mulish": "^4.5.11",

--- a/demo/package.json
+++ b/demo/package.json
@@ -15,7 +15,7 @@
         "watch": "vite build --watch"
     },
     "keywords": [],
-    "license": "LGPL-3.0",
+    "license": "LGPL-3.0-or-later",
     "devDependencies": {
         "@babel/core": "^7.14.3",
         "@babel/preset-env": "^7.14.2",

--- a/elasticms-admin/composer.json
+++ b/elasticms-admin/composer.json
@@ -8,7 +8,7 @@
         }
     ],
     "type": "project",
-    "license": "LGPL-3.0",
+    "license": "LGPL-3.0-or-later",
     "minimum-stability": "stable",
     "prefer-stable": true,
     "require": {

--- a/elasticms-cli/composer.json
+++ b/elasticms-cli/composer.json
@@ -8,7 +8,7 @@
         }
     ],
     "type": "project",
-    "license": "LGPL-3.0",
+    "license": "LGPL-3.0-or-later",
     "minimum-stability": "stable",
     "prefer-stable": true,
     "require": {

--- a/elasticms-web/composer.json
+++ b/elasticms-web/composer.json
@@ -8,7 +8,7 @@
         }
     ],
     "type": "project",
-    "license": "LGPL-3.0",
+    "license": "LGPL-3.0-or-later",
     "minimum-stability": "stable",
     "prefer-stable": true,
     "require": {


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  n |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Composer validate: License "LGPL-3.0" is a deprecated SPDX license identifier, use "LGPL-3.0-only" or "LGPL-3.0-or-later" instead

