### PR TITLE
fix(twig): symfony request::get() is deprecated

### DIFF
--- a/EMS/admin-ui-bundle/templates/bootstrap5/elements/revision-toolbar.html.twig
+++ b/EMS/admin-ui-bundle/templates/bootstrap5/elements/revision-toolbar.html.twig
@@ -14,7 +14,7 @@
     {% endif %}
     {% if current and not draft and is_granted(instance.contentType.roles.edit) %}
         {{ include('@EMSAdminUI/bootstrap5/elements/post-button.html.twig', {
-            url: path('revision.new-draft', {ouuid: revision.ouuid, type: revision.contentType.name, item: app.request.get('item')}),
+            url: path('revision.new-draft', {ouuid: revision.ouuid, type: revision.contentType.name, item: app.request.query.get('item')}),
             label: 'views.elements.revision-toolbar-html.new-draft-label'|trans,
             btnType: 'primary',
             icon: 'pencil'}) }}
@@ -24,7 +24,7 @@
             {% if not instance.contentType.circlesField or attribute(instance.rawData, instance.contentType.circlesField) is not defined or attribute(instance.rawData, instance.contentType.circlesField)|emsco_in_my_circles %}
                 <div class="btn-group">
                     {{ include('@EMSAdminUI/bootstrap5/elements/get-button.html.twig', {
-                        url: path('emsco_edit_revision', {revisionId: revisionId, item: app.request.get('item')}),
+                        url: path('emsco_edit_revision', {revisionId: revisionId, item: app.request.query.get('item')}),
                         label: 'views.elements.revision-toolbar-html.edit-draft-label'|trans,
                         btnType: 'primary',
                         icon: 'pencil'}) }}

--- a/EMS/admin-ui-bundle/templates/bootstrap5/revision/json/json_menu_nested.html.twig
+++ b/EMS/admin-ui-bundle/templates/bootstrap5/revision/json/json_menu_nested.html.twig
@@ -16,7 +16,7 @@
          data-urls="{{ def.urls|json_encode|e('html_attr') }}"
          data-config="{{ def.config }}"
 
-         {%- if app.request.get('item', false) %}data-select-item-id="{{- app.request.get('item') -}}"{% endif -%}
+         {%- if app.request.query.get('item', false) %}data-select-item-id="{{- app.request.query.get('item') -}}"{% endif -%}
          data-hidden-field-id="{{ def.id }}"
         >
         <div class="json-menu-nested-loading"><i class="fa fa-cog fa-spin fa-3x fa-fw"></i></div>

--- a/EMS/admin-ui-bundle/templates/bootstrap5/revision/task/dashboard.html.twig
+++ b/EMS/admin-ui-bundle/templates/bootstrap5/revision/task/dashboard.html.twig
@@ -6,9 +6,9 @@
 {% block pagetitle %}{{ 'task.title'|trans }}{% endblock %}
 
 {% block body %}
-{%- set route = app.request.get('_route') -%}
+{%- set route = app.request.attributes.get('_route') -%}
 {%- set requestQuery = app.request.query.all -%}
-{%- set routeParams = app.request.get('_route_params')|merge(requestQuery) -%}
+{%- set routeParams = app.request.attributes.get('_route_params')|merge(requestQuery) -%}
 {%- set showFilters = attribute(requestQuery, 'filters')|default([])|length > 0 -%}
 <div id="task-dashboard" class="card card-{{ theme_color }}">
     <div class="card-header p-0 border-bottom-0">
@@ -83,7 +83,7 @@
                         <input type="hidden" name="tab" value="{{ currentTab }}" />
                         <div class="btn-group">
                             {{ form_widget(filterForm.submit, {attr: {class: 'btn btn-primary'}}) }}
-                            <a href="{{ path(route, app.request.get('_route_params')|merge({tab: currentTab})) }}"  class="btn btn-default">
+                            <a href="{{ path(route, app.request.attributes.get('_route_params')|merge({tab: currentTab})) }}"  class="btn btn-default">
                                 <i class="fa fa-remove" aria-hidden="true"></i>  {{ 'task.filter.reset'|trans }}
                             </a>
                         </div>

--- a/EMS/core-bundle/templates/elements/revision-toolbar.html.twig
+++ b/EMS/core-bundle/templates/elements/revision-toolbar.html.twig
@@ -14,7 +14,7 @@
 	{% endif %}
 	{% if current and not draft and is_granted(instance.contentType.roles.edit) %}
 		{% include '@EMSCore/elements/post-button.html.twig' with {
-			'url': path('revision.new-draft', {'ouuid': revision.ouuid, 'type':revision.contentType.name, 'item': app.request.get('item') }),
+			'url': path('revision.new-draft', {'ouuid': revision.ouuid, 'type':revision.contentType.name, 'item': app.request.query.get('item') }),
 			'label': 'views.elements.revision-toolbar-html.new-draft-label'|trans,
 			'btnType': 'primary',
 			'icon': 'pencil' }%}
@@ -24,7 +24,7 @@
 			{% if not  instance.contentType.circlesField or attribute(instance.rawData, instance.contentType.circlesField) is not defined or attribute(instance.rawData, instance.contentType.circlesField)|emsco_in_my_circles %}
 				<div class="btn-group">
 					{% include '@EMSCore/elements/get-button.html.twig' with {
-						'url': path('emsco_edit_revision', {'revisionId': revisionId, 'item': app.request.get('item') }),
+						'url': path('emsco_edit_revision', {'revisionId': revisionId, 'item': app.request.query.get('item') }),
 						'label': 'views.elements.revision-toolbar-html.edit-draft-label'|trans,
 						'btnType': 'primary',
 						'icon': 'pencil' }%}

--- a/EMS/core-bundle/templates/revision/json/json_menu_nested.html.twig
+++ b/EMS/core-bundle/templates/revision/json/json_menu_nested.html.twig
@@ -16,7 +16,7 @@
          data-urls="{{ def.urls|json_encode|e('html_attr') }}"
          data-config="{{ def.config }}"
 
-         {%- if app.request.get('item', false) %}data-select-item-id="{{- app.request.get('item') -}}"{% endif -%}
+         {%- if app.request.query.get('item', false) %}data-select-item-id="{{- app.request.query.get('item') -}}"{% endif -%}
          data-hidden-field-id="{{ def.id }}"
         >
         <div class="json-menu-nested-loading"><i class="fa fa-cog fa-spin fa-3x fa-fw"></i></div>

--- a/EMS/core-bundle/templates/revision/task/dashboard.html.twig
+++ b/EMS/core-bundle/templates/revision/task/dashboard.html.twig
@@ -6,9 +6,9 @@
 {% block pagetitle %}{{ 'task.title'|trans }}{% endblock %}
 
 {% block body %}
-{%- set route = app.request.get('_route') -%}
+{%- set route = app.request.attributes.get('_route') -%}
 {%- set requestQuery = app.request.query.all -%}
-{%- set routeParams = app.request.get('_route_params')|merge(requestQuery) -%}
+{%- set routeParams = app.request.attributes.get('_route_params')|merge(requestQuery) -%}
 {%- set showFilters = attribute(requestQuery, 'filters')|default([])|length > 0 -%}
 <div id="task-dashboard" class="nav-tabs-custom">
     <ul class="nav nav-tabs">
@@ -85,7 +85,7 @@
                         <input type="hidden" name="tab" value="{{ currentTab }}" />
                         <div class="btn-group">
                             {{ form_widget(filterForm.submit, { 'attr': { 'class': 'btn btn-primary' } }) }}
-                            <a href="{{ path(route, app.request.get('_route_params')|merge({ 'tab': currentTab }) ) }}"  class="btn btn-default">
+                            <a href="{{ path(route, app.request.attributes.get('_route_params')|merge({ 'tab': currentTab }) ) }}"  class="btn btn-default">
                                 <i class="fa fa-remove" aria-hidden="true"></i>  {{ 'task.filter.reset'|trans }}
                             </a>
                         </div>

--- a/EMS/form-bundle/templates/debug/form.html.twig
+++ b/EMS/form-bundle/templates/debug/form.html.twig
@@ -1,7 +1,7 @@
 {% extends '@EMSForm/debug/base.html.twig' %}
 
 {% set config = form.vars.form_config %}
-{% set validate = app.request.get('validate')|default('1')  %}
+{% set validate = app.request.query.get('validate')|default('1')  %}
 {% trans_default_domain config.translationDomain %}
 {% form_theme form with config.themes %}
 
@@ -14,13 +14,13 @@
     </div>
     <div class="btn-group px-2" role="group" aria-label="Locales">
         {% for l in locales %}
-            <a href="{{ path(app.request.get('_route'), requestQuery|merge({'_locale': l })) }}" class="btn btn-sm btn-outline-warning {{ l == locale ? "active" }}"><b>{{ l|upper }}</b></a>
+            <a href="{{ path(app.request.attributes.get('_route'), requestQuery|merge({'_locale': l })) }}" class="btn btn-sm btn-outline-warning {{ l == locale ? "active" }}"><b>{{ l|upper }}</b></a>
         {% endfor %}
     </div>
     <div class="btn-group px-2" role="group" aria-label="Validation">
         <button class="btn btn-sm btn-light" disabled>JS validation</button>
-        <a href="{{ path(app.request.get('_route'), requestQuery|merge({'validate': '1', '_locale': locale })) }}" class="btn btn-sm {{ validate == '1' ? 'btn-success' : 'btn-outline-success' }}"><b>ON</b></a>
-        <a href="{{ path(app.request.get('_route'), requestQuery|merge({'validate': '0', '_locale': locale })) }}" class="btn btn-sm {{ validate == '0' ? 'btn-danger' : 'btn-outline-danger' }}"><b>OFF</b></a>
+        <a href="{{ path(app.request.attributes.get('_route'), requestQuery|merge({'validate': '1', '_locale': locale })) }}" class="btn btn-sm {{ validate == '1' ? 'btn-success' : 'btn-outline-success' }}"><b>ON</b></a>
+        <a href="{{ path(app.request.attributes.get('_route'), requestQuery|merge({'validate': '0', '_locale': locale })) }}" class="btn btn-sm {{ validate == '0' ? 'btn-danger' : 'btn-outline-danger' }}"><b>OFF</b></a>
     </div>
 {% endblock %}
 

--- a/EMS/form-bundle/templates/debug/iframe.html.twig
+++ b/EMS/form-bundle/templates/debug/iframe.html.twig
@@ -9,7 +9,7 @@
     </div>
     <div class="btn-group px-2" role="group" aria-label="Locales">
         {% for l in locales %}
-            <a href="{{ path(app.request.get('_route'), {'_locale': l, 'ouuid': config.id }) }}" class="btn btn-sm btn-outline-warning {{ l == locale ? "active" }}"><b>{{ l|upper }}</b></a>
+            <a href="{{ path(app.request.attributes.get('_route'), {'_locale': l, 'ouuid': config.id }) }}" class="btn btn-sm btn-outline-warning {{ l == locale ? "active" }}"><b>{{ l|upper }}</b></a>
         {% endfor %}
     </div>
 {% endblock %}

--- a/demo/skeleton/template/page/word-export/export.twig
+++ b/demo/skeleton/template/page/word-export/export.twig
@@ -9,8 +9,8 @@
     "lang": locale
 } %}
 
-{% set contentType = app.request.get('contentType') %}
-{% set ouuid = app.request.get('ouuid') %}
+{% set contentType = app.request.attributes.get('contentType') %}
+{% set ouuid = app.request.attributes.get('ouuid') %}
 {% set document = [contentType, ouuid]|join(':') %}
 
 {% set structureNode = false %}

--- a/demo/skeleton/template/redirects/_emsch_go_to.json.twig
+++ b/demo/skeleton/template/redirects/_emsch_go_to.json.twig
@@ -2,8 +2,8 @@
 
 {%- block request -%}
     {%- if app.user -%}
-        {%- set contentType = app.request.get('contentType') -%}
-        {%- set ouuid = app.request.get('ouuid') -%}
+        {%- set contentType = app.request.attributes.get('contentType') -%}
+        {%- set ouuid = app.request.attributes.get('ouuid') -%}
         {%- set emsLink = "ems://object:#{contentType}:#{ouuid}" -%}
         
         {%- set routingUrl = emsLink|emsch_routing_config({

--- a/demo/skeleton/template/redirects/asset.json.twig
+++ b/demo/skeleton/template/redirects/asset.json.twig
@@ -1,6 +1,6 @@
-{%- set hash = app.request.get('hash') -%}
-{%- set filename = app.request.get('filename') -%}
-{%- set config = app.request.get('config') -%}
+{%- set hash = app.request.attributes.get('hash') -%}
+{%- set filename = app.request.attributes.get('filename') -%}
+{%- set config = app.request.attributes.get('config') -%}
 {%- set search = emsch_search([], {
     "query": {
         "match_phrase": {

--- a/demo/skeleton/template/redirects/icon.json.twig
+++ b/demo/skeleton/template/redirects/icon.json.twig
@@ -5,8 +5,8 @@
         path: emsch_asset('img/head/icon.png', {
             _config_type: 'image',
             _image_format: 'png',
-            _width: app.request.get('width'),
-            _height: app.request.get('height'),
+            _width: app.request.attributes.get('width'),
+            _height: app.request.attributes.get('height'),
             _get_file_path: true,
         }),
     }|json_encode|raw -}}

--- a/demo/skeleton/template/structure/by_path.html.twig
+++ b/demo/skeleton/template/structure/by_path.html.twig
@@ -1,7 +1,7 @@
 {% trans_default_domain trans_default_domain %}
 
-{% set path = app.request.get('path') %}
-{% set locale = app.request.get('_locale') %}
+{% set path = app.request.attributes.get('path') %}
+{% set locale = app.request.attributes.get('_locale') %}
 {% set locales = app.request.server.all['EMSCH_LOCALES']|default('[]')|ems_json_decode %}
 
 {% set searchSection = emsch_search('section', {

--- a/demo/skeleton/template/structure/target-not-found.html.twig
+++ b/demo/skeleton/template/structure/target-not-found.html.twig
@@ -2,4 +2,4 @@
 {% extends '@EMSCH/template/base/bootstrap.html.twig' %}
 
 
-{% block main -%}<h1>{{ 'error.target-not-found'|trans({'%path%': app.request.get('path')}) }}</h1>{%- endblock main %}
+{% block main -%}<h1>{{ 'error.target-not-found'|trans({'%path%': app.request.attributes.get('path')}) }}</h1>{%- endblock main %}

--- a/demo/skeleton/template/view/abstract.html.twig
+++ b/demo/skeleton/template/view/abstract.html.twig
@@ -4,7 +4,7 @@
 {% block request %}
     {% set switchUrls = {} %}
     {% for l in locales|filter(p => p != locale) %}
-        {% set switchUrls = {(l): path(app.request.get('_route')|split('.')|map(p => p == locale ? l : p)|join('.'), route_parameters.(l)|default({}))} %}
+        {% set switchUrls = {(l): path(app.request.attributes.get('_route')|split('.')|map(p => p == locale ? l : p)|join('.'), route_parameters.(l)|default({}))} %}
     {% endfor %}
     {{ parent() }}
 {% endblock request %}

--- a/demo/skeleton/template_ems/channel/page-component-preview.html.twig
+++ b/demo/skeleton/template_ems/channel/page-component-preview.html.twig
@@ -3,7 +3,7 @@
 
 {% block body -%}
     {% with {
-        'structure': [app.request.get('data')|ems_json_decode],
+        'structure': [app.request.request.('data')|ems_json_decode],
         'trans_default_domain': trans_default_domain,
     } %}
         {{ block("render", "@EMSCH/template/page/blocks/abstract-block.html.twig") }}

--- a/demo/skeleton/template_ems/dashboard/sitemap.twig
+++ b/demo/skeleton/template_ems/dashboard/sitemap.twig
@@ -35,7 +35,7 @@
                         'field_path': '[structure]',
                         'template': '@EMSCH/template_ems/dashboard/json_menu_nested.twig',
                         'context_block': 'build_context',
-                        'active_item_id': app.request.get('activeItemId')|default(null),
+                        'active_item_id': app.request.query.get('activeItemId')|default(null),
                         'context': {
                             'sectionLabel': section._source.label,
                             'locale': locale


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Request::get() is deprecated, use properties ->attributes, query or request directly instead.
