### PR TITLE
fix(twig): translatableMessage __toString deprecated

### DIFF
--- a/EMS/admin-ui-bundle/templates/bootstrap5/form/fields.html.twig
+++ b/EMS/admin-ui-bundle/templates/bootstrap5/form/fields.html.twig
@@ -141,7 +141,7 @@
 {%- endblock objectpicker_widget %}
 
 {%- block submitems_widget -%}
-    {%- if label is empty -%}
+    {%- if label is not defined -%}
         {%- if label_format is not empty -%}
             {% set label = label_format|replace({
                 '%name%': name,

--- a/EMS/admin-ui-bundle/templates/bootstrap5/form/forms.html.twig
+++ b/EMS/admin-ui-bundle/templates/bootstrap5/form/forms.html.twig
@@ -397,7 +397,7 @@
                         <div class="modal-content">
                             <div class="modal-header">
                                 <h4 class="modal-title" id="{{ table.attributeName|e('html_attr') }}_modal_reorder_label">
-                                    <strong>{{ reorder_label|default(form.vars.reorder_label)|trans }}</strong>
+                                    <strong>{{ (reorder_label ?? form.vars.reorder_label)|trans }}</strong>
                                 </h4>
                                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ 'action.close'|trans({}, 'emsco-core') }}"></button>
                             </div>

--- a/EMS/core-bundle/templates/form/fields.html.twig
+++ b/EMS/core-bundle/templates/form/fields.html.twig
@@ -127,7 +127,7 @@
 {%- endblock selectpicker_widget %}
 
 {%- block submitems_widget -%}
-    {%- if label is empty -%}
+    {%- if label is not defined -%}
         {%- if label_format is not empty -%}
             {% set label = label_format|replace({
                 '%name%': name,

--- a/EMS/core-bundle/templates/form/forms.html.twig
+++ b/EMS/core-bundle/templates/form/forms.html.twig
@@ -401,7 +401,7 @@
                             <div class="modal-header">
                                 <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
                                 <h4 class="modal-title" id="{{ table.attributeName|e('html_attr') }}_modal_reorder_label">
-                                    <strong>{{ reorder_label|default(form.vars.reorder_label)|trans }}</strong>
+                                    <strong>{{ (reorder_label ?? form.vars.reorder_label)|trans }}</strong>
                                 </h4>
                             </div>
                             <div class="modal-body">


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

User Deprecated: Since symfony/translation 7.4: Method "Symfony\Component\Translation\TranslatableMessage::__toString()" is deprecated.

Calling the default filter with a  TranslatableMessages triggers the deprecated __toString method
