### PR TITLE
fix(xliff): replace commonBundle dependency with ems helpers

### DIFF
--- a/EMS/common-bundle/src/Common/PropertyAccess/PropertyAccessor.php
+++ b/EMS/common-bundle/src/Common/PropertyAccess/PropertyAccessor.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace EMS\CommonBundle\Common\PropertyAccess;
 
-use EMS\CommonBundle\Helper\EmsFields;
 use EMS\Helpers\Standard\Base64;
 use EMS\Helpers\Standard\Json;
 
@@ -119,11 +118,12 @@ class PropertyAccessor
 
     /**
      * @param  mixed[]                             $rawData
+     * @param  string[]                            $attributeNames
      * @return iterable<array<string, int|string>>
      */
-    public function fileFields(array $rawData): iterable
+    public function fieldsWithAttributes(array $rawData, array $attributeNames, int $atLeast = 1): iterable
     {
-        yield from $this->returnFileFields($rawData);
+        yield from $this->returnFieldsWithAttributes($rawData, $attributeNames, $atLeast);
     }
 
     private function getPropertyPath(PropertyPath|string $propertyPath): PropertyPath
@@ -220,23 +220,40 @@ class PropertyAccessor
 
     /**
      * @param  mixed[]                             $rawData
+     * @param  string[]                            $attributeNames
      * @return iterable<array<string, int|string>>
      */
-    private function returnFileFields(array $rawData, string $propertyPath = ''): iterable
+    private function returnFieldsWithAttributes(array $rawData, array $attributeNames, int $atLeast, string $propertyPath = ''): iterable
     {
         foreach ($rawData as $key => $value) {
             if (\is_string($value) && u($value)->trim()->startsWith('{') && Json::isJson($value)) {
-                $this->returnFileFields(Json::decode($value), \sprintf('%s[json:%s]', $propertyPath, $key));
+                $this->returnFieldsWithAttributes(Json::decode($value), $attributeNames, $atLeast, \sprintf('%s[json:%s]', $propertyPath, $key));
                 continue;
             }
             if (!\is_array($value)) {
                 continue;
             }
-            if (isset($value[EmsFields::CONTENT_FILE_HASH_FIELD]) || isset($value[EmsFields::CONTENT_FILE_HASH_FIELD_])) {
+            if ($this->hasAtLeastAttribute($value, $attributeNames, $atLeast)) {
                 yield \sprintf('%s[%s]', $propertyPath, $key) => $value;
                 continue;
             }
-            $this->returnFileFields($value, \sprintf('%s[%s]', $propertyPath, $key));
+            $this->returnFieldsWithAttributes($value, $attributeNames, $atLeast, \sprintf('%s[%s]', $propertyPath, $key));
         }
+    }
+
+    /**
+     * @param mixed[]  $rawData
+     * @param string[] $attributeNames
+     */
+    private function hasAtLeastAttribute(array $rawData, array $attributeNames, int $atLeast): bool
+    {
+        $counter = 0;
+        foreach ($attributeNames as $attributeName) {
+            if (isset($rawData[$attributeName]) && (++$counter >= $atLeast)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/EMS/common-bundle/src/Json/JsonMenuNested.php
+++ b/EMS/common-bundle/src/Json/JsonMenuNested.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace EMS\CommonBundle\Json;
 
-use EMS\CommonBundle\Common\PropertyAccess\PropertyAccessor;
+use EMS\Helpers\PropertyAccess\PropertyAccessor;
 use EMS\Helpers\Standard\Base64;
 use EMS\Helpers\Standard\Json;
 use EMS\Helpers\Standard\Type;

--- a/EMS/core-bundle/src/Command/Asset/RefreshFileFieldCommand.php
+++ b/EMS/core-bundle/src/Command/Asset/RefreshFileFieldCommand.php
@@ -66,7 +66,7 @@ class RefreshFileFieldCommand extends AbstractCommand
         $propertyAccessor = PropertyAccessor::createPropertyAccessor();
         $rawData = $revision->getRawData();
         $fieldsFound = false;
-        foreach ($propertyAccessor->fileFields($revision->getRawData()) as $propertyPath => $fileField) {
+        foreach ($propertyAccessor->fieldsWithAttributes($revision->getRawData(), [EmsFields::CONTENT_FILE_HASH_FIELD, EmsFields::CONTENT_FILE_HASH_FIELD_]) as $propertyPath => $fileField) {
             $fieldsFound = true;
             $hash = $fileField[EmsFields::CONTENT_FILE_HASH_FIELD] ?? $fileField[EmsFields::CONTENT_FILE_HASH_FIELD_] ?? null;
             $filename = $fileField[EmsFields::CONTENT_FILE_NAME_FIELD] ?? $fileField[EmsFields::CONTENT_FILE_NAME_FIELD_] ?? null;

--- a/EMS/core-bundle/src/Command/Asset/RefreshFileFieldCommand.php
+++ b/EMS/core-bundle/src/Command/Asset/RefreshFileFieldCommand.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace EMS\CoreBundle\Command\Asset;
 
 use EMS\CommonBundle\Common\Command\AbstractCommand;
-use EMS\CommonBundle\Common\PropertyAccess\PropertyAccessor;
 use EMS\CommonBundle\Common\Standard\Image;
 use EMS\CommonBundle\Helper\EmsFields;
 use EMS\CommonBundle\Storage\Processor\Config;
@@ -17,6 +16,7 @@ use EMS\CoreBundle\Entity\User;
 use EMS\CoreBundle\Service\FileService;
 use EMS\CoreBundle\Service\Revision\RevisionService;
 use EMS\Helpers\Html\MimeTypes;
+use EMS\Helpers\PropertyAccess\PropertyAccessor;
 use EMS\Helpers\Standard\Json;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;

--- a/EMS/core-bundle/src/Command/Asset/RefreshFileFieldCommand.php
+++ b/EMS/core-bundle/src/Command/Asset/RefreshFileFieldCommand.php
@@ -66,7 +66,7 @@ class RefreshFileFieldCommand extends AbstractCommand
         $propertyAccessor = PropertyAccessor::createPropertyAccessor();
         $rawData = $revision->getRawData();
         $fieldsFound = false;
-        foreach ($propertyAccessor->fieldsWithAttributes($revision->getRawData(), [EmsFields::CONTENT_FILE_HASH_FIELD, EmsFields::CONTENT_FILE_HASH_FIELD_]) as $propertyPath => $fileField) {
+        foreach ($propertyAccessor->fieldsWithAttributes($revision->getRawData(), [EmsFields::CONTENT_FILE_HASH_FIELD, EmsFields::CONTENT_FILE_HASH_FIELD_], 1) as $propertyPath => $fileField) {
             $fieldsFound = true;
             $hash = $fileField[EmsFields::CONTENT_FILE_HASH_FIELD] ?? $fileField[EmsFields::CONTENT_FILE_HASH_FIELD_] ?? null;
             $filename = $fileField[EmsFields::CONTENT_FILE_NAME_FIELD] ?? $fileField[EmsFields::CONTENT_FILE_NAME_FIELD_] ?? null;

--- a/EMS/core-bundle/src/Core/Component/MediaLibrary/Folder/MediaLibraryFolders.php
+++ b/EMS/core-bundle/src/Core/Component/MediaLibrary/Folder/MediaLibraryFolders.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace EMS\CoreBundle\Core\Component\MediaLibrary\Folder;
 
-use EMS\CommonBundle\Common\PropertyAccess\PropertyAccessor;
-use EMS\CommonBundle\Common\PropertyAccess\PropertyPath;
 use EMS\CommonBundle\Elasticsearch\Document\DocumentInterface;
 use EMS\CoreBundle\Core\Component\MediaLibrary\Config\MediaLibraryConfig;
 use EMS\CoreBundle\Core\Component\MediaLibrary\MediaLibraryPath;
+use EMS\Helpers\PropertyAccess\PropertyAccessor;
+use EMS\Helpers\PropertyAccess\PropertyPath;
 
 class MediaLibraryFolders
 {

--- a/EMS/core-bundle/src/Service/Internationalization/XliffService.php
+++ b/EMS/core-bundle/src/Service/Internationalization/XliffService.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace EMS\CoreBundle\Service\Internationalization;
 
 use Doctrine\ORM\UnexpectedResultException;
-use EMS\CommonBundle\Common\PropertyAccess\PropertyAccessor;
 use EMS\CommonBundle\Elasticsearch\Document\Document;
 use EMS\CommonBundle\Elasticsearch\Exception\NotSingleResultException;
 use EMS\CommonBundle\Search\Search;
@@ -16,6 +15,7 @@ use EMS\CoreBundle\Entity\Revision;
 use EMS\CoreBundle\Exception\XliffException;
 use EMS\CoreBundle\Service\Revision\RevisionService;
 use EMS\Helpers\Html\HtmlHelper;
+use EMS\Helpers\PropertyAccess\PropertyAccessor;
 use EMS\Xliff\Xliff\Entity\InsertReport;
 use EMS\Xliff\Xliff\Extractor;
 use EMS\Xliff\Xliff\InsertionRevision;

--- a/EMS/helpers/src/PropertyAccess/InvalidPropertyPathException.php
+++ b/EMS/helpers/src/PropertyAccess/InvalidPropertyPathException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace EMS\CommonBundle\Common\PropertyAccess;
+namespace EMS\Helpers\PropertyAccess;
 
 use Symfony\Component\PropertyAccess\Exception\RuntimeException;
 

--- a/EMS/helpers/src/PropertyAccess/PropertyAccessor.php
+++ b/EMS/helpers/src/PropertyAccess/PropertyAccessor.php
@@ -124,13 +124,13 @@ class PropertyAccessor
     public function fieldsWithAttributes(array $rawData, array $attributeNames, ?int $atLeast = null): iterable
     {
         if (null === $atLeast) {
-            $atLeast = \count($rawData);
+            $atLeast = \count($attributeNames);
         }
-        if (0 === \count($rawData)) {
+        if (0 === \count($attributeNames)) {
             throw new \RuntimeException('At least one attribute\'s name is required');
         } elseif ($atLeast < 1) {
             throw new \RuntimeException('The atLeast parameter must bigger than 0');
-        } elseif ($atLeast > \count($rawData)) {
+        } elseif ($atLeast > \count($attributeNames)) {
             throw new \RuntimeException('The atLeast can\'t be bigger than the number of looking attributes');
         }
         yield from $this->returnFieldsWithAttributes($rawData, $attributeNames, $atLeast);

--- a/EMS/helpers/src/PropertyAccess/PropertyAccessor.php
+++ b/EMS/helpers/src/PropertyAccess/PropertyAccessor.php
@@ -121,8 +121,18 @@ class PropertyAccessor
      * @param  string[]                            $attributeNames
      * @return iterable<array<string, int|string>>
      */
-    public function fieldsWithAttributes(array $rawData, array $attributeNames, int $atLeast = 1): iterable
+    public function fieldsWithAttributes(array $rawData, array $attributeNames, ?int $atLeast = null): iterable
     {
+        if (null === $atLeast) {
+            $atLeast = \count($rawData);
+        }
+        if (0 === \count($rawData)) {
+            throw new \RuntimeException('At least one attribute\'s name is required');
+        } elseif ($atLeast < 1) {
+            throw new \RuntimeException('The atLeast parameter must bigger than 0');
+        } elseif ($atLeast > \count($rawData)) {
+            throw new \RuntimeException('The atLeast can\'t be bigger than the number of looking attributes');
+        }
         yield from $this->returnFieldsWithAttributes($rawData, $attributeNames, $atLeast);
     }
 

--- a/EMS/helpers/src/PropertyAccess/PropertyAccessor.php
+++ b/EMS/helpers/src/PropertyAccess/PropertyAccessor.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace EMS\CommonBundle\Common\PropertyAccess;
+namespace EMS\Helpers\PropertyAccess;
 
 use EMS\Helpers\Standard\Base64;
 use EMS\Helpers\Standard\Json;

--- a/EMS/helpers/src/PropertyAccess/PropertyPath.php
+++ b/EMS/helpers/src/PropertyAccess/PropertyPath.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace EMS\CommonBundle\Common\PropertyAccess;
+namespace EMS\Helpers\PropertyAccess;
 
 /**
  * @implements \Iterator<PropertyPathElement>

--- a/EMS/helpers/src/PropertyAccess/PropertyPathElement.php
+++ b/EMS/helpers/src/PropertyAccess/PropertyPathElement.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace EMS\CommonBundle\Common\PropertyAccess;
+namespace EMS\Helpers\PropertyAccess;
 
 class PropertyPathElement
 {

--- a/EMS/helpers/tests/Unit/PropertyAccess/PropertyAccessorAiTest.php
+++ b/EMS/helpers/tests/Unit/PropertyAccess/PropertyAccessorAiTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EMS\CommonBundle\Tests\Unit\Common\PropertyAccess;
+namespace EMS\Helpers\Tests\Unit\PropertyAccess;
 
-use EMS\CommonBundle\Common\PropertyAccess\PropertyAccessor;
+use EMS\Helpers\PropertyAccess\PropertyAccessor;
 use PHPUnit\Framework\TestCase;
 
 class PropertyAccessorAiTest extends TestCase

--- a/EMS/helpers/tests/Unit/PropertyAccess/PropertyAcessTest.php
+++ b/EMS/helpers/tests/Unit/PropertyAccess/PropertyAcessTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace EMS\CommonBundle\Tests\Unit\Common\PropertyAccess;
+namespace EMS\Helpers\Tests\Unit\PropertyAccess;
 
-use EMS\CommonBundle\Common\PropertyAccess\PropertyAccessor;
 use EMS\CommonBundle\Elasticsearch\Document\Document;
+use EMS\Helpers\PropertyAccess\PropertyAccessor;
 use EMS\Helpers\Standard\Json;
 use PHPUnit\Framework\TestCase;
 

--- a/EMS/helpers/tests/Unit/PropertyAccess/PropertyAcessTest.php
+++ b/EMS/helpers/tests/Unit/PropertyAccess/PropertyAcessTest.php
@@ -7,6 +7,7 @@ namespace EMS\Helpers\Tests\Unit\PropertyAccess;
 use EMS\CommonBundle\Elasticsearch\Document\Document;
 use EMS\Helpers\PropertyAccess\PropertyAccessor;
 use EMS\Helpers\Standard\Json;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class PropertyAcessTest extends TestCase
@@ -222,5 +223,104 @@ class PropertyAcessTest extends TestCase
         $accessor->setValue($array, '[json:id_key:codes][91d68620-558d-4cdd-8ced-79b622244fa6][object][remarks_nl]', 'Remarks NL');
 
         $this->assertEquals('[{"id":"742a85b3-46f7-4e46-b2e8-444fc29a8ea1","label":"TEST MDK \/ TEST MDK (19\/05\/2023 - )","type":"code","object":{"validity_start":"2023-05-19T11:00:55+0200","title_nl":"TEST MDK","title_fr":"TEST MDK","meaning_nl":"TEST MDK","meaning_fr":"TEST MDK","remarks_nl":"TEST MDK","remarks_fr":"TEST MDK","label":"TEST MDK \/ TEST MDK (19\/05\/2023 - )"},"children":[]},{"id":"91d68620-558d-4cdd-8ced-79b622244fa6","label":"","type":"code","object":{"validity_start":"2023-05-17T12:23:42+0200","validity_end":"2023-05-17T12:23:42+0200","title_fr":"Title FR","meaning_fr":"Meaning FR","remarks_fr":"Remarks FR","label":"","title_nl":"Title NL","meaning_nl":"Meaning NL","remarks_nl":"Remarks NL"},"children":[]}]', $array['codes']);
+    }
+
+    /**
+     * @return array<array<mixed[], string[], int, int>>
+     */
+    public static function fieldsWithAttributesProvider(): array
+    {
+        return [[
+            [
+                'attr1' => [
+                    'A' => 'not',
+                    'B' => 'not',
+                    'C' => 'found',
+                ],
+                'attr2' => [
+                    'C' => 'found',
+                    'D' => 'not',
+                    'E' => 'not',
+                ],
+            ], ['C'], 1, 2,
+        ], [
+            [
+                'attr1' => [
+                    'A' => 'not',
+                    'B' => 'not',
+                    'C' => 'found',
+                ],
+                'attr2' => [
+                    'C' => 'found',
+                    'D' => 'found',
+                    'E' => 'not',
+                ],
+            ], ['C', 'D'], 1, 2,
+        ], [
+            [
+                'attr1' => [
+                    'A' => 'not',
+                    'B' => 'not',
+                    'C' => 'not',
+                ],
+                'attr2' => [
+                    'C' => 'found',
+                    'D' => 'found',
+                    'E' => 'not',
+                ],
+            ], ['C', 'D'], null, 1,
+        ], [
+            [
+                'attr1' => [
+                    'A' => 'not',
+                    'B' => 'not',
+                    'C' => 'not',
+                ],
+                'attr2' => [
+                    'C' => 'not',
+                    'D' => 'not',
+                    'E' => 'not',
+                ],
+            ], ['B', 'C', 'D'], 3, 0,
+        ], [
+            [
+                'attr1' => [
+                    'A' => 'not',
+                    'B' => 'found',
+                    'C' => 'found',
+                ],
+                'attr2' => [
+                    'C' => 'found',
+                    'D' => 'found',
+                    'E' => 'not',
+                ],
+            ], ['B', 'C', 'D'], 2, 2,
+        ]];
+    }
+
+    /**
+     * @param mixed[]  $data
+     * @param string[] $attributeNames
+     */
+    #[DataProvider('fieldsWithAttributesProvider')]
+    public function testGetFieldsWithAttributes(array $data, array $attributeNames, ?int $atLeast, int $expectedFields): void
+    {
+        $accessor = PropertyAccessor::createPropertyAccessor();
+        $counter = 0;
+        foreach ($accessor->fieldsWithAttributes($data, $attributeNames, $atLeast) as $path => $field) {
+            ++$counter;
+            $matchCounter = 0;
+            foreach ($accessor->getValue($data, $path) as $attribute => $foundValue) {
+                $found = \in_array($attribute, $attributeNames, true);
+                if (!$found) {
+                    $this->assertSame('not', $foundValue);
+                    continue;
+                }
+                ++$matchCounter;
+                $this->assertSame('found', $foundValue);
+            }
+            $this->assertGreaterThanOrEqual($atLeast, $matchCounter);
+        }
+        $this->assertSame($expectedFields, $counter);
     }
 }

--- a/EMS/helpers/tests/Unit/PropertyAccess/PropertyPathAiTest.php
+++ b/EMS/helpers/tests/Unit/PropertyAccess/PropertyPathAiTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace EMS\CommonBundle\Tests\Unit\Common\PropertyAccess;
+namespace EMS\Helpers\Tests\Unit\PropertyAccess;
 
-use EMS\CommonBundle\Common\PropertyAccess\InvalidPropertyPathException;
-use EMS\CommonBundle\Common\PropertyAccess\PropertyPath;
+use EMS\Helpers\PropertyAccess\InvalidPropertyPathException;
+use EMS\Helpers\PropertyAccess\PropertyPath;
 use PHPUnit\Framework\TestCase;
 
 class PropertyPathAiTest extends TestCase

--- a/EMS/helpers/tests/Unit/PropertyAccess/PropertyPathElementAiTest.php
+++ b/EMS/helpers/tests/Unit/PropertyAccess/PropertyPathElementAiTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EMS\CommonBundle\Tests\Unit\Common\PropertyAccess;
+namespace EMS\Helpers\Tests\Unit\PropertyAccess;
 
-use EMS\CommonBundle\Common\PropertyAccess\PropertyPathElement;
+use EMS\Helpers\PropertyAccess\PropertyPathElement;
 use PHPUnit\Framework\TestCase;
 
 class PropertyPathElementAiTest extends TestCase

--- a/EMS/helpers/tests/Unit/PropertyAccess/PropertyPathTest.php
+++ b/EMS/helpers/tests/Unit/PropertyAccess/PropertyPathTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace EMS\CommonBundle\Tests\Unit\Common\PropertyAccess;
+namespace EMS\Helpers\Tests\Unit\PropertyAccess;
 
-use EMS\CommonBundle\Common\PropertyAccess\InvalidPropertyPathException;
-use EMS\CommonBundle\Common\PropertyAccess\PropertyPath;
+use EMS\Helpers\PropertyAccess\InvalidPropertyPathException;
+use EMS\Helpers\PropertyAccess\PropertyPath;
 use PHPUnit\Framework\TestCase;
 
 class PropertyPathTest extends TestCase

--- a/EMS/xliff/src/Xliff/InsertionRevision.php
+++ b/EMS/xliff/src/Xliff/InsertionRevision.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace EMS\Xliff\Xliff;
 
-use EMS\CommonBundle\Common\PropertyAccess\PropertyAccessor;
 use EMS\Helpers\Html\HtmlHelper;
+use EMS\Helpers\PropertyAccess\PropertyAccessor;
 use EMS\Helpers\Standard\Accessor;
 use EMS\Xliff\Xliff\Entity\InsertReport;
 use EMS\Xliff\XML\DomHelper;


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? |  n |
| Documentation? | n  |

The Xliff was depending on the Common Bundle via the PropertyAccessor. So moved the PropertyAccessor to the Helper instead.