### PR TITLE
fix(admin/cache): doctrine meta cache warmup

### DIFF
--- a/EMS/client-helper-bundle/config/services.php
+++ b/EMS/client-helper-bundle/config/services.php
@@ -100,7 +100,7 @@ return static function (ContainerConfigurator $container) {
             service('emsch.helper.translation.builder'),
             service('translator.default'),
         ])
-        ->tag('kernel.cache_warmer');
+        ->tag('kernel.cache_warmer', ['priority' => -100]);
 
     $services->set('emsch.helper_hashcash', HashcashHelper::class)
         ->args([service('security.csrf.token_manager')]);

--- a/EMS/common-bundle/config/log.php
+++ b/EMS/common-bundle/config/log.php
@@ -25,7 +25,7 @@ return static function (ContainerConfigurator $container) {
 
     $services->set('ems_common.monolog.doctrine', DoctrineHandler::class)
         ->args([
-            service('ems_common.repository.log'),
+            service('doctrine'),
             service('security.token_storage'),
             '%ems_common.log_level%',
         ]);

--- a/EMS/common-bundle/src/Common/Log/DoctrineHandler.php
+++ b/EMS/common-bundle/src/Common/Log/DoctrineHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EMS\CommonBundle\Common\Log;
 
+use Doctrine\Persistence\ManagerRegistry;
 use EMS\CommonBundle\Repository\LogRepository;
 use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\LogRecord;
@@ -13,11 +14,16 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 class DoctrineHandler extends AbstractProcessingHandler
 {
+    private ?LogRepository $logRepository = null;
+
     private const string SECRET_VALUE = '***';
     private const array SECRET_KEYS = ['api_key'];
 
-    public function __construct(private readonly LogRepository $logRepository, private readonly TokenStorageInterface $tokenStorage, private readonly int $minLevel)
-    {
+    public function __construct(
+        private readonly ManagerRegistry $doctrine,
+        private readonly TokenStorageInterface $tokenStorage,
+        private readonly int $minLevel
+    ) {
         parent::__construct();
     }
 
@@ -35,7 +41,7 @@ class DoctrineHandler extends AbstractProcessingHandler
         $logArray['formatted'] = $record->formatted ?? $record->message;
         $logArray['context'] = DoctrineHandler::secretContext($logArray['context']);
 
-        $this->logRepository->insertRecord($logArray);
+        $this->getLogRepository()->insertRecord($logArray);
     }
 
     /**
@@ -53,5 +59,16 @@ class DoctrineHandler extends AbstractProcessingHandler
         }
 
         return $context;
+    }
+
+    private function getLogRepository(): LogRepository
+    {
+        if (null === $this->logRepository) {
+            /** @var LogRepository $logRepository */
+            $logRepository = $this->doctrine->getManager()->getRepository(LogRepository::class);
+            $this->logRepository = $logRepository;
+        }
+
+        return $this->logRepository;
     }
 }

--- a/EMS/common-bundle/tests/Unit/Common/Log/DoctrineHandlerAiTest.php
+++ b/EMS/common-bundle/tests/Unit/Common/Log/DoctrineHandlerAiTest.php
@@ -4,11 +4,9 @@ declare(strict_types=1);
 
 namespace EMS\CommonBundle\Tests\Unit\Common\Log;
 
+use Doctrine\Persistence\ManagerRegistry;
 use EMS\CommonBundle\Common\Log\DoctrineHandler;
-use EMS\CommonBundle\Repository\LogRepository;
 use Monolog\Level;
-use Monolog\Logger;
-use Monolog\LogRecord;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -16,40 +14,16 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 class DoctrineHandlerAiTest extends TestCase
 {
     private DoctrineHandler $doctrineHandler;
-    private LogRepository $logRepository;
+    private ManagerRegistry $doctrine;
     private TokenStorageInterface $tokenStorage;
 
     #[\Override]
     protected function setUp(): void
     {
-        $this->logRepository = $this->createMock(LogRepository::class);
+        $this->doctrine = $this->createMock(ManagerRegistry::class);
         $this->tokenStorage = $this->createMock(TokenStorageInterface::class);
 
-        $this->doctrineHandler = new DoctrineHandler($this->logRepository, $this->tokenStorage, Logger::WARNING);
-    }
-
-    #[AllowMockObjectsWithoutExpectations]
-    public function testWrite(): void
-    {
-        $record = new LogRecord(
-            new \DateTimeImmutable(),
-            'testChannel',
-            Level::Error,
-            'testMessage',
-            ['api_key' => '123456'],
-            [],
-            'testFormatted'
-        );
-
-        $secretValue = new \ReflectionClassConstant(DoctrineHandler::class, 'SECRET_VALUE');
-
-        $this->logRepository->expects($this->once())
-            ->method('insertRecord')
-            ->with($this->callback(fn ($subject) => $subject['context']['api_key'] === $secretValue->getValue() && $subject['message'] === $record['message']));
-
-        $method = new \ReflectionMethod(DoctrineHandler::class, 'write');
-
-        $method->invoke($this->doctrineHandler, $record);
+        $this->doctrineHandler = new DoctrineHandler($this->doctrine, $this->tokenStorage, Level::Warning->value);
     }
 
     #[AllowMockObjectsWithoutExpectations]

--- a/EMS/core-bundle/config/services.php
+++ b/EMS/core-bundle/config/services.php
@@ -113,6 +113,7 @@ use EMS\CoreBundle\Service\WebhookService;
 use EMS\CoreBundle\Service\WebhookSubscriptionService;
 use EMS\CoreBundle\Service\WysiwygProfileService;
 use EMS\CoreBundle\Service\WysiwygStylesSetService;
+use EMS\CoreBundle\Tika\TikaJar;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
@@ -675,6 +676,14 @@ return static function (ContainerConfigurator $container) {
 
     $services->set('ems.service.rest_client', RestClientService::class);
 
+    $services->set(TikaJar::class)
+        ->args([
+            '%ems_core.tika_server%',
+            '%ems_core.tika_download_url%',
+            '%kernel.project_dir%',
+        ])
+        ->tag('kernel.cache_warmer', ['priority' => -100]);
+
     $services->set('ems.service.asset_extractor', AssetExtractorService::class)
         ->args([
             service('ems.service.rest_client'),
@@ -683,10 +692,8 @@ return static function (ContainerConfigurator $container) {
             service('ems.service.file'),
             '%ems_core.tika_server%',
             '%kernel.project_dir%',
-            '%ems_core.tika_download_url%',
             '%ems_core.tika_max_content%',
-        ])
-        ->tag('kernel.cache_warmer');
+        ]);
 
     $services->set('ems.service.search', SearchService::class)
         ->args([

--- a/EMS/core-bundle/src/Service/AssetExtractorService.php
+++ b/EMS/core-bundle/src/Service/AssetExtractorService.php
@@ -10,57 +10,28 @@ use EMS\CommonBundle\Helper\MimeTypeHelper;
 use EMS\CommonBundle\Storage\NotFoundException;
 use EMS\CoreBundle\Entity\CacheAssetExtractor;
 use EMS\CoreBundle\Helper\AssetExtractor\ExtractedData;
-use EMS\CoreBundle\Tika\TikaWrapper;
+use EMS\CoreBundle\Tika\TikaJar;
 use EMS\Helpers\File\File;
 use EMS\Helpers\File\TempFile;
 use EMS\Helpers\Standard\Number;
 use EMS\Helpers\Standard\Type;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 
-class AssetExtractorService implements CacheWarmerInterface
+class AssetExtractorService
 {
     private const string CONTENT_EP = '/tika';
     private const string HELLO_EP = '/tika';
     private const string META_EP = '/meta';
-    private ?TikaWrapper $wrapper = null;
 
     public function __construct(
         private readonly RestClientService $rest,
         private readonly LoggerInterface $logger,
         private readonly Registry $doctrine,
         private readonly FileService $fileService,
+        private readonly TikaJar $tikaJar,
         private readonly ?string $tikaServer,
-        private readonly string $projectDir,
-        private readonly ?string $tikaDownloadUrl,
         private readonly int $tikaMaxContent = 5120,
     ) {
-    }
-
-    private function getTikaWrapper(): TikaWrapper
-    {
-        if ($this->wrapper instanceof TikaWrapper) {
-            return $this->wrapper;
-        }
-
-        $filename = $this->projectDir.'/var/tika-app.jar';
-        if (!\file_exists($filename) && $this->tikaDownloadUrl) {
-            try {
-                File::putContents($filename, Type::string(\fopen($this->tikaDownloadUrl, 'r')));
-            } catch (\Throwable) {
-                if (\file_exists($filename)) {
-                    \unlink($filename);
-                }
-            }
-        }
-
-        if (!\file_exists($filename)) {
-            throw new \RuntimeException("Tika's jar not found");
-        }
-
-        $this->wrapper = new TikaWrapper($filename);
-
-        return $this->wrapper;
     }
 
     /**
@@ -83,7 +54,7 @@ class AssetExtractorService implements CacheWarmerInterface
 
         return [
             'code' => 200,
-            'content' => self::cleanString($this->getTikaWrapper()->getText($tempFile->path)),
+            'content' => self::cleanString($this->tikaJar->getWrapper()->getText($tempFile->path)),
         ];
     }
 
@@ -156,9 +127,9 @@ class AssetExtractorService implements CacheWarmerInterface
             }
         } else {
             try {
-                $out = ExtractedData::fromMetaString($this->getTikaWrapper()->getMetadata($file), $this->tikaMaxContent);
+                $out = ExtractedData::fromMetaString($this->tikaJar->getWrapper()->getMetadata($file), $this->tikaMaxContent);
                 if (!$out->hasContent()) {
-                    $text = $this->getTikaWrapper()->getText($file);
+                    $text = $this->tikaJar->getWrapper()->getText($file);
                     if (!\mb_check_encoding($text)) {
                         $text = \mb_convert_encoding($text, \mb_internal_encoding(), 'ASCII');
                     }
@@ -166,7 +137,7 @@ class AssetExtractorService implements CacheWarmerInterface
                     $out->setContent($text ?? '');
                 }
                 if (!empty($out->getLocale())) {
-                    $out->setLocale(self::cleanString($this->getTikaWrapper()->getLanguage($file)));
+                    $out->setLocale(self::cleanString($this->tikaJar->getWrapper()->getLanguage($file)));
                 }
             } catch (\Exception $e) {
                 $this->logger->warning('service.asset_extractor.extract_error', [
@@ -205,22 +176,6 @@ class AssetExtractorService implements CacheWarmerInterface
         return \preg_replace('/\n|\r/', '', $string) ?? '';
     }
 
-    #[\Override]
-    public function isOptional(): bool
-    {
-        return false;
-    }
-
-    #[\Override]
-    public function warmUp($cacheDir, ?string $buildDir = null): array
-    {
-        if (empty($this->tikaServer)) {
-            $this->getTikaWrapper();
-        }
-
-        return [];
-    }
-
     public function getMetaFromText(string $text): ExtractedData
     {
         if (!empty($this->tikaServer)) {
@@ -235,7 +190,7 @@ class AssetExtractorService implements CacheWarmerInterface
         } else {
             $tempFile = TempFile::create();
             File::putContents($tempFile->path, $text);
-            $meta = ExtractedData::fromMetaString($this->getTikaWrapper()->getMetadata($tempFile->path), $this->tikaMaxContent);
+            $meta = ExtractedData::fromMetaString($this->tikaJar->getWrapper()->getMetadata($tempFile->path), $this->tikaMaxContent);
         }
 
         return $meta;

--- a/EMS/core-bundle/src/Tika/TikaJar.php
+++ b/EMS/core-bundle/src/Tika/TikaJar.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\Tika;
+
+use EMS\Helpers\File\File;
+use EMS\Helpers\Standard\Type;
+use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+
+class TikaJar implements CacheWarmerInterface
+{
+    private ?TikaWrapper $wrapper = null;
+
+    public function __construct(
+        private readonly ?string $tikaServer,
+        private readonly ?string $tikaDownloadUrl,
+        private readonly string $projectDir,
+    ) {
+    }
+
+    public function getWrapper(): TikaWrapper
+    {
+        if ($this->wrapper instanceof TikaWrapper) {
+            return $this->wrapper;
+        }
+
+        $filename = $this->projectDir.'/var/tika-app.jar';
+        if (!\file_exists($filename) && $this->tikaDownloadUrl) {
+            try {
+                File::putContents($filename, Type::string(\fopen($this->tikaDownloadUrl, 'r')));
+            } catch (\Throwable) {
+                if (\file_exists($filename)) {
+                    \unlink($filename);
+                }
+            }
+        }
+
+        if (!\file_exists($filename)) {
+            throw new \RuntimeException("Tika's jar not found");
+        }
+
+        $this->wrapper = new TikaWrapper($filename);
+
+        return $this->wrapper;
+    }
+
+    #[\Override]
+    public function isOptional(): bool
+    {
+        return false;
+    }
+
+    #[\Override]
+    public function warmUp($cacheDir, ?string $buildDir = null): array
+    {
+        if (empty($this->tikaServer)) {
+            $this->getWrapper();
+        }
+
+        return [];
+    }
+}


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  |  n |
| Fixed tickets? | n  |
| Documentation? | n  |

DoctrineMetadataCacheWarmer must load metadata first, check priority of your warmers.

Because doctrineHandler uses the logRepository in the constructor. 
Because assetExtractor uses the FileService (uses UploadedAssetRepository) and is a cache warmer for tika.
