### PR TITLE
fix(admin/cache): doctrine meta cache warmup with lazy repositories

### DIFF
--- a/EMS/common-bundle/config/log.php
+++ b/EMS/common-bundle/config/log.php
@@ -17,6 +17,7 @@ return static function (ContainerConfigurator $container) {
         ->autoconfigure(false);
 
     $services->set('ems_common.repository.log', LogRepository::class)
+        ->lazy()
         ->public()
         ->args([service('doctrine')]);
 

--- a/EMS/core-bundle/config/repositories.php
+++ b/EMS/core-bundle/config/repositories.php
@@ -175,6 +175,7 @@ return static function (ContainerConfigurator $container) {
         ->args([service('doctrine')]);
 
     $services->set('ems.repository.uploaded_asset_repository', UploadedAssetRepository::class)
+        ->lazy()
         ->args([UploadedAsset::class])
         ->factory([service('doctrine.orm.default_entity_manager'), 'getRepository']);
 

--- a/docker/.env.dist
+++ b/docker/.env.dist
@@ -11,7 +11,6 @@ ELK_VERSION=elk8
 EMS_VERSION=7.0.0
 
 POSTGRES_VERSION=17
-#POSTGRES_VOLUME=postgres
 
 ###> Cluster's variables ###
 # Set the cluster name


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

When running cache:clear --no-debug in admin: DoctrineMetadataCacheWarmer must load metadata first, check priority of your warmers.

The following two repositories need to be lazy, because they are injected in a cache warmer. And their for loaded before doctrine is warmed up.

- EMS\CommonBundle\Repository\LogRepository: use in doctrine monolog handler
- EMS\CoreBundle\Repository\UploadedAssetRepository: used in the fileService which is used by the assetExtractorService which is warming up tika.
