### PR TITLE
fix(docker): add OTEL_ENABLED variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 #!/usr/bin/make -f
 
+include ./docker/.env
+
 PWD					= $(shell pwd)
 DOCKER_USER			?= $(shell id -u)
 DOCKER_COMPOSE		= docker compose --project-directory=docker
@@ -15,6 +17,7 @@ RUN_POSTGRES		= docker compose --project-directory=docker exec -i -u ${DOCKER_US
 NPM_CMD          	= "${NPM_EXTRA_CMD} npm $*"
 RUN_DEMO_NPM		= docker run -u ${DOCKER_USER}:0 --rm -it -v ${PWD}/demo:/opt/src --workdir /opt/src elasticms/base-php:8.4-cli-dev sh -c ${NPM_CMD}
 RUN_ADMIN_UI_NPM 	= docker run -u ${DOCKER_USER}:0 --rm -p 5173:5173 -it -v ${PWD}/EMS/admin-ui-bundle:/opt/src --workdir /opt/src/assets elasticms/base-php:8.4-cli-dev sh -c ${NPM_CMD}
+OTEL_ENABLED 		?= false
 
 .DEFAULT_GOAL := help
 .PHONY: help demo docs
@@ -23,6 +26,7 @@ help: # Show help for each of the Makefile recipes.
 	@echo "EMS Monorepo"
 	@echo "---------------------------"
 	@echo "DOCKER_USER:   ${DOCKER_USER}"
+	@echo "OTEL enabled:  ${OTEL_ENABLED}"
 	@echo "NPM_EXTRA_CMD: ${NPM_EXTRA_CMD}"
 	@echo "ADMIN:         http://localhost:8881"
 	@echo "WEB:           http://localhost:8882"
@@ -70,17 +74,22 @@ status: ## status
 
 ## —— Symfony server ———————————————————————————————————————————————————————————————————————————————————————————————————
 server-start/%: ## server-start/(admin|web|cli)
-	OTEL_PHP_AUTOLOAD_ENABLED=true \
-	OTEL_SERVICE_NAME=demo-ems-$(*) \
-	OTEL_TRACES_EXPORTER=otlp \
-	OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
-	OTEL_EXPORTER_OTLP_ENDPOINT=http://apm-server.localhost \
-	OTEL_RESOURCE_ATTRIBUTES=deployment.environment=dev \
-	OTEL_TRACES_SAMPLER=always_on \
-	OTEL_LOG_LEVEL=debug \
-	OTEL_PHP_LOG_DESTINATION=stderr \
-	OTEL_PHP_AUTOLOAD_PATH=$(MAKEFILE_DIR)/vendor/autoload.php \
-	symfony server:start --dir=elasticms-${*} -d --port=$(PORT_$(*)) --no-tls --allow-all-ip
+	@if [ "$(OTEL_ENABLED)" = "true" ]; then \
+		env \
+		OTEL_PHP_AUTOLOAD_ENABLED=true \
+		OTEL_SERVICE_NAME=demo-ems-$(*) \
+		OTEL_TRACES_EXPORTER=otlp \
+		OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
+		OTEL_EXPORTER_OTLP_ENDPOINT=http://apm-server.localhost \
+		OTEL_RESOURCE_ATTRIBUTES=deployment.environment=dev \
+		OTEL_TRACES_SAMPLER=always_on \
+		OTEL_LOG_LEVEL=debug \
+		OTEL_PHP_LOG_DESTINATION=stderr \
+		OTEL_PHP_AUTOLOAD_PATH=$(MAKEFILE_DIR)/vendor/autoload.php \
+		symfony server:start --dir=elasticms-$* -d --port=$(PORT_$(*)) --no-tls --allow-all-ip; \
+	else \
+		symfony server:start --dir=elasticms-$* -d --port=$(PORT_$(*)) --no-tls --allow-all-ip; \
+	fi
 server-stop/%: ## server-stop/(admin|web|cli)
 	symfony server:stop --dir=elasticms-${*}
 server-log/%: ## server-log/(admin|web|cli)

--- a/docker/.env.dist
+++ b/docker/.env.dist
@@ -1,6 +1,8 @@
 # Project namespace (defaults to the current folder name if not set)
 COMPOSE_PROJECT_NAME=ems-mono
 
+OTEL_ENABLED=false
+
 # Search stack's version
 # Possible values:
 # * elk8: Elasticsearch 8: default value

--- a/docs/src/getting-started/dev-env.md
+++ b/docs/src/getting-started/dev-env.md
@@ -313,3 +313,6 @@ Verify the installation with
 php -m | grep opentelemetry
 ```
 
+> [!NOTE]
+> To enable OpenTelemetry, set the `OTEL_ENABLED` environment variable to true in `docker/.env`. A server restart is
+required for the change to take effect (make server-restart).


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? |  n |
| Documentation? | n  |

By default OTEL is disabled for now. Because it throw a lot deprecations in php 8.5

