### PR TITLE
fix(common/coreApi): runCommand use new core JobApiController

### DIFF
--- a/EMS/common-bundle/src/Common/CoreApi/Endpoint/Admin/Admin.php
+++ b/EMS/common-bundle/src/Common/CoreApi/Endpoint/Admin/Admin.php
@@ -92,14 +92,15 @@ class Admin implements AdminInterface
     #[\Override]
     public function runCommand(string $command, ?OutputInterface $output = null): string
     {
-        $job = [
-            'class' => 'EMS\CoreBundle\Entity\Job',
-            'arguments' => [],
-            'properties' => [
-                'command' => $command,
-            ],
-        ];
-        $jobId = $this->getConfig('job')->create($job);
+        $create = $this->client->post('/api/admin/job/create', [
+            'command' => $command,
+        ])->getData();
+
+        $jobId = $create['jobId'] ?? null;
+        if (null === $jobId) {
+            throw new \RuntimeException('Could not create job');
+        }
+
         $this->startJob($jobId);
         if (null !== $output) {
             $this->writeJobOutput($jobId, $output);

--- a/EMS/common-bundle/src/Common/CoreApi/Endpoint/Admin/Admin.php
+++ b/EMS/common-bundle/src/Common/CoreApi/Endpoint/Admin/Admin.php
@@ -28,7 +28,7 @@ class Admin implements AdminInterface
     public function getJobStatus(string $jobId): array
     {
         /** @var array{id: string, created: string, modified: string, command: string, user: string,started: bool, done: bool, status: string, output: ?string } $status */
-        $status = $this->client->get(\implode('/', ['api', 'admin', 'job-status', $jobId]))->getData();
+        $status = $this->client->get(\implode('/', ['api', 'admin', 'job', $jobId, 'status']))->getData();
 
         return $status;
     }

--- a/EMS/core-bundle/config/controllers.php
+++ b/EMS/core-bundle/config/controllers.php
@@ -21,6 +21,7 @@ use EMS\CoreBundle\Controller\Api\Admin\MetaController;
 use EMS\CoreBundle\Controller\Api\AuthTokenLoginController;
 use EMS\CoreBundle\Controller\Api\File\ExtractDataController;
 use EMS\CoreBundle\Controller\Api\Form\VerificationController;
+use EMS\CoreBundle\Controller\Api\JobApiController;
 use EMS\CoreBundle\Controller\Api\WebhookSubscriptionController;
 use EMS\CoreBundle\Controller\ChannelController;
 use EMS\CoreBundle\Controller\Component\JsonMenuNestedController;
@@ -262,6 +263,10 @@ return static function (ContainerConfigurator $container) {
         ->tag('controller.service_arguments');
 
     $services->set(AuthTokenLoginController::class);
+
+    $services->set(JobApiController::class)
+        ->args([service('ems.service.job')])
+        ->tag('controller.service_arguments');
 
     $services->set(\EMS\CoreBundle\Controller\Api\UserController::class)
         ->args([service('emsco.manager.user')])

--- a/EMS/core-bundle/config/routing/api/admin.php
+++ b/EMS/core-bundle/config/routing/api/admin.php
@@ -14,6 +14,11 @@ return function (RoutingConfigurator $routes) {
         ->controller([JobApiController::class, 'create'])
         ->defaults(['_format' => 'json'])
         ->methods(['POST']);
+    $routes->add('emsco_api_job_status', '/job/{job}/status')
+        ->controller([JobApiController::class, 'status'])
+        ->defaults(['_format' => 'json'])
+        ->methods(['GET'])
+        ->options(['openapi' => true]);
 
     $routes->add('emsco_api_start_job', '/start-job/{job}')
         ->controller([JobController::class, 'startJob'])
@@ -47,12 +52,6 @@ return function (RoutingConfigurator $routes) {
 
     $routes->add('emsco_api_get_versions', '/versions')
         ->controller([InfoController::class, 'versions'])
-        ->methods(['GET'])
-        ->options(['openapi' => true]);
-
-    $routes->add('emsco_api_job_status', '/job-status/{job}')
-        ->controller([EntitiesController::class, 'jobStatus'])
-        ->defaults(['_format' => 'json'])
         ->methods(['GET'])
         ->options(['openapi' => true]);
 

--- a/EMS/core-bundle/config/routing/api/admin.php
+++ b/EMS/core-bundle/config/routing/api/admin.php
@@ -5,10 +5,16 @@ declare(strict_types=1);
 use EMS\CoreBundle\Controller\Api\Admin\EntitiesController;
 use EMS\CoreBundle\Controller\Api\Admin\InfoController;
 use EMS\CoreBundle\Controller\Api\Admin\MetaController;
+use EMS\CoreBundle\Controller\Api\JobApiController;
 use EMS\CoreBundle\Controller\ContentManagement\JobController;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 
 return function (RoutingConfigurator $routes) {
+    $routes->add('emsco_api_job_create', '/job/create')
+        ->controller([JobApiController::class, 'create'])
+        ->defaults(['_format' => 'json'])
+        ->methods(['POST']);
+
     $routes->add('emsco_api_start_job', '/start-job/{job}')
         ->controller([JobController::class, 'startJob'])
         ->methods(['POST'])

--- a/EMS/core-bundle/src/Controller/Api/Admin/EntitiesController.php
+++ b/EMS/core-bundle/src/Controller/Api/Admin/EntitiesController.php
@@ -6,7 +6,6 @@ namespace EMS\CoreBundle\Controller\Api\Admin;
 
 use EMS\CoreBundle\Core\Entity\EntitiesHelper;
 use EMS\CoreBundle\Entity\EntityInterface;
-use EMS\CoreBundle\Entity\Job;
 use EMS\CoreBundle\Exception\EntityServiceNotFoundException;
 use EMS\CoreBundle\Service\EntityServiceInterface;
 use Psr\Log\LoggerInterface;
@@ -115,21 +114,6 @@ class EntitiesController
 
         return new JsonResponse([
             'id' => (string) $entityObject->getId(),
-        ]);
-    }
-
-    public function jobStatus(Job $job): Response
-    {
-        return new JsonResponse([
-            'id' => (string) $job->getId(),
-            'created' => $job->getCreated()->format('c'),
-            'modified' => $job->getModified()->format('c'),
-            'command' => $job->getCommand(),
-            'user' => $job->getUser(),
-            'done' => $job->getDone(),
-            'output' => $job->getOutput(),
-            'started' => $job->getStarted(),
-            'status' => $job->getStatus(),
         ]);
     }
 

--- a/EMS/core-bundle/src/Controller/Api/JobApiController.php
+++ b/EMS/core-bundle/src/Controller/Api/JobApiController.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\Controller\Api;
+
+use EMS\CoreBundle\Service\JobService;
+use EMS\Helpers\Standard\Json;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class JobApiController
+{
+    public function __construct(
+        private readonly JobService $jobService
+    ) {
+    }
+
+    public function create(Request $request, UserInterface $user): JsonResponse
+    {
+        $content = Json::decode($request->getContent());
+        $command = $content['command'] ?? null;
+
+        if (null === $command) {
+            throw new BadRequestHttpException('Command not found');
+        }
+
+        $job = $this->jobService->createCommand($user, $command);
+
+        return new JsonResponse([
+            'success' => true,
+            'jobId' => (string) $job->getId(),
+        ]);
+    }
+}

--- a/EMS/core-bundle/src/Controller/Api/JobApiController.php
+++ b/EMS/core-bundle/src/Controller/Api/JobApiController.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace EMS\CoreBundle\Controller\Api;
 
+use EMS\CoreBundle\Entity\Job;
 use EMS\CoreBundle\Service\JobService;
 use EMS\Helpers\Standard\Json;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Security\Core\User\UserInterface;
 
@@ -32,6 +34,21 @@ class JobApiController
         return new JsonResponse([
             'success' => true,
             'jobId' => (string) $job->getId(),
+        ]);
+    }
+
+    public function status(Job $job): Response
+    {
+        return new JsonResponse([
+            'id' => (string) $job->getId(),
+            'created' => $job->getCreated()->format('c'),
+            'modified' => $job->getModified()->format('c'),
+            'command' => $job->getCommand(),
+            'user' => $job->getUser(),
+            'done' => $job->getDone(),
+            'output' => $job->getOutput(),
+            'started' => $job->getStarted(),
+            'status' => $job->getStatus(),
         ]);
     }
 }


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Currently  for executing command over the common coreApi, we use the admin entity controller by sending 'EMS\CoreBundle\Entity\Job'. This creates a reference to the coreBundle in the commonBundle. Better is to create a dedicated endpoint for running a job. Also moved the status of jobs from entitiesController to this new controller.
