### PR TITLE
fix(common/es): include ems internal fields in _source

### DIFF
--- a/EMS/common-bundle/src/Search/Search.php
+++ b/EMS/common-bundle/src/Search/Search.php
@@ -71,17 +71,14 @@ class Search
      */
     public function getSources(): array
     {
-        if (\count($this->sourceIncludes) > 0 && !\in_array('_*', $this->sourceIncludes)) {
-            $this->sourceIncludes[] = '_*';
-        }
         if (\count($this->sourceExcludes) > 0) {
             return \array_filter([
-                'includes' => $this->sourceIncludes,
+                'includes' => \array_values(\array_unique(\array_merge($this->sourceIncludes, EMSSource::REQUIRED_FIELDS))),
                 'excludes' => $this->sourceExcludes,
             ]);
         }
 
-        return $this->sourceIncludes;
+        return \array_values(\array_unique(\array_merge($this->sourceIncludes, EMSSource::REQUIRED_FIELDS)));
     }
 
     /**
@@ -134,11 +131,9 @@ class Search
         if (isset($sources['includes']) || isset($sources['excludes'])) {
             $this->sourceIncludes = $sources['includes'] ?? [];
             $this->sourceExcludes = $sources['excludes'] ?? [];
-
-            return;
+        } else {
+            $this->sourceIncludes = $sources;
         }
-
-        $this->sourceIncludes = \array_merge($sources, EMSSource::REQUIRED_FIELDS);
     }
 
     /**

--- a/EMS/common-bundle/src/Search/Search.php
+++ b/EMS/common-bundle/src/Search/Search.php
@@ -71,6 +71,9 @@ class Search
      */
     public function getSources(): array
     {
+        if (\count($this->sourceIncludes) > 0 && !\in_array('_*', $this->sourceIncludes)) {
+            $this->sourceIncludes[] = '_*';
+        }
         if (\count($this->sourceExcludes) > 0) {
             return \array_filter([
                 'includes' => $this->sourceIncludes,


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  |  n |
| Fixed tickets? | n  |
| Documentation? | n  |

If the route's elasticsearch query specifies include fields, internal fields might be forgotten
