### PR TITLE
feat: command to convert file links to object links in wysiwyg

### DIFF
--- a/elasticms-cli/src/Command/MediaLibrary/UpdateFileLinks.php
+++ b/elasticms-cli/src/Command/MediaLibrary/UpdateFileLinks.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\CLI\Command\MediaLibrary;
+
+use App\CLI\Commands;
+use EMS\CommonBundle\Common\Command\AbstractCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: Commands::UPDATE_FILE_LINKS,
+    description: '', // TODO Ajouter une description au script
+    hidden: false
+)]
+final class UpdateFileLinks extends AbstractCommand
+{
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->io->title(\sprintf('Convert ems file links into ems object link in %s', 'content type name'));
+
+        
+        return self::EXECUTE_SUCCESS;
+    }
+}

--- a/elasticms-cli/src/Commands.php
+++ b/elasticms-cli/src/Commands.php
@@ -13,6 +13,7 @@ class Commands
     final public const string DOCUMENTS_UPDATE = 'emscli:documents:update';
     final public const string MEDIA_LIBRARY_SYNC = 'emscli:media-library:synchronize';
     final public const string MEDIA_LIBRARY_TIKA_CACHE = 'emscli:media-library:load-tika-cache';
+    final public const string UPDATE_FILE_LINKS = 'emscli:media-library:update-file-links';
 
     final public const string IMPORT_FILE = 'emscli:import:file';
     final public const string IMPORT_DATABASE = 'emscli:import:database';


### PR DESCRIPTION


| Q              | A |
|----------------|---|
| Bug fix?       | n  |
| New feature?   | y  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n |
| Documentation? | n |

a command to convert ems file links (in wysiwyg fields) into ems object links (if the file already exists in a media library)
