### PR TITLE
fix(admin/user):  authToken user provider not using group defined roles

### DIFF
--- a/EMS/core-bundle/config/security/security.xml
+++ b/EMS/core-bundle/config/security/security.xml
@@ -9,7 +9,6 @@
         <!-- User Provider -->
         <service id="emsco.security.provider.user" class="EMS\CoreBundle\Security\Provider\UserProvider">
             <argument type="service" id="ems.repository.user"/>
-            <argument type="service" id="ems.repository.group"/>
         </service>
         <service id="emsco.security.provider.user_api" class="EMS\CoreBundle\Security\Provider\UserApiProvider">
             <argument type="service" id="ems.repository.auth_token" />

--- a/EMS/core-bundle/src/Entity/User.php
+++ b/EMS/core-bundle/src/Entity/User.php
@@ -31,8 +31,6 @@ class User implements UserInterface, EntityInterface, PasswordAuthenticatedUserI
     private Collection $authTokens;
     private string $locale = self::DEFAULT_LOCALE;
     private ?string $localePreferred = null;
-    /** @var string[] */
-    private array $groupRoles = [];
     private ?string $username = null;
     private ?string $usernameCanonical = null;
     private ?string $email = null;
@@ -93,14 +91,6 @@ class User implements UserInterface, EntityInterface, PasswordAuthenticatedUserI
         $now = new \DateTime('now');
 
         return $now > $this->expirationDate;
-    }
-
-    /**
-     * @param string[] $groupRoles
-     */
-    public function setGroupRoles(array $groupRoles): void
-    {
-        $this->groupRoles = $groupRoles;
     }
 
     public function getLanguage(): string
@@ -403,9 +393,11 @@ class User implements UserInterface, EntityInterface, PasswordAuthenticatedUserI
     #[\Override]
     public function getRoles(): array
     {
-        $roles = [...$this->roles, ...$this->groupRoles];
-        // we need to make sure to have at least one role
-        $roles[] = Roles::ROLE_USER;
+        $roles = $this->roles;
+        $group = $this->getGroup();
+        if (null !== $group) {
+            $roles = \array_merge($roles, $group->getRoles());
+        }
 
         return \array_unique($roles);
     }

--- a/EMS/core-bundle/src/Security/Provider/UserProvider.php
+++ b/EMS/core-bundle/src/Security/Provider/UserProvider.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace EMS\CoreBundle\Security\Provider;
 
-use EMS\CoreBundle\Entity\Group;
 use EMS\CoreBundle\Entity\User;
-use EMS\CoreBundle\Repository\GroupRepository;
 use EMS\CoreBundle\Repository\UserRepository;
 use Symfony\Component\Security\Core\Exception\AccountExpiredException;
 use Symfony\Component\Security\Core\Exception\DisabledException;
@@ -21,8 +19,7 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
 class UserProvider implements UserProviderInterface
 {
     public function __construct(
-        private readonly UserRepository $userRepository,
-        private readonly GroupRepository $groupRepository
+        private readonly UserRepository $userRepository
     ) {
     }
 
@@ -60,14 +57,6 @@ class UserProvider implements UserProviderInterface
 
         if (!$user->isEnabled()) {
             throw new DisabledException(\sprintf('The account "%s" is disabled', $user->getUserIdentifier()));
-        }
-
-        $userGroup = $user->getGroup();
-        $group = $userGroup instanceof Group ? $this->groupRepository->getById($userGroup->getId()) : null;
-        if (null !== $group) {
-            $user->setGroupRoles($group->getRoles());
-        } else {
-            $user->setGroupRoles([]);
         }
 
         return $user;


### PR DESCRIPTION


| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

* The User::groupRoles is useless (and is unnecessary complex)
* A User without role can't have a default role