### PR TITLE
fix(admin/form): form label empty calling deprecated __toString

### DIFF
--- a/EMS/admin-ui-bundle/templates/bootstrap5/form/fields.html.twig
+++ b/EMS/admin-ui-bundle/templates/bootstrap5/form/fields.html.twig
@@ -35,7 +35,7 @@
         {%- if parent_label_class is defined -%}
             {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' ' ~ parent_label_class)|trim}) -%}
         {%- endif -%}
-        {%- if label is not same as(false) and label is empty -%}
+        {%- if label is not same as(false) -%}
             {%- if label_format is not empty -%}
                 {%- set label = label_format|replace({
                     '%name%': name,
@@ -321,7 +321,7 @@
         {% if required -%}
             {% set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' required')|trim}) %}
         {%- endif -%}
-        {% if label is empty -%}
+        {% if label is not same as(false) -%}
             {%- if label_format is not empty -%}
                 {% set label = label_format|replace({
                     '%name%': name,
@@ -770,7 +770,7 @@
         {% if required -%}
             {% set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' required')|trim}) %}
         {%- endif -%}
-        {% if label is empty -%}
+        {% if label is not same as(false) -%}
             {%- if label_format is not empty -%}
                 {% set label = label_format|replace({
                     '%name%': name,

--- a/EMS/admin-ui-bundle/templates/bootstrap5/form/forms.html.twig
+++ b/EMS/admin-ui-bundle/templates/bootstrap5/form/forms.html.twig
@@ -104,7 +104,7 @@
 
 {% block emsco_form_table_column_data_value_string_array %}
     {%- set value = attribute(line.data, column.attribute)|default([]) -%}
-    {%- if value is iterable and column.valid(line.data)  -%}
+    {%- if value is iterable and column.valid(line.data) -%}
         <ul>
         {%- for string in value -%}
             <li>{{- string -}}</li>

--- a/EMS/core-bundle/templates/form/fields.html.twig
+++ b/EMS/core-bundle/templates/form/fields.html.twig
@@ -10,7 +10,7 @@
         {%- if parent_label_class is defined -%}
             {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' ' ~ parent_label_class)|trim}) -%}
         {%- endif -%}
-        {%- if label is not same as(false) and label is empty -%}
+        {%- if label is not same as(false) -%}
             {%- if label_format is not empty -%}
                 {%- set label = label_format|replace({
                     '%name%': name,
@@ -298,7 +298,7 @@
         {% if required -%}
             {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' required')|trim}) %}
         {%- endif -%}
-        {% if label is empty -%}
+		{%- if label is not same as(false) -%}
             {%- if label_format is not empty -%}
                 {% set label = label_format|replace({
                     '%name%': name,
@@ -756,7 +756,7 @@
         {% if required -%}
             {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' required')|trim}) %}
         {%- endif -%}
-        {% if label is empty -%}
+		{%- if label is not same as(false) -%}
             {%- if label_format is not empty -%}
                 {% set label = label_format|replace({
                     '%name%': name,

--- a/composer.json
+++ b/composer.json
@@ -241,6 +241,7 @@
             "APP_DEBUG=1 php elasticms-web/bin/console lint:container"
         ],
         "lint-twig": [
+            "twig-cs-fixer fix -c ./config/.twig-cs-fixer.php",
             "@lint-twig-bundles",
             "@lint-twig-demo"
         ],


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Because the empty is calling the deprecated __toString method on translatableMessages object. Checked parent templates, and the empty check is not called anymore.
