### PR TITLE
fix(docker): optional include docker .env file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 
-include ./docker/.env
+-include ./docker/.env
 
 PWD					= $(shell pwd)
 DOCKER_USER			?= $(shell id -u)


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Because on fresh install the docker/.env file is not existing, until the user runs `make init`
