### PR TITLE
fix(common/api): /upload-chunk/{sha1} replaced by /chunk/{hash}

### DIFF
--- a/EMS/common-bundle/src/Storage/Service/HttpStorage.php
+++ b/EMS/common-bundle/src/Storage/Service/HttpStorage.php
@@ -24,7 +24,7 @@ class HttpStorage extends AbstractUrlStorage implements \Stringable
 
     public static function addChunkUrl(string $hash): string
     {
-        return '/api/file/upload-chunk/'.\urlencode($hash);
+        return '/api/file/chunk/'.\urlencode($hash);
     }
 
     /**


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   |  n |
| BC breaks?     |  n |
| Deprecations?  |n   |
| Fixed tickets? | n  |
| Documentation? |  n |

