### PR TITLE
fix(web/security): ping identity http basic auth

### DIFF
--- a/EMS/client-helper-bundle/src/Security/Sso/OAuth2/Provider/PingIdentityOAuth2Provider.php
+++ b/EMS/client-helper-bundle/src/Security/Sso/OAuth2/Provider/PingIdentityOAuth2Provider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EMS\ClientHelperBundle\Security\Sso\OAuth2\Provider;
 
+use League\OAuth2\Client\OptionProvider\HttpBasicAuthOptionProvider;
 use League\OAuth2\Client\Provider\AbstractProvider;
 use League\OAuth2\Client\Provider\GenericProvider;
 use League\OAuth2\Client\Token\AccessToken;
@@ -25,14 +26,19 @@ final class PingIdentityOAuth2Provider extends AbstractOAuth2Provider
         private readonly string $redirectUri,
         private readonly ?array $scopes = null,
     ) {
-        $this->provider = new GenericProvider([
-            'clientId' => $clientId,
-            'clientSecret' => $clientSecret,
-            'redirectUri' => $redirectUri,
-            'urlAuthorize' => $issuer.'/authorize',
-            'urlAccessToken' => $issuer.'/access_token',
-            'urlResourceOwnerDetails' => $issuer.'/userinfo',
-        ]);
+        $this->provider = new GenericProvider(
+            options: [
+                'clientId' => $clientId,
+                'clientSecret' => $clientSecret,
+                'redirectUri' => $redirectUri,
+                'urlAuthorize' => $issuer.'/authorize',
+                'urlAccessToken' => $issuer.'/access_token',
+                'urlResourceOwnerDetails' => $issuer.'/userinfo',
+            ],
+            collaborators: [
+                'optionProvider' => new HttpBasicAuthOptionProvider(),
+            ]
+        );
     }
 
     protected function getName(): string
@@ -64,7 +70,7 @@ final class PingIdentityOAuth2Provider extends AbstractOAuth2Provider
         $data = $this->provider->getResourceOwner($accessToken)->toArray();
 
         return [
-            'username' => $data['preferred_username'] ?? $data['sub'] ?? null,
+            'username' => $data['preferred_username'] ?? $data['name'] ?? $data['sub'] ?? null,
             'email' => $data['email'] ?? null,
         ];
     }


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Fetching the access token needs to be with  http basic, not the default post body.
