### PR TITLE
fix(web/security): saml redirect with RelayState

### DIFF
--- a/EMS/client-helper-bundle/src/Security/Sso/Saml/SamlAuthenticator.php
+++ b/EMS/client-helper-bundle/src/Security/Sso/Saml/SamlAuthenticator.php
@@ -59,12 +59,15 @@ class SamlAuthenticator extends AbstractAuthenticator
     #[\Override]
     public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
     {
+        $relayState = $request->request->get('RelayState');
+
+        if (\is_string($relayState) && \strlen($relayState) > 0) {
+            return $this->httpUtils->createRedirectResponse($request, $relayState);
+        }
+
         $loginPath = $this->httpUtils->generateUri($request, SamlService::ROUTE_LOGIN);
 
-        $targetPath = $this->getTargetPath($request->getSession(), $firewallName);
-        $path = ($targetPath && $loginPath !== $targetPath ? $targetPath : '/');
-
-        return $this->httpUtils->createRedirectResponse($request, $path);
+        return $this->httpUtils->createRedirectResponse($request, $loginPath);
     }
 
     #[\Override]


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Currently we are using the session for  determining the target after a authentication success. This is wrong if the IDP is on a different domain. Correct way is to use the RelayState of the SAML response.
