### PR TITLE
fix(web/routing): routing include only required field

### DIFF
--- a/EMS/common-bundle/src/Search/Search.php
+++ b/EMS/common-bundle/src/Search/Search.php
@@ -71,14 +71,19 @@ class Search
      */
     public function getSources(): array
     {
-        if (\count($this->sourceExcludes) > 0) {
+        $includes = [];
+        if ([] !== $this->sourceIncludes) {
+            $includes = \array_values(\array_unique(\array_merge($this->sourceIncludes, EMSSource::REQUIRED_FIELDS)));
+        }
+
+        if ([] !== $this->sourceExcludes) {
             return \array_filter([
-                'includes' => \array_values(\array_unique(\array_merge($this->sourceIncludes, EMSSource::REQUIRED_FIELDS))),
+                'includes' => $includes,
                 'excludes' => $this->sourceExcludes,
             ]);
         }
 
-        return \array_values(\array_unique(\array_merge($this->sourceIncludes, EMSSource::REQUIRED_FIELDS)));
+        return $includes;
     }
 
     /**


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Fix the regression bug from https://github.com/ems-project/elasticms/pull/1567/changes

We can only merge the required fields if a specific source is defined. Currently not defining a source is only returning the required fields, this is not correct behavior.
