### PR TITLE
fix(docker): NGINX / PHP-FPM configuration 

### DIFF
--- a/elasticms-admin/.docker/config/nginx/conf.d/include.fastcgi.conf.gtpl
+++ b/elasticms-admin/.docker/config/nginx/conf.d/include.fastcgi.conf.gtpl
@@ -3,6 +3,7 @@ fastcgi_split_path_info ^(.+\.php)(/.*)$;
 
 include fastcgi_params;
 
+fastcgi_param SERVER_NAME $host;
 fastcgi_param SCRIPT_NAME {{ $.Env.SYMFONY_SCRIPT_NAME_NGINX_VARIABLE_NAME }};
 fastcgi_param SCRIPT_FILENAME {{ $.Env.NGINX_PUBLIC_DIR }}/index.php;
 

--- a/elasticms-admin/.docker/config/php/php-fpm.d/elasticms.conf.gtpl
+++ b/elasticms-admin/.docker/config/php/php-fpm.d/elasticms.conf.gtpl
@@ -1,17 +1,25 @@
 [{{ $.Env.ELASTICMS_INSTANCE_NAME }}]
-listen = /app/var/run/php-fpm/{{ $.Env.ELASTICMS_INSTANCE_NAME }}.php-fpm.sock
-listen.mode = 0777
-listen.allowed_clients = 127.0.0.1
+access.log = {{ $.Env.PHP_FPM_ACCESS_LOG }}
+access.format = "{{ $.Env.PHP_FPM_ACCESS_FORMAT }}"
 
-pm = ondemand
-pm.max_children = {{.Env.PHP_FPM_MAX_CHILDREN}}
+clear_env = {{ $.Env.PHP_FPM_CLEAR_ENV }}
+
+listen = /app/var/run/php-fpm/{{ $.Env.ELASTICMS_INSTANCE_NAME }}.php-fpm.sock
+listen.mode = {{ $.Env.PHP_FPM_LISTEN_MODE }}
+listen.allowed_clients = {{ $.Env.PHP_FPM_LISTEN_ALLOWED_CLIENTS }}
+
+pm = {{ $.Env.PHP_FPM_PM }}
+pm.max_children = {{ $.Env.PHP_FPM_PM_MAX_CHILDREN }}
+pm.process_idle_timeout = {{ $.Env.PHP_FPM_PM_PROCESS_IDLE_TIMEOUT }}
+pm.max_requests = {{ $.Env.PHP_FPM_PM_MAX_REQUESTS }}
 
 pm.status_path = /{{ $.Env.ELASTICMS_INSTANCE_NAME }}-status
 ping.path = /{{ $.Env.ELASTICMS_INSTANCE_NAME }}-ping
 
-clear_env = no
+catch_workers_output = {{ $.Env.PHP_FPM_CATCH_WORKERS_OUTPUT }}
+decorate_workers_output = {{ $.Env.PHP_FPM_DECORATE_WORKERS_OUTPUT }}
 
-{{- range $key, $value := ds "variables" }}
+{{ range $key, $value := ds "variables" }}
 {{- if ne $value "" }}
 {{- $safe_value := $value | printf "%s" | strings.ReplaceAll "\"" "\\\"" }}
 env[{{ $key }}] = "{{ $safe_value }}"

--- a/elasticms-web/.docker/config/nginx/conf.d/include.fastcgi.conf.gtpl
+++ b/elasticms-web/.docker/config/nginx/conf.d/include.fastcgi.conf.gtpl
@@ -3,6 +3,7 @@ fastcgi_split_path_info ^(.+\.php)(/.*)$;
 
 include fastcgi_params;
 
+fastcgi_param SERVER_NAME $host;
 fastcgi_param SCRIPT_NAME {{ $.Env.SYMFONY_SCRIPT_NAME_NGINX_VARIABLE_NAME }};
 fastcgi_param SCRIPT_FILENAME {{ $.Env.NGINX_PUBLIC_DIR }}/index.php;
 

--- a/elasticms-web/.docker/config/php/php-fpm.d/elasticms.conf.gtpl
+++ b/elasticms-web/.docker/config/php/php-fpm.d/elasticms.conf.gtpl
@@ -1,17 +1,25 @@
 [{{ $.Env.ELASTICMS_INSTANCE_NAME }}]
-listen = /app/var/run/php-fpm/{{ $.Env.ELASTICMS_INSTANCE_NAME }}.php-fpm.sock
-listen.mode = 0777
-listen.allowed_clients = 127.0.0.1
+access.log = {{ $.Env.PHP_FPM_ACCESS_LOG }}
+access.format = "{{ $.Env.PHP_FPM_ACCESS_FORMAT }}"
 
-pm = ondemand
-pm.max_children = {{.Env.PHP_FPM_MAX_CHILDREN}}
+clear_env = {{ $.Env.PHP_FPM_CLEAR_ENV }}
+
+listen = /app/var/run/php-fpm/{{ $.Env.ELASTICMS_INSTANCE_NAME }}.php-fpm.sock
+listen.mode = {{ $.Env.PHP_FPM_LISTEN_MODE }}
+listen.allowed_clients = {{ $.Env.PHP_FPM_LISTEN_ALLOWED_CLIENTS }}
+
+pm = {{ $.Env.PHP_FPM_PM }}
+pm.max_children = {{ $.Env.PHP_FPM_PM_MAX_CHILDREN }}
+pm.process_idle_timeout = {{ $.Env.PHP_FPM_PM_PROCESS_IDLE_TIMEOUT }}
+pm.max_requests = {{ $.Env.PHP_FPM_PM_MAX_REQUESTS }}
 
 pm.status_path = /{{ $.Env.ELASTICMS_INSTANCE_NAME }}-status
 ping.path = /{{ $.Env.ELASTICMS_INSTANCE_NAME }}-ping
 
-clear_env = no
+catch_workers_output = {{ $.Env.PHP_FPM_CATCH_WORKERS_OUTPUT }}
+decorate_workers_output = {{ $.Env.PHP_FPM_DECORATE_WORKERS_OUTPUT }}
 
-{{- range $key, $value := ds "variables" }}
+{{ range $key, $value := ds "variables" }}
 {{- if ne $value "" }}
 {{- $safe_value := $value | printf "%s" | strings.ReplaceAll "\"" "\\\"" }}
 env[{{ $key }}] = "{{ $safe_value }}"


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | n |
| New feature?   | n |
| BC breaks?     | n |
| Deprecations?  | n |
| Fixed tickets? | n |
| Documentation? | n |

- Update Nginx configuration to ensure the correct hostname is passed to PHP-FPM (FastCGI). We are switching from $server_name to $host for the SERVER_NAME parameter.
- Optimize support of PHP-FPM pool configuration (logging).
