### PR TITLE
fix: remove fork stevenmaguire/oauth2-keycloak

### DIFF
--- a/EMS/client-helper-bundle/composer.json
+++ b/EMS/client-helper-bundle/composer.json
@@ -18,7 +18,7 @@
         "elasticms/common-bundle": "7.0.*",
         "league/oauth2-client": "^2.8",
         "onelogin/php-saml": "^4.1",
-        "stevenmaguire/oauth2-keycloak": "dev-jwt7-support as 5.1.1",
+        "stevenmaguire/oauth2-keycloak": "^6.1",
         "symfony-cmf/routing": "^3.0",
         "symfony/asset": "7.4.*",
         "symfony/console": "7.4.*",

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
         "ruflin/elastica": "^8.0",
         "scssphp/scssphp": "^2.0",
         "sensiolabs/ansi-to-html": "^2.0",
-        "stevenmaguire/oauth2-keycloak": "dev-jwt7-support as 5.1.1",
+        "stevenmaguire/oauth2-keycloak": "^6.1",
         "symfony-cmf/routing": "^3.0",
         "symfony/asset": "7.4.*",
         "symfony/cache": "7.4.*",
@@ -143,12 +143,6 @@
         "symplify/monorepo-builder": "^12.0",
         "vincentlanglet/twig-cs-fixer": "^3.10"
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "git@github.com:ems-project/oauth2-keycloak.git"
-        }
-    ],
     "config": {
         "sort-packages": true,
         "allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "25dfd015d5ab66041c1c457206c1014d",
+    "content-hash": "1f7dfb91a918f6639d8be701132656bf",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -62,16 +62,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.371.3",
+            "version": "3.371.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "d300ec1c861e52dc8f17ca3d75dc754da949f065"
+                "reference": "957f8a5ecc30670c95dfc37a9d04660899fc44e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/d300ec1c861e52dc8f17ca3d75dc754da949f065",
-                "reference": "d300ec1c861e52dc8f17ca3d75dc754da949f065",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/957f8a5ecc30670c95dfc37a9d04660899fc44e0",
+                "reference": "957f8a5ecc30670c95dfc37a9d04660899fc44e0",
                 "shasum": ""
             },
             "require": {
@@ -153,9 +153,9 @@
             "support": {
                 "forum": "https://github.com/aws/aws-sdk-php/discussions",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.371.3"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.371.4"
             },
-            "time": "2026-02-27T19:05:40+00:00"
+            "time": "2026-03-03T19:52:06+00:00"
         },
         {
             "name": "bacon/bacon-qr-code",
@@ -1790,16 +1790,16 @@
         },
         {
             "name": "dompdf/dompdf",
-            "version": "v3.1.4",
+            "version": "v3.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dompdf/dompdf.git",
-                "reference": "db712c90c5b9868df3600e64e68da62e78a34623"
+                "reference": "f11ead23a8a76d0ff9bbc6c7c8fd7e05ca328496"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dompdf/dompdf/zipball/db712c90c5b9868df3600e64e68da62e78a34623",
-                "reference": "db712c90c5b9868df3600e64e68da62e78a34623",
+                "url": "https://api.github.com/repos/dompdf/dompdf/zipball/f11ead23a8a76d0ff9bbc6c7c8fd7e05ca328496",
+                "reference": "f11ead23a8a76d0ff9bbc6c7c8fd7e05ca328496",
                 "shasum": ""
             },
             "require": {
@@ -1848,9 +1848,9 @@
             "homepage": "https://github.com/dompdf/dompdf",
             "support": {
                 "issues": "https://github.com/dompdf/dompdf/issues",
-                "source": "https://github.com/dompdf/dompdf/tree/v3.1.4"
+                "source": "https://github.com/dompdf/dompdf/tree/v3.1.5"
             },
-            "time": "2025-10-29T12:43:30+00:00"
+            "time": "2026-03-03T13:54:37+00:00"
         },
         {
             "name": "dompdf/php-font-lib",
@@ -6287,16 +6287,16 @@
         },
         {
             "name": "sabberworm/php-css-parser",
-            "version": "v9.2.0",
+            "version": "v9.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/MyIntervals/PHP-CSS-Parser.git",
-                "reference": "59373045e11ad47b5c18fc615feee0219e42f6d3"
+                "reference": "88dbd0f7f91abbfe4402d0a3071e9ff4d81ed949"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/MyIntervals/PHP-CSS-Parser/zipball/59373045e11ad47b5c18fc615feee0219e42f6d3",
-                "reference": "59373045e11ad47b5c18fc615feee0219e42f6d3",
+                "url": "https://api.github.com/repos/MyIntervals/PHP-CSS-Parser/zipball/88dbd0f7f91abbfe4402d0a3071e9ff4d81ed949",
+                "reference": "88dbd0f7f91abbfe4402d0a3071e9ff4d81ed949",
                 "shasum": ""
             },
             "require": {
@@ -6323,7 +6323,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "9.3.x-dev"
+                    "dev-main": "9.4.x-dev"
                 }
             },
             "autoload": {
@@ -6361,9 +6361,9 @@
             ],
             "support": {
                 "issues": "https://github.com/MyIntervals/PHP-CSS-Parser/issues",
-                "source": "https://github.com/MyIntervals/PHP-CSS-Parser/tree/v9.2.0"
+                "source": "https://github.com/MyIntervals/PHP-CSS-Parser/tree/v9.3.0"
             },
-            "time": "2026-02-21T17:12:03+00:00"
+            "time": "2026-03-03T17:31:43+00:00"
         },
         {
             "name": "scssphp/scssphp",
@@ -6548,25 +6548,26 @@
         },
         {
             "name": "stevenmaguire/oauth2-keycloak",
-            "version": "dev-jwt7-support",
+            "version": "6.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/ems-project/oauth2-keycloak.git",
-                "reference": "107c24beea7c58bf4d4aa905fb3c4d302c75d603"
+                "url": "https://github.com/stevenmaguire/oauth2-keycloak.git",
+                "reference": "459cc58576d37f5823de2a677a7b17667b85ba7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ems-project/oauth2-keycloak/zipball/107c24beea7c58bf4d4aa905fb3c4d302c75d603",
-                "reference": "107c24beea7c58bf4d4aa905fb3c4d302c75d603",
+                "url": "https://api.github.com/repos/stevenmaguire/oauth2-keycloak/zipball/459cc58576d37f5823de2a677a7b17667b85ba7f",
+                "reference": "459cc58576d37f5823de2a677a7b17667b85ba7f",
                 "shasum": ""
             },
             "require": {
                 "firebase/php-jwt": "^7.0",
-                "league/oauth2-client": "^2.0",
-                "php": "~7.2 || ~8.0"
+                "league/oauth2-client": "^2.8",
+                "php": "^8.0"
             },
             "require-dev": {
-                "mockery/mockery": "~1.5.0",
+                "mockery/mockery": "^1.6",
+                "phpstan/phpstan": "^1.12",
                 "phpunit/phpunit": "~9.6.4",
                 "squizlabs/php_codesniffer": "~3.7.0"
             },
@@ -6581,17 +6582,7 @@
                     "Stevenmaguire\\OAuth2\\Client\\": "src/"
                 }
             },
-            "autoload-dev": {
-                "psr-4": {
-                    "Stevenmaguire\\OAuth2\\Client\\Test\\": "test/src/"
-                }
-            },
-            "scripts": {
-                "test": [
-                    "@putenv XDEBUG_MODE=coverage",
-                    "phpunit --colors=always"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -6612,9 +6603,10 @@
                 "oauth2"
             ],
             "support": {
-                "source": "https://github.com/ems-project/oauth2-keycloak/tree/jwt7-support"
+                "issues": "https://github.com/stevenmaguire/oauth2-keycloak/issues",
+                "source": "https://github.com/stevenmaguire/oauth2-keycloak/tree/6.1.0"
             },
-            "time": "2026-02-23T08:38:05+00:00"
+            "time": "2026-03-03T11:50:29+00:00"
         },
         {
             "name": "symfony-cmf/routing",
@@ -15890,12 +15882,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "89525190c449738e468ee27e77f9fdc1bc160e08"
+                "reference": "5a17df9a478a03dff7428a3172cf7204d4d017a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/89525190c449738e468ee27e77f9fdc1bc160e08",
-                "reference": "89525190c449738e468ee27e77f9fdc1bc160e08",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/5a17df9a478a03dff7428a3172cf7204d4d017a8",
+                "reference": "5a17df9a478a03dff7428a3172cf7204d4d017a8",
                 "shasum": ""
             },
             "conflict": {
@@ -16196,7 +16188,7 @@
                 "friendsoftypo3/openid": ">=4.5,<4.5.31|>=4.7,<4.7.16|>=6,<6.0.11|>=6.1,<6.1.6",
                 "froala/wysiwyg-editor": "<=4.3",
                 "frosh/adminer-platform": "<2.2.1",
-                "froxlor/froxlor": "<=2.2.5",
+                "froxlor/froxlor": "<=2.3.3",
                 "frozennode/administrator": "<=5.0.12",
                 "fuel/core": "<1.8.1",
                 "funadmin/funadmin": "<=7.1.0.0-RC4",
@@ -16246,7 +16238,7 @@
                 "ibexa/solr": ">=4.5,<4.5.4",
                 "ibexa/user": ">=4,<4.4.3|>=5,<5.0.4",
                 "icecoder/icecoder": "<=8.1",
-                "idno/known": "<=1.6.2",
+                "idno/known": "<1.6.4",
                 "ilicmiljan/secure-props": ">=1.2,<1.2.2",
                 "illuminate/auth": "<5.5.10",
                 "illuminate/cookie": ">=4,<=4.0.11|>=4.1,<6.18.31|>=7,<7.22.4",
@@ -16909,7 +16901,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-01T01:36:02+00:00"
+            "time": "2026-03-03T18:18:18+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -18369,18 +18361,10 @@
             "time": "2026-02-27T10:28:38+00:00"
         }
     ],
-    "aliases": [
-        {
-            "package": "stevenmaguire/oauth2-keycloak",
-            "version": "dev-jwt7-support",
-            "alias": "5.1.1",
-            "alias_normalized": "5.1.1.0"
-        }
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "roave/security-advisories": 20,
-        "stevenmaguire/oauth2-keycloak": 20
+        "roave/security-advisories": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/elasticms-admin/composer.json
+++ b/elasticms-admin/composer.json
@@ -49,12 +49,6 @@
         "symfony/debug-bundle": "7.4.*",
         "symfony/web-profiler-bundle": "7.4.*"
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "git@github.com:ems-project/oauth2-keycloak.git"
-        }
-    ],
     "config": {
         "allow-plugins": {
             "php-http/discovery": true,

--- a/elasticms-web/composer.json
+++ b/elasticms-web/composer.json
@@ -49,12 +49,6 @@
         "symfony/debug-bundle": "7.4.*",
         "symfony/web-profiler-bundle": "7.4.*"
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "git@github.com:ems-project/oauth2-keycloak.git"
-        }
-    ],
     "config": {
         "allow-plugins": {
             "php-http/discovery": true,


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  Y  |
| New feature?   |  n |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? |  n |
| Documentation? | n  |

Remove the fork, now 6.1.0 has been released
