### PR TITLE
fix(web): local push route without query

### DIFF
--- a/EMS/client-helper-bundle/src/Helper/Local/Status/Item.php
+++ b/EMS/client-helper-bundle/src/Helper/Local/Status/Item.php
@@ -33,7 +33,7 @@ final class Item
             return false;
         }
 
-        if (!$this->hasDataLocal() || $this->dataLocal === $this->dataOrigin) {
+        if (!$this->hasDataLocal() || \array_filter($this->dataLocal, fn($v) => $v !== null) === $this->dataOrigin) {
             return false;
         }
 

--- a/EMS/client-helper-bundle/src/Helper/Local/Status/Item.php
+++ b/EMS/client-helper-bundle/src/Helper/Local/Status/Item.php
@@ -33,7 +33,7 @@ final class Item
             return false;
         }
 
-        if (!$this->hasDataLocal() || \array_filter($this->dataLocal, fn($v) => $v !== null) === $this->dataOrigin) {
+        if (!$this->hasDataLocal() || \array_filter($this->dataLocal, fn ($v) => null !== $v) === $this->dataOrigin) {
             return false;
         }
 

--- a/EMS/client-helper-bundle/src/Helper/Routing/RoutingFile.php
+++ b/EMS/client-helper-bundle/src/Helper/Routing/RoutingFile.php
@@ -79,6 +79,12 @@ final class RoutingFile implements \Countable
                     $route['template_static'] = $template->getPathOuuid();
                 }
             }
+            foreach (['template_static', 'template_source', 'query', 'index_regex'] as $field) {
+                if (isset($route[$field])) {
+                    continue;
+                }
+                $route[$field] = null;
+            }
 
             $route['order'] = ++$order;
             $data[$name] = $route;

--- a/demo/skeleton/routes.yaml
+++ b/demo/skeleton/routes.yaml
@@ -85,9 +85,9 @@ emsch_language_selection:
     template_static: template/view/language_select.html.twig
 emsch_js_translations:
     config:
-        path: /translations/{_locale}.js
+        path: '/translations/{_locale}.js'
         requirements: { _locale: en|fr|nl|de }
-        defaults: {_format: js}
+        defaults: { _format: js }
     template_static: template/js/translations.js.twig
 emsch_word_export:
     config:
@@ -117,7 +117,7 @@ emsch_error:
     config:
         path: '/_error/{statusCode}.{_format}'
         controller: 'emsch.controller.router::errorPreview'
-        requirements: { statusCode: '[0-9]{3}', _format: 'html|json' }
+        requirements: { statusCode: '[0-9]{3}', _format: html|json }
         defaults: { _format: html }
         method: [POST, GET]
 emsch_login:
@@ -132,7 +132,7 @@ ems:
         defaults: { _authenticated: true }
     template_static: template/security/ems.html.twig
 ems_check_asset:
-  config:
-    path: '/file/{config}/{hash}/{filename}'
-    controller: 'emsch.controller.router::redirect'
-  template_static: template/redirects/asset.json.twig
+    config:
+        path: '/file/{config}/{hash}/{filename}'
+        controller: 'emsch.controller.router::redirect'
+    template_static: template/redirects/asset.json.twig

--- a/demo/skeleton/translations/messages.fr.yaml
+++ b/demo/skeleton/translations/messages.fr.yaml
@@ -16,9 +16,9 @@ blog:
     title: 'What’s new?'
 breadcrumb:
     back-to: 'Retour à la page %title%'
-    homepage: 'd''accueil'
+    homepage: "d'accueil"
 cookie:
-    close: 'J''ai compris !'
+    close: "J'ai compris !"
     closeAll: 'les cookies sociaux'
     closeSite: 'les cookies fonctionnels'
     link: 'En savoir plus'
@@ -30,12 +30,12 @@ ems_form:
 emsch:
     security:
         exception:
-            bad_credentials: 'Nom d''utilisateur ou mot de passe invalide'
-            error: 'Une erreur s''est produite !'
+            bad_credentials: "Nom d'utilisateur ou mot de passe invalide"
+            error: "Une erreur s'est produite !"
         form:
             password: 'Mot de passe'
             submit: 'Se connecter'
-            username: 'Nom d''utilisateur'
+            username: "Nom d'utilisateur"
 features:
     discover: 'Découvrez toutes les fonctionnalités'
 files_browse: 'Glisser-déposer des fichiers ici ou'
@@ -51,16 +51,16 @@ js:
     format_not_supported: 'Erreur: Format incorrect.'
     incorrect_format: 'Format incorrect'
     max_size_reached: 'Les fichiers sont trop volumineux. La taille maximale autorisée est de %fileSize%.'
-    required_field: '(*) Champ obligatoire'
     remove: Supprimer
     remove_all: 'Supprimer tout'
+    required_field: '(*) Champ obligatoire'
 language:
     selection: 'select language'
 locale: Français
 login: 'Se connecter'
 missing:
     description: 'Changer de langue pour voir les versions alternatives.'
-    title: 'Ce contenu n''est pas disponible en français'
+    title: "Ce contenu n'est pas disponible en français"
 month:
     April: Avril
     August: Août
@@ -89,7 +89,7 @@ site:
     copy: 'Copyright %year%'
     lead: 'Un CMS sur mesure au service du secteur public'
     name: elasticMS
-    news_title: 'What''s new?'
+    news_title: "What's new?"
     short_name: elasticMS
 usergroup:
     facilitator: 'Présentateur du prochain User Group'

--- a/demo/skeleton/translations/messages.nl.yaml
+++ b/demo/skeleton/translations/messages.nl.yaml
@@ -42,18 +42,18 @@ files_browse: 'Kiezen bestanden'
 footer:
     join-us-github: 'Join-us on GitHub'
 js:
-  file_selected: '1 bestand geselecteerd'
-  files_selected: '%count% geselecteerde bestanden'
-  form_error: 'Het formulier is op een probleem gestoten : %message%'
-  form_error_try_later: 'Het formulier is op een probleem gestoten, probeer het later opnieuw.'
-  form_processed: 'Uw bericht is verzonden.'
-  form_saved: 'Uw bericht is verzonden.'
-  format_not_supported: 'Fout: Onjuist formaat.'
-  incorrect_format: 'Onjuist formaat'
-  max_size_reached: 'De bestanden zijn te groot. Toegestane maximum grootte is %fileSize%.'
-  required_field: '(*) Verplicht veld'
-  remove: Verwijderen
-  remove_all: 'Alles verwijderen'
+    file_selected: '1 bestand geselecteerd'
+    files_selected: '%count% geselecteerde bestanden'
+    form_error: 'Het formulier is op een probleem gestoten : %message%'
+    form_error_try_later: 'Het formulier is op een probleem gestoten, probeer het later opnieuw.'
+    form_processed: 'Uw bericht is verzonden.'
+    form_saved: 'Uw bericht is verzonden.'
+    format_not_supported: 'Fout: Onjuist formaat.'
+    incorrect_format: 'Onjuist formaat'
+    max_size_reached: 'De bestanden zijn te groot. Toegestane maximum grootte is %fileSize%.'
+    remove: Verwijderen
+    remove_all: 'Alles verwijderen'
+    required_field: '(*) Verplicht veld'
 language:
     selection: 'select language'
 locale: Nederlands
@@ -89,7 +89,7 @@ site:
     copy: 'Copyright %year%'
     lead: 'Een CMS op maat voor de openbare sector'
     name: elasticMS
-    news_title: 'What''s new?'
+    news_title: "What's new?"
     short_name: elasticMS
 usergroup:
     facilitator: 'Facilitator van de volgende User Group'


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n |
| Fixed tickets? | n  |
| Documentation? | n  |

#1621: Optional fields cannot be removed from the route config