### PR TITLE
feat(common/spreadsheet): cell type option 's' for string

### DIFF
--- a/EMS/common-bundle/src/Common/Spreadsheet/SpreadsheetGeneratorService.php
+++ b/EMS/common-bundle/src/Common/Spreadsheet/SpreadsheetGeneratorService.php
@@ -10,6 +10,7 @@ use EMS\Helpers\File\TempFile;
 use EMS\Helpers\Standard\DateTime;
 use PhpOffice\PhpSpreadsheet\Cell\AdvancedValueBinder;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\Cell\DefaultValueBinder;
 use PhpOffice\PhpSpreadsheet\Cell\StringValueBinder;
 use PhpOffice\PhpSpreadsheet\Settings;
@@ -142,6 +143,10 @@ final class SpreadsheetGeneratorService implements SpreadsheetGeneratorServiceIn
             $valueBinder = new DefaultValueBinder();
         }
 
+        if ($cell->isType(DataType::TYPE_STRING)) {
+            $valueBinder = new StringValueBinder();
+        }
+
         $value = $cell->isType(Cell::TYPE_DATE) ? Date::PHPToExcel($data) : Converter::stringify($data);
         $sheet->setCellValue($cellCoordinate, $value, $valueBinder ?? null);
 
@@ -204,7 +209,7 @@ final class SpreadsheetGeneratorService implements SpreadsheetGeneratorServiceIn
                 Cell::CELL_FORMAT_DISPLAY => null,
             ])
             ->setRequired([Cell::CELL_DATA])
-            ->setAllowedValues(Cell::CELL_TYPE, [null, 'date'])
+            ->setAllowedValues(Cell::CELL_TYPE, [null, 'date', DataType::TYPE_STRING])
             ->setAllowedTypes(Cell::CELL_STYLE, ['array'])
             ->setAllowedTypes(Cell::CELL_FORMAT_INPUT, ['null', 'string'])
             ->setAllowedTypes(Cell::CELL_FORMAT_DISPLAY, ['null', 'string'])

--- a/EMS/common-bundle/tests/Unit/Common/SpreadsheetGeneratorTest.php
+++ b/EMS/common-bundle/tests/Unit/Common/SpreadsheetGeneratorTest.php
@@ -6,6 +6,7 @@ namespace EMS\CommonBundle\Tests\Unit\Common;
 
 use EMS\CommonBundle\Common\Spreadsheet\SpreadsheetGeneratorService;
 use EMS\CommonBundle\Common\Spreadsheet\SpreadsheetValidation;
+use PhpOffice\PhpSpreadsheet\Shared\Date;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
@@ -29,6 +30,16 @@ class SpreadsheetGeneratorTest extends TestCase
         $configColor = \json_decode('{"filename":"export_with_color","writer":"xlsx","active_sheet":0,"sheets":[{"name":"Export form with Color","color":"#FF0000","rows":[[{"data":"apple"},{"data":"banana","style":{"fill":{"fillType":"solid","color":{"rgb":"F9D73F"}}}}],[{"data":"pineapple","style":{"fill":{"fillType":"solid","color":{"rgb":"F9D73F"}}}},{"data":"strawberry","style":{}}]]}]}', true);
         $this->assertSame('Export form with Color', $this->callMethod($this->spreadSheetGenerator, 'buildUpSheets', [$configColor])->getActiveSheet()->getTitle());
         $this->assertSame('pineapple', $this->callMethod($this->spreadSheetGenerator, 'buildUpSheets', [$configColor])->getActiveSheet()->getCell('A2')->getValue());
+    }
+
+    public function testConfigWithTypeToExcel(): void
+    {
+        $config = \json_decode('{"filename":"export","writer":"xlsx","active_sheet":0,"sheets":[{"name":"Export form","color":"#FF0000","rows":[[{"data":"123","type":"s"},{"data":"apple"}],[{"data":"123"},{"data":"banana"}],[{"data":"23/08/2025","type":"date","format_input": "d/m/Y","format_display": "dd/mm/yyyy"},{"data":"banana"}]]}]}', true);
+        $this->assertSame('Export form', $this->callMethod($this->spreadSheetGenerator, 'buildUpSheets', [$config])->getActiveSheet()->getTitle());
+        $this->assertIsString($this->callMethod($this->spreadSheetGenerator, 'buildUpSheets', [$config])->getActiveSheet()->getCell('A1')->getValue());
+        $this->assertIsInt($this->callMethod($this->spreadSheetGenerator, 'buildUpSheets', [$config])->getActiveSheet()->getCell('A2')->getValue());
+        $date = $this->callMethod($this->spreadSheetGenerator, 'buildUpSheets', [$config])->getActiveSheet()->getCell('A3');
+        $this->assertTrue(Date::isDateTime($date));
     }
 
     public function testConfigWithValidationToExcel(): void

--- a/docs/dev/common-bundle/spreadsheet.md
+++ b/docs/dev/common-bundle/spreadsheet.md
@@ -139,3 +139,23 @@ Define:
   ]
 }
 ```
+## String cells
+
+Force text mode on a cell that contains only numbers
+
+Define:
+
+- Type: s
+
+```json
+{
+    "rows": [
+        [
+            {
+                "data": "12345",
+                "type": "s"
+            }
+        ]
+    ]
+}
+```


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  n |
| New feature?   | y  |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? |  n |

Description for the pull request
For spreadsheet, force text mode on a cell that contains only numbers