### PR TITLE
fix: publiccode.yml validation warnings

### DIFF
--- a/.github/workflows/publiccode.yml
+++ b/.github/workflows/publiccode.yml
@@ -1,0 +1,23 @@
+name: Validate publiccode.yml
+
+on:
+  push:
+    paths:
+      - 'publiccode.yml'
+      - '.github/workflows/publiccode.yml'
+  pull_request:
+    paths:
+      - 'publiccode.yml'
+      - '.github/workflows/publiccode.yml'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    name: publiccode.yml validation
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: italia/publiccode-parser-action@v1
+        with:
+          publiccode: 'publiccode.yml'
+          no-network: true

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -1,4 +1,4 @@
-publiccodeYmlVersion: "0.2"
+publiccodeYmlVersion: "0"
 name: elasticMS
 applicationSuite: elasticMS
 url: https://github.com/ems-project/elasticms
@@ -16,7 +16,6 @@ developmentStatus: stable
 softwareType: standalone/web
 description:
   en:
-    genericName: Content Management System
     shortDescription: Modular open-source headless CMS for public-sector websites
     longDescription: >
       elasticMS is a modular open-source headless CMS designed to manage,


### PR DESCRIPTION
The publiccode.yml had two warnings from the validator. `publiccodeYmlVersion` was outdated and `description.en.genericName` is deprecated.

Also added a GitHub Actions workflow so these issues get caught automatically on future PRs