### PR TITLE
fix(common/search): correct serialization suggest

### DIFF
--- a/EMS/common-bundle/src/Elasticsearch/Response/Response.php
+++ b/EMS/common-bundle/src/Elasticsearch/Response/Response.php
@@ -26,6 +26,8 @@ final class Response implements ResponseInterface
     private bool $accurate = true;
     /** @var array<mixed> */
     private array $aggregations;
+    /** @var array<mixed> */
+    private array $suggest;
 
     /**
      * @param array<mixed> $response
@@ -40,6 +42,7 @@ final class Response implements ResponseInterface
         }
         $this->hits = $response['hits']['hits'] ?? [];
         $this->aggregations = $response['aggregations'] ?? [];
+        $this->suggest = $response['suggest'] ?? [];
         $this->scrollId = $response['_scroll_id'] ?? null;
     }
 
@@ -161,5 +164,13 @@ final class Response implements ResponseInterface
         $response->getData();
 
         return new ResultSet($response, $query, \array_map(fn (array $p) => new Result($p), $this->hits));
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public function getSuggest(): array
+    {
+        return $this->suggest;
     }
 }

--- a/EMS/common-bundle/src/Search/Search.php
+++ b/EMS/common-bundle/src/Search/Search.php
@@ -32,7 +32,8 @@ class Search
     /** @var array<mixed>|null */
     private ?array $sort = null;
     private ?AbstractQuery $postFilter = null;
-    private ?Suggest $suggest = null;
+    /** @var array<mixed> */
+    private array $suggest = [];
     /** @var array<mixed>|null */
     private ?array $highlight = null;
 
@@ -48,7 +49,7 @@ class Search
 
     public function serialize(string $format = 'json'): string
     {
-        return self::getSerializer()->serialize($this, $format, [AbstractNormalizer::IGNORED_ATTRIBUTES => ['query', 'aggregations']]);
+        return self::getSerializer()->serialize($this, $format, [AbstractNormalizer::IGNORED_ATTRIBUTES => ['query', 'aggregations', 'suggest']]);
     }
 
     public static function deserialize(string $data, string $format = 'json'): Search
@@ -290,14 +291,17 @@ class Search
         return $this->postFilter;
     }
 
-    public function getSuggest(): ?Suggest
+    /**
+     * @return array<mixed>
+     */
+    public function getSuggest(): array
     {
         return $this->suggest;
     }
 
     public function setSuggest(?Suggest $suggest): void
     {
-        $this->suggest = $suggest;
+        $this->suggest = $suggest?->toArray() ?? [];
     }
 
     /**

--- a/EMS/common-bundle/src/Service/ElasticaService.php
+++ b/EMS/common-bundle/src/Service/ElasticaService.php
@@ -597,9 +597,8 @@ class ElasticaService
             $query->addAggregation($aggregation);
         }
 
-        $suggest = $search->getSuggest();
-        if (null !== $suggest && \count($suggest) > 0) {
-            $query->setSuggest($suggest);
+        if ([] !== $search->getSuggest()) {
+            $query->setParam('suggest', $search->getSuggest());
         }
 
         $esSearch = new ElasticaSearch($this->client);

--- a/EMS/common-bundle/tests/Unit/Search/SearchAiTest.php
+++ b/EMS/common-bundle/tests/Unit/Search/SearchAiTest.php
@@ -7,6 +7,7 @@ namespace EMS\CommonBundle\Tests\Unit\Common\Search;
 use Elastica\Aggregation\Terms;
 use Elastica\Query\MatchAll;
 use Elastica\Suggest;
+use Elastica\Suggest\Term;
 use EMS\CommonBundle\Search\Search;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Serializer;
@@ -120,8 +121,19 @@ class SearchAiTest extends TestCase
     {
         $search = new Search(['index1']);
         $suggest = new Suggest();
+        $term = new Term('suggestTest', 'title');
+        $term->setText('test');
+        $suggest->addSuggestion($term);
         $search->setSuggest($suggest);
-        $this->assertEquals($suggest, $search->getSuggest());
+
+        $this->assertEquals([
+            'suggest' => [
+                'suggestTest' => [
+                    'term' => ['field' => 'title'],
+                    'text' => 'test',
+                ],
+            ],
+        ], $search->getSuggest());
     }
 
     public function testSetAndGetHighlight(): void


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

When using the search api with `EMS_ELASTICSEARCH_PROXY_API=true`, faced an issue that we are not correctly serializing the suggest on the search object. Also fixed that the suggest is available in the search response when using the emsch search controller.
