### PR TITLE
fix(common/spreadsheets): generate normalized xlsx files

### DIFF
--- a/EMS/common-bundle/src/Common/Spreadsheet/DeterministicXlsxNormalizer.php
+++ b/EMS/common-bundle/src/Common/Spreadsheet/DeterministicXlsxNormalizer.php
@@ -1,0 +1,339 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CommonBundle\Common\Spreadsheet;
+
+use EMS\Helpers\File\TempDirectory;
+
+final class DeterministicXlsxNormalizer
+{
+    private string $fixedIso8601;
+    private int $fixedUnixTime;
+    private string $fixedCreator;
+    private string $fixedLastModifiedBy;
+    private string $fixedCalcId;
+
+    public function __construct(
+        ?\DateTimeImmutable $fixedDate = null,
+        string $fixedCreator = 'Normalized',
+        string $fixedLastModifiedBy = 'Normalized',
+        string $fixedCalcId = '171027'
+    ) {
+        $fixedDate ??= new \DateTimeImmutable('2000-01-01 00:00:00', new \DateTimeZone('UTC'));
+
+        $utcDate = $fixedDate->setTimezone(new \DateTimeZone('UTC'));
+
+        $this->fixedIso8601 = $utcDate->format('Y-m-d\TH:i:s\Z');
+        $this->fixedUnixTime = $utcDate->getTimestamp();
+        $this->fixedCreator = $fixedCreator;
+        $this->fixedLastModifiedBy = $fixedLastModifiedBy;
+        $this->fixedCalcId = $fixedCalcId;
+    }
+
+    public function normalize(string $inputFile, string $outputFile): void
+    {
+        $this->assertEnvironment($inputFile);
+
+        $tempDirectory = TempDirectory::create();
+        $extractDir = $tempDirectory->path;
+
+        try {
+            $this->extractZip($inputFile, $extractDir);
+
+            $this->normalizeCoreXml($extractDir.'/docProps/core.xml');
+            $this->normalizeAppXml($extractDir.'/docProps/app.xml');
+            $this->normalizeWorkbookXml($extractDir.'/xl/workbook.xml');
+            $this->removeIfExists($extractDir.'/xl/calcChain.xml');
+            $this->normalizeContentTypes($extractDir.'/[Content_Types].xml');
+
+            $this->createDeterministicZip($extractDir, $outputFile);
+        } catch (\Throwable $e) {
+            throw new \RuntimeException(\sprintf('Impossible to normalize the file XLSX "%s": %s', $inputFile, $e->getMessage()), 0, $e);
+        }
+    }
+
+    private function assertEnvironment(string $inputFile): void
+    {
+        if (!\is_file($inputFile)) {
+            throw new \RuntimeException(\sprintf('File not found: %s', $inputFile));
+        }
+    }
+
+    private function extractZip(string $zipFile, string $destination): void
+    {
+        $zip = new \ZipArchive();
+        if (true !== $zip->open($zipFile)) {
+            throw new \RuntimeException(\sprintf('Unable to open the ZIP/XLSX: %s', $zipFile));
+        }
+
+        if (!$zip->extractTo($destination)) {
+            $zip->close();
+            throw new \RuntimeException(\sprintf('Unable to extract the ZIP/XLSX: %s', $zipFile));
+        }
+
+        $zip->close();
+    }
+
+    private function normalizeCoreXml(string $file): void
+    {
+        if (!\is_file($file)) {
+            return;
+        }
+
+        $dom = $this->loadXml($file);
+        $xpath = new \DOMXPath($dom);
+
+        $xpath->registerNamespace('cp', 'http://schemas.openxmlformats.org/package/2006/metadata/core-properties');
+        $xpath->registerNamespace('dc', 'http://purl.org/dc/elements/1.1/');
+        $xpath->registerNamespace('dcterms', 'http://purl.org/dc/terms/');
+
+        $this->setSingleNodeValue($xpath, '/cp:coreProperties/dc:creator', $this->fixedCreator);
+        $this->setSingleNodeValue($xpath, '/cp:coreProperties/cp:lastModifiedBy', $this->fixedLastModifiedBy);
+
+        $created = $this->ensureSingleNode(
+            $dom,
+            $xpath,
+            '/cp:coreProperties/dcterms:created',
+            'created',
+            'http://purl.org/dc/terms/',
+            '/cp:coreProperties'
+        );
+        $created->nodeValue = $this->fixedIso8601;
+        $created->setAttributeNS(
+            'http://www.w3.org/2001/XMLSchema-instance',
+            'xsi:type',
+            'dcterms:W3CDTF'
+        );
+
+        $modified = $this->ensureSingleNode(
+            $dom,
+            $xpath,
+            '/cp:coreProperties/dcterms:modified',
+            'modified',
+            'http://purl.org/dc/terms/',
+            '/cp:coreProperties'
+        );
+        $modified->nodeValue = $this->fixedIso8601;
+        $modified->setAttributeNS(
+            'http://www.w3.org/2001/XMLSchema-instance',
+            'xsi:type',
+            'dcterms:W3CDTF'
+        );
+
+        $this->saveXml($dom, $file);
+    }
+
+    private function normalizeAppXml(string $file): void
+    {
+        if (!\is_file($file)) {
+            return;
+        }
+
+        $dom = $this->loadXml($file);
+        $xpath = new \DOMXPath($dom);
+        $xpath->registerNamespace('ep', 'http://schemas.openxmlformats.org/officeDocument/2006/extended-properties');
+
+        $this->setSingleNodeValue($xpath, '/ep:Properties/ep:Manager', '');
+        $this->setSingleNodeValue($xpath, '/ep:Properties/ep:Company', '');
+        $this->setSingleNodeValue($xpath, '/ep:Properties/ep:AppVersion', '1.0');
+
+        $this->saveXml($dom, $file);
+    }
+
+    private function normalizeWorkbookXml(string $file): void
+    {
+        if (!\is_file($file)) {
+            return;
+        }
+
+        $dom = $this->loadXml($file);
+        $xpath = new \DOMXPath($dom);
+        $xpath->registerNamespace('x', 'http://schemas.openxmlformats.org/spreadsheetml/2006/main');
+
+        $calcPr = $this->query($xpath, '/x:workbook/x:calcPr')->item(0);
+
+        if (!$calcPr instanceof \DOMElement) {
+            $workbook = $this->query($xpath, '/x:workbook')->item(0);
+            if ($workbook instanceof \DOMElement) {
+                $calcPr = $dom->createElementNS(
+                    'http://schemas.openxmlformats.org/spreadsheetml/2006/main',
+                    'calcPr'
+                );
+                $workbook->appendChild($calcPr);
+            }
+        }
+
+        if ($calcPr instanceof \DOMElement) {
+            $calcPr->setAttribute('calcId', $this->fixedCalcId);
+            $calcPr->setAttribute('calcMode', 'auto');
+            $calcPr->setAttribute('fullCalcOnLoad', '0');
+            $calcPr->setAttribute('forceFullCalc', '0');
+        }
+
+        $this->saveXml($dom, $file);
+    }
+
+    private function normalizeContentTypes(string $file): void
+    {
+        if (!\is_file($file)) {
+            return;
+        }
+
+        $dom = $this->loadXml($file);
+        $xpath = new \DOMXPath($dom);
+        $xpath->registerNamespace('ct', 'http://schemas.openxmlformats.org/package/2006/content-types');
+
+        $nodes = $xpath->query('/ct:Types/ct:Override[@PartName="/xl/calcChain.xml"]');
+        if (false !== $nodes) {
+            foreach ($nodes as $node) {
+                if (!$node instanceof \DOMNode) {
+                    continue;
+                }
+                $node->parentNode?->removeChild($node);
+            }
+        }
+
+        $this->saveXml($dom, $file);
+    }
+
+    private function createDeterministicZip(string $sourceDir, string $outputFile): void
+    {
+        $files = $this->listFilesRecursively($sourceDir);
+        \sort($files, SORT_STRING);
+
+        $zip = new \ZipArchive();
+        if (true !== $zip->open($outputFile, \ZipArchive::CREATE | \ZipArchive::OVERWRITE)) {
+            throw new \RuntimeException(\sprintf('Unable to created the output file %s', $outputFile));
+        }
+
+        foreach ($files as $absolutePath) {
+            $localName = \str_replace('\\', '/', \substr($absolutePath, \strlen($sourceDir) + 1));
+            $contents = \file_get_contents($absolutePath);
+
+            if (false === $contents) {
+                $zip->close();
+                throw new \RuntimeException(\sprintf('Unable to read the file: %s', $absolutePath));
+            }
+
+            if (!$zip->addFromString($localName, $contents)) {
+                $zip->close();
+                throw new \RuntimeException(\sprintf('Unable to add the ZIP: %s', $localName));
+            }
+
+            $zip->setMtimeName($localName, $this->fixedUnixTime);
+        }
+
+        $zip->close();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function listFilesRecursively(string $dir): array
+    {
+        $result = [];
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::LEAVES_ONLY
+        );
+
+        /** @var \SplFileInfo $fileInfo */
+        foreach ($iterator as $fileInfo) {
+            if ($fileInfo->isFile()) {
+                $result[] = $fileInfo->getPathname();
+            }
+        }
+
+        return $result;
+    }
+
+    private function loadXml(string $file): \DOMDocument
+    {
+        $xml = \file_get_contents($file);
+        if (false === $xml) {
+            throw new \RuntimeException(\sprintf('Unable to read the XML: %s', $file));
+        }
+
+        $dom = new \DOMDocument('1.0', 'UTF-8');
+        $dom->preserveWhiteSpace = false;
+        $dom->formatOutput = false;
+
+        \libxml_use_internal_errors(true);
+        $ok = $dom->loadXML($xml, LIBXML_NONET | LIBXML_NOBLANKS);
+
+        if (!$ok) {
+            $errors = \libxml_get_errors();
+            \libxml_clear_errors();
+            $message = isset($errors[0]) ? \trim($errors[0]->message) : 'Invalid XML';
+            throw new \RuntimeException(\sprintf('Impossible to parse the XML "%s": %s', $file, $message));
+        }
+
+        return $dom;
+    }
+
+    private function saveXml(\DOMDocument $dom, string $file): void
+    {
+        $xml = $dom->saveXML();
+        if (false === $xml) {
+            throw new \RuntimeException(\sprintf('Impossible to serialize the XML: %s', $file));
+        }
+
+        if (false === \file_put_contents($file, $xml)) {
+            throw new \RuntimeException(\sprintf('Impossible to write the XML: %s', $file));
+        }
+    }
+
+    private function setSingleNodeValue(\DOMXPath $xpath, string $query, string $value): void
+    {
+        $node = $this->query($xpath, $query)->item(0);
+        if ($node instanceof \DOMNode) {
+            $node->nodeValue = $value;
+        }
+    }
+
+    private function ensureSingleNode(
+        \DOMDocument $dom,
+        \DOMXPath $xpath,
+        string $query,
+        string $localName,
+        string $namespace,
+        string $parentQuery
+    ): \DOMElement {
+        $node = $this->query($xpath, $query)->item(0);
+        if ($node instanceof \DOMElement) {
+            return $node;
+        }
+
+        $parent = $this->query($xpath, $parentQuery)->item(0);
+        if (!$parent instanceof \DOMElement) {
+            throw new \RuntimeException(\sprintf('Unfindable parent XML for %s', $query));
+        }
+
+        $newNode = $dom->createElementNS($namespace, $localName);
+        $parent->appendChild($newNode);
+
+        return $newNode;
+    }
+
+    private function removeIfExists(string $file): void
+    {
+        if (\is_file($file) && !\unlink($file)) {
+            throw new \RuntimeException(\sprintf('Impossible to delete the file: %s', $file));
+        }
+    }
+
+    /**
+     * @return \DOMNodeList<\DOMNameSpaceNode|\DOMNode>
+     */
+    private function query(\DOMXPath $xpath, string $query): \DOMNodeList
+    {
+        $result = $xpath->query($query);
+        if (!$result) {
+            throw new \RuntimeException(\sprintf('Unreadable field %s', $query));
+        }
+
+        return $result;
+    }
+}

--- a/EMS/common-bundle/src/Common/Spreadsheet/SpreadsheetGeneratorService.php
+++ b/EMS/common-bundle/src/Common/Spreadsheet/SpreadsheetGeneratorService.php
@@ -30,15 +30,15 @@ use Symfony\Component\Serializer\Serializer;
 final class SpreadsheetGeneratorService implements SpreadsheetGeneratorServiceInterface
 {
     /**
-     * @param array{writer: string, filename: string, disposition: string, sheets: array<mixed>, creator: string} $config
+     * @param array{writer: string, filename: string, disposition: string, sheets: array<mixed>, creator: string, normalized: bool} $config
      */
     #[\Override]
-    public function generateSpreadsheetFile(array $config, string $filename, bool $normalized = false): void
+    public function generateSpreadsheetFile(array $config, string $filename): void
     {
         $config = $this->resolveOptions($config);
 
         match ($config[self::WRITER]) {
-            self::XLSX_WRITER => $this->getXlsxStreamedFile($config, $filename, $normalized),
+            self::XLSX_WRITER => $this->getXlsxStreamedFile($config, $filename),
             self::CSV_WRITER => $this->getCsvStreamedFile($config, $filename),
             default => throw new \RuntimeException('Unknown Spreadsheet writer'),
         };
@@ -131,6 +131,14 @@ final class SpreadsheetGeneratorService implements SpreadsheetGeneratorServiceIn
         if (isset($config['active_sheet'])) {
             $spreadsheet->setActiveSheetIndex($config['active_sheet']);
         }
+        $spreadsheet->getProperties()
+            ->setCreator($config[self::CREATOR])
+            ->setLastModifiedBy($config[self::CREATOR]);
+        if ($config[self::NORMALIZED]) {
+            $spreadsheet->getProperties()
+                ->setCreated('2000-01-01 00:00:00')
+                ->setModified('2000-01-01 00:00:00');
+        }
 
         return $spreadsheet;
     }
@@ -166,6 +174,7 @@ final class SpreadsheetGeneratorService implements SpreadsheetGeneratorServiceIn
         return [
             self::CONTENT_FILENAME => 'spreadsheet',
             self::CREATOR => 'Normalized',
+            self::NORMALIZED => false,
             self::CONTENT_DISPOSITION => 'attachment',
             self::WRITER => self::XLSX_WRITER,
             self::CSV_SEPARATOR => ',',
@@ -177,7 +186,7 @@ final class SpreadsheetGeneratorService implements SpreadsheetGeneratorServiceIn
     /**
      * @param array<mixed> $config
      *
-     * @return array{writer: string, filename: string, disposition: string, sheets: array<mixed>, csv_separator: string, creator: string}
+     * @return array{writer: string, filename: string, disposition: string, sheets: array<mixed>, csv_separator: string, creator: string, normalized: bool}
      */
     private function resolveOptions(array $config): array
     {
@@ -185,14 +194,15 @@ final class SpreadsheetGeneratorService implements SpreadsheetGeneratorServiceIn
 
         $resolver = new OptionsResolver();
         $resolver->setDefaults($defaults);
-        $resolver->setRequired([self::WRITER, self::CONTENT_FILENAME, self::SHEETS, self::CONTENT_DISPOSITION, self::CREATOR]);
+        $resolver->setRequired([self::WRITER, self::CONTENT_FILENAME, self::SHEETS, self::CONTENT_DISPOSITION, self::CREATOR, self::NORMALIZED]);
         $resolver->setAllowedTypes(self::CONTENT_DISPOSITION, ['string']);
         $resolver->setAllowedTypes(self::CREATOR, ['string']);
+        $resolver->setAllowedTypes(self::NORMALIZED, ['boolean']);
         $resolver->setAllowedValues(self::WRITER, [self::XLSX_WRITER, self::CSV_WRITER]);
         $resolver->setAllowedValues(self::CONTENT_DISPOSITION, ['attachment', 'inline']);
         $resolver->setAllowedValues(self::VALUE_BINDER, [null, 'string', 'advanced']);
 
-        /** @var array{writer: string, filename: string, disposition: string, sheets: array<mixed>, csv_separator: string, creator: string} $resolved */
+        /** @var array{writer: string, filename: string, disposition: string, sheets: array<mixed>, csv_separator: string, creator: string, normalized: bool} $resolved */
         $resolved = $resolver->resolve($config);
 
         return $resolved;
@@ -230,20 +240,13 @@ final class SpreadsheetGeneratorService implements SpreadsheetGeneratorServiceIn
     }
 
     /**
-     * @param array{writer: string, filename: string, disposition: string, sheets: array<mixed>, creator: string} $config
+     * @param array{writer: string, filename: string, disposition: string, sheets: array<mixed>, creator: string, normalized: bool} $config
      */
-    private function getXlsxStreamedFile(array $config, string $filename, bool $normalized): void
+    private function getXlsxStreamedFile(array $config, string $filename): void
     {
         $spreadsheet = $this->buildUpSheets($config);
-        if ($normalized) {
-            $spreadsheet->getProperties()
-                ->setCreator($config[self::CREATOR])
-                ->setLastModifiedBy($config[self::CREATOR])
-                ->setCreated('2000-01-01 00:00:00')
-                ->setModified('2000-01-01 00:00:00');
-        }
         $writer = new Xlsx($spreadsheet);
-        if (!$normalized) {
+        if (!$config[self::NORMALIZED]) {
             $writer->save($filename);
 
             return;

--- a/EMS/common-bundle/src/Common/Spreadsheet/SpreadsheetGeneratorService.php
+++ b/EMS/common-bundle/src/Common/Spreadsheet/SpreadsheetGeneratorService.php
@@ -30,7 +30,7 @@ use Symfony\Component\Serializer\Serializer;
 final class SpreadsheetGeneratorService implements SpreadsheetGeneratorServiceInterface
 {
     /**
-     * @param array{writer: string, filename: string, disposition: string, sheets: array<mixed>, creator: string, normalized: bool} $config
+     * @param array{writer: string, filename: string, disposition: string, sheets: array<mixed>, creator?: string, normalized?: bool} $config
      */
     #[\Override]
     public function generateSpreadsheetFile(array $config, string $filename): void

--- a/EMS/common-bundle/src/Common/Spreadsheet/SpreadsheetGeneratorService.php
+++ b/EMS/common-bundle/src/Common/Spreadsheet/SpreadsheetGeneratorService.php
@@ -30,7 +30,7 @@ use Symfony\Component\Serializer\Serializer;
 final class SpreadsheetGeneratorService implements SpreadsheetGeneratorServiceInterface
 {
     /**
-     * @param array{writer: string, filename: string, disposition: string, sheets: array<mixed>} $config
+     * @param array{writer: string, filename: string, disposition: string, sheets: array<mixed>, creator: string} $config
      */
     #[\Override]
     public function generateSpreadsheetFile(array $config, string $filename, bool $normalized = false): void
@@ -165,6 +165,7 @@ final class SpreadsheetGeneratorService implements SpreadsheetGeneratorServiceIn
     {
         return [
             self::CONTENT_FILENAME => 'spreadsheet',
+            self::CREATOR => 'Normalized',
             self::CONTENT_DISPOSITION => 'attachment',
             self::WRITER => self::XLSX_WRITER,
             self::CSV_SEPARATOR => ',',
@@ -176,7 +177,7 @@ final class SpreadsheetGeneratorService implements SpreadsheetGeneratorServiceIn
     /**
      * @param array<mixed> $config
      *
-     * @return array{writer: string, filename: string, disposition: string, sheets: array<mixed>, csv_separator: string}
+     * @return array{writer: string, filename: string, disposition: string, sheets: array<mixed>, csv_separator: string, creator: string}
      */
     private function resolveOptions(array $config): array
     {
@@ -184,13 +185,14 @@ final class SpreadsheetGeneratorService implements SpreadsheetGeneratorServiceIn
 
         $resolver = new OptionsResolver();
         $resolver->setDefaults($defaults);
-        $resolver->setRequired([self::WRITER, self::CONTENT_FILENAME, self::SHEETS, self::CONTENT_DISPOSITION]);
+        $resolver->setRequired([self::WRITER, self::CONTENT_FILENAME, self::SHEETS, self::CONTENT_DISPOSITION, self::CREATOR]);
         $resolver->setAllowedTypes(self::CONTENT_DISPOSITION, ['string']);
+        $resolver->setAllowedTypes(self::CREATOR, ['string']);
         $resolver->setAllowedValues(self::WRITER, [self::XLSX_WRITER, self::CSV_WRITER]);
         $resolver->setAllowedValues(self::CONTENT_DISPOSITION, ['attachment', 'inline']);
         $resolver->setAllowedValues(self::VALUE_BINDER, [null, 'string', 'advanced']);
 
-        /** @var array{writer: string, filename: string, disposition: string, sheets: array<mixed>, csv_separator: string} $resolved */
+        /** @var array{writer: string, filename: string, disposition: string, sheets: array<mixed>, csv_separator: string, creator: string} $resolved */
         $resolved = $resolver->resolve($config);
 
         return $resolved;
@@ -228,15 +230,15 @@ final class SpreadsheetGeneratorService implements SpreadsheetGeneratorServiceIn
     }
 
     /**
-     * @param array{writer: string, filename: string, disposition: string, sheets: array<mixed>} $config
+     * @param array{writer: string, filename: string, disposition: string, sheets: array<mixed>, creator: string} $config
      */
     private function getXlsxStreamedFile(array $config, string $filename, bool $normalized): void
     {
         $spreadsheet = $this->buildUpSheets($config);
         if ($normalized) {
             $spreadsheet->getProperties()
-                ->setCreator('Normalized')
-                ->setLastModifiedBy('Normalized')
+                ->setCreator($config[self::CREATOR])
+                ->setLastModifiedBy($config[self::CREATOR])
                 ->setCreated('2000-01-01 00:00:00')
                 ->setModified('2000-01-01 00:00:00');
         }

--- a/EMS/common-bundle/src/Common/Spreadsheet/SpreadsheetGeneratorService.php
+++ b/EMS/common-bundle/src/Common/Spreadsheet/SpreadsheetGeneratorService.php
@@ -33,12 +33,12 @@ final class SpreadsheetGeneratorService implements SpreadsheetGeneratorServiceIn
      * @param array{writer: string, filename: string, disposition: string, sheets: array<mixed>} $config
      */
     #[\Override]
-    public function generateSpreadsheetFile(array $config, string $filename): void
+    public function generateSpreadsheetFile(array $config, string $filename, bool $normalized = false): void
     {
         $config = $this->resolveOptions($config);
 
         match ($config[self::WRITER]) {
-            self::XLSX_WRITER => $this->getXlsxStreamedFile($config, $filename),
+            self::XLSX_WRITER => $this->getXlsxStreamedFile($config, $filename, $normalized),
             self::CSV_WRITER => $this->getCsvStreamedFile($config, $filename),
             default => throw new \RuntimeException('Unknown Spreadsheet writer'),
         };
@@ -230,11 +230,31 @@ final class SpreadsheetGeneratorService implements SpreadsheetGeneratorServiceIn
     /**
      * @param array{writer: string, filename: string, disposition: string, sheets: array<mixed>} $config
      */
-    private function getXlsxStreamedFile(array $config, string $filename): void
+    private function getXlsxStreamedFile(array $config, string $filename, bool $normalized): void
     {
         $spreadsheet = $this->buildUpSheets($config);
+        if ($normalized) {
+            $spreadsheet->getProperties()
+                ->setCreator('Normalized')
+                ->setLastModifiedBy('Normalized')
+                ->setCreated('2000-01-01 00:00:00')
+                ->setModified('2000-01-01 00:00:00');
+        }
         $writer = new Xlsx($spreadsheet);
-        $writer->save($filename);
+        if (!$normalized) {
+            $writer->save($filename);
+
+            return;
+        }
+
+        $tempFile = TempFile::create();
+        $writer->setPreCalculateFormulas(false);
+        $writer->save($tempFile->path);
+        $normalizer = new DeterministicXlsxNormalizer();
+        $normalizer->normalize(
+            $tempFile->path,
+            $filename
+        );
     }
 
     /**

--- a/EMS/common-bundle/src/Contracts/Spreadsheet/SpreadsheetGeneratorServiceInterface.php
+++ b/EMS/common-bundle/src/Contracts/Spreadsheet/SpreadsheetGeneratorServiceInterface.php
@@ -23,7 +23,7 @@ interface SpreadsheetGeneratorServiceInterface
     /**
      * @param array<mixed> $config
      */
-    public function generateSpreadsheetFile(array $config, string $filename): void;
+    public function generateSpreadsheetFile(array $config, string $filename, bool $normalized = false): void;
 
     /**
      * @param array<mixed> $config

--- a/EMS/common-bundle/src/Contracts/Spreadsheet/SpreadsheetGeneratorServiceInterface.php
+++ b/EMS/common-bundle/src/Contracts/Spreadsheet/SpreadsheetGeneratorServiceInterface.php
@@ -17,6 +17,7 @@ interface SpreadsheetGeneratorServiceInterface
     public const string CSV_SEPARATOR = 'csv_separator';
     public const string SHEETS = 'sheets';
     public const string CONTENT_FILENAME = 'filename';
+    public const string CREATOR = 'creator';
     public const string CONTENT_DISPOSITION = 'disposition';
     public const string VALUE_BINDER = 'value_binder';
 

--- a/EMS/common-bundle/src/Contracts/Spreadsheet/SpreadsheetGeneratorServiceInterface.php
+++ b/EMS/common-bundle/src/Contracts/Spreadsheet/SpreadsheetGeneratorServiceInterface.php
@@ -18,13 +18,14 @@ interface SpreadsheetGeneratorServiceInterface
     public const string SHEETS = 'sheets';
     public const string CONTENT_FILENAME = 'filename';
     public const string CREATOR = 'creator';
+    public const string NORMALIZED = 'normalized';
     public const string CONTENT_DISPOSITION = 'disposition';
     public const string VALUE_BINDER = 'value_binder';
 
     /**
      * @param array<mixed> $config
      */
-    public function generateSpreadsheetFile(array $config, string $filename, bool $normalized = false): void;
+    public function generateSpreadsheetFile(array $config, string $filename): void;
 
     /**
      * @param array<mixed> $config

--- a/EMS/common-bundle/tests/Unit/Common/SpreadsheetGeneratorTest.php
+++ b/EMS/common-bundle/tests/Unit/Common/SpreadsheetGeneratorTest.php
@@ -96,13 +96,18 @@ class SpreadsheetGeneratorTest extends TestCase
         $tempFile = TempFile::create();
         $sheetParams = [
             SpreadsheetGeneratorServiceInterface::WRITER => SpreadsheetGeneratorServiceInterface::XLSX_WRITER,
+            SpreadsheetGeneratorServiceInterface::CREATOR => 'SpreadsheetGeneratorTest',
             SpreadsheetGeneratorServiceInterface::SHEETS => [[
                 'rows' => [['A1', 'B1']],
                 'name' => 'Worksheet',
             ]]];
         $this->spreadSheetGenerator->generateSpreadsheetFile($sheetParams, $tempFile->path, true);
         $hash = \hash_file('sha256', $tempFile->path);
-        $this->assertSame('a2c719036576bcf6eac53ee44db09566fca058c4eaaf7e57046b266b305ea42d', $hash);
+
+        $tempFile = TempFile::create();
+        $this->spreadSheetGenerator->generateSpreadsheetFile($sheetParams, $tempFile->path, true);
+        $hash2 = \hash_file('sha256', $tempFile->path);
+        $this->assertSame($hash2, $hash);
     }
 
     /**

--- a/EMS/common-bundle/tests/Unit/Common/SpreadsheetGeneratorTest.php
+++ b/EMS/common-bundle/tests/Unit/Common/SpreadsheetGeneratorTest.php
@@ -91,21 +91,22 @@ class SpreadsheetGeneratorTest extends TestCase
         $this->assertSame('', $lines[3]);
     }
 
-    public function testSameHash(): void
+    public function testNormalizedXlsx(): void
     {
         $tempFile = TempFile::create();
         $sheetParams = [
             SpreadsheetGeneratorServiceInterface::WRITER => SpreadsheetGeneratorServiceInterface::XLSX_WRITER,
             SpreadsheetGeneratorServiceInterface::CREATOR => 'SpreadsheetGeneratorTest',
+            SpreadsheetGeneratorServiceInterface::NORMALIZED => true,
             SpreadsheetGeneratorServiceInterface::SHEETS => [[
                 'rows' => [['A1', 'B1']],
                 'name' => 'Worksheet',
             ]]];
-        $this->spreadSheetGenerator->generateSpreadsheetFile($sheetParams, $tempFile->path, true);
+        $this->spreadSheetGenerator->generateSpreadsheetFile($sheetParams, $tempFile->path);
         $hash = \hash_file('sha256', $tempFile->path);
 
         $tempFile = TempFile::create();
-        $this->spreadSheetGenerator->generateSpreadsheetFile($sheetParams, $tempFile->path, true);
+        $this->spreadSheetGenerator->generateSpreadsheetFile($sheetParams, $tempFile->path);
         $hash2 = \hash_file('sha256', $tempFile->path);
         $this->assertSame($hash2, $hash);
     }

--- a/EMS/common-bundle/tests/Unit/Common/SpreadsheetGeneratorTest.php
+++ b/EMS/common-bundle/tests/Unit/Common/SpreadsheetGeneratorTest.php
@@ -6,6 +6,8 @@ namespace EMS\CommonBundle\Tests\Unit\Common;
 
 use EMS\CommonBundle\Common\Spreadsheet\SpreadsheetGeneratorService;
 use EMS\CommonBundle\Common\Spreadsheet\SpreadsheetValidation;
+use EMS\CommonBundle\Contracts\Spreadsheet\SpreadsheetGeneratorServiceInterface;
+use EMS\Helpers\File\TempFile;
 use PhpOffice\PhpSpreadsheet\Shared\Date;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -87,6 +89,20 @@ class SpreadsheetGeneratorTest extends TestCase
         $this->assertSame('pineapple,strawberry', $lines[1]);
         $this->assertSame('"àï$@,& & "" \' ! @ # $ €",foobar', $lines[2]);
         $this->assertSame('', $lines[3]);
+    }
+
+    public function testSameHash(): void
+    {
+        $tempFile = TempFile::create();
+        $sheetParams = [
+            SpreadsheetGeneratorServiceInterface::WRITER => SpreadsheetGeneratorServiceInterface::XLSX_WRITER,
+            SpreadsheetGeneratorServiceInterface::SHEETS => [[
+                'rows' => [['A1', 'B1']],
+                'name' => 'Worksheet',
+            ]]];
+        $this->spreadSheetGenerator->generateSpreadsheetFile($sheetParams, $tempFile->path, true);
+        $hash = \hash_file('sha256', $tempFile->path);
+        $this->assertSame('a2c719036576bcf6eac53ee44db09566fca058c4eaaf7e57046b266b305ea42d', $hash);
     }
 
     /**

--- a/EMS/common-bundle/tests/Unit/Common/SpreadsheetGeneratorTest.php
+++ b/EMS/common-bundle/tests/Unit/Common/SpreadsheetGeneratorTest.php
@@ -25,18 +25,18 @@ class SpreadsheetGeneratorTest extends TestCase
 
     public function testConfigToExcel(): void
     {
-        $config = \json_decode('{"filename":"export","writer":"xlsx","active_sheet":0,"sheets":[{"name":"Export form","color":"#FF0000","rows":[["apple","banana"],["pineapple","strawberry"]]},{"name":"Export form sheet 2","rows":[["a1","a2"],["b1","b3"]]}]}', true);
+        $config = \json_decode('{"normalized":false,"creator": "Creator","filename":"export","writer":"xlsx","active_sheet":0,"sheets":[{"name":"Export form","color":"#FF0000","rows":[["apple","banana"],["pineapple","strawberry"]]},{"name":"Export form sheet 2","rows":[["a1","a2"],["b1","b3"]]}]}', true);
         $this->assertSame('Export form', $this->callMethod($this->spreadSheetGenerator, 'buildUpSheets', [$config])->getActiveSheet()->getTitle());
         $this->assertSame('pineapple', $this->callMethod($this->spreadSheetGenerator, 'buildUpSheets', [$config])->getActiveSheet()->getCell('A2')->getValue());
 
-        $configColor = \json_decode('{"filename":"export_with_color","writer":"xlsx","active_sheet":0,"sheets":[{"name":"Export form with Color","color":"#FF0000","rows":[[{"data":"apple"},{"data":"banana","style":{"fill":{"fillType":"solid","color":{"rgb":"F9D73F"}}}}],[{"data":"pineapple","style":{"fill":{"fillType":"solid","color":{"rgb":"F9D73F"}}}},{"data":"strawberry","style":{}}]]}]}', true);
+        $configColor = \json_decode('{"normalized":false,"creator": "Creator","filename":"export_with_color","writer":"xlsx","active_sheet":0,"sheets":[{"name":"Export form with Color","color":"#FF0000","rows":[[{"data":"apple"},{"data":"banana","style":{"fill":{"fillType":"solid","color":{"rgb":"F9D73F"}}}}],[{"data":"pineapple","style":{"fill":{"fillType":"solid","color":{"rgb":"F9D73F"}}}},{"data":"strawberry","style":{}}]]}]}', true);
         $this->assertSame('Export form with Color', $this->callMethod($this->spreadSheetGenerator, 'buildUpSheets', [$configColor])->getActiveSheet()->getTitle());
         $this->assertSame('pineapple', $this->callMethod($this->spreadSheetGenerator, 'buildUpSheets', [$configColor])->getActiveSheet()->getCell('A2')->getValue());
     }
 
     public function testConfigWithTypeToExcel(): void
     {
-        $config = \json_decode('{"filename":"export","writer":"xlsx","active_sheet":0,"sheets":[{"name":"Export form","color":"#FF0000","rows":[[{"data":"123","type":"s"},{"data":"apple"}],[{"data":"123"},{"data":"banana"}],[{"data":"23/08/2025","type":"date","format_input": "d/m/Y","format_display": "dd/mm/yyyy"},{"data":"banana"}]]}]}', true);
+        $config = \json_decode('{"normalized":false,"creator": "Creator","filename":"export","writer":"xlsx","active_sheet":0,"sheets":[{"name":"Export form","color":"#FF0000","rows":[[{"data":"123","type":"s"},{"data":"apple"}],[{"data":"123"},{"data":"banana"}],[{"data":"23/08/2025","type":"date","format_input": "d/m/Y","format_display": "dd/mm/yyyy"},{"data":"banana"}]]}]}', true);
         $this->assertSame('Export form', $this->callMethod($this->spreadSheetGenerator, 'buildUpSheets', [$config])->getActiveSheet()->getTitle());
         $this->assertIsString($this->callMethod($this->spreadSheetGenerator, 'buildUpSheets', [$config])->getActiveSheet()->getCell('A1')->getValue());
         $this->assertIsInt($this->callMethod($this->spreadSheetGenerator, 'buildUpSheets', [$config])->getActiveSheet()->getCell('A2')->getValue());
@@ -56,14 +56,14 @@ class SpreadsheetGeneratorTest extends TestCase
             'show_error' => true,
         ]);
 
-        $config = \json_decode('{"filename":"export","writer":"xlsx","active_sheet":0,"sheets":[{"name":"Export form","color":"#FF0000","rows":[["apple","low"],["pineapple",""]]},{"name":"Export form sheet 2","rows":[["a1",""],["b2",""]]}]}', true);
+        $config = \json_decode('{"normalized":false,"creator": "Creator","filename":"export","writer":"xlsx","active_sheet":0,"sheets":[{"name":"Export form","color":"#FF0000","rows":[["apple","low"],["pineapple",""]]},{"name":"Export form sheet 2","rows":[["a1",""],["b2",""]]}]}', true);
         foreach ($config['sheets'] as $index => $sheet) {
             $config['sheets'][$index] = \array_merge($sheet, ['validations' => [null, $validation]]);
         }
         $this->assertSame('Export form', $this->callMethod($this->spreadSheetGenerator, 'buildUpSheets', [$config])->getActiveSheet()->getTitle());
         $this->assertSame('pineapple', $this->callMethod($this->spreadSheetGenerator, 'buildUpSheets', [$config])->getActiveSheet()->getCell('A2')->getValue());
 
-        $configColor = \json_decode('{"filename":"export_with_color","writer":"xlsx","active_sheet":0,"sheets":[{"name":"Export form with Color","color":"#FF0000","rows":[[{"data":"apple"},{"data":"low","style":{"fill":{"fillType":"solid","color":{"rgb":"F9D73F"}}}}],[{"data":"pineapple","style":{"fill":{"fillType":"solid","color":{"rgb":"F9D73F"}}}},{"data":"","style":{}}]]}]}', true);
+        $configColor = \json_decode('{"normalized":false,"creator": "Creator","filename":"export_with_color","writer":"xlsx","active_sheet":0,"sheets":[{"name":"Export form with Color","color":"#FF0000","rows":[[{"data":"apple"},{"data":"low","style":{"fill":{"fillType":"solid","color":{"rgb":"F9D73F"}}}}],[{"data":"pineapple","style":{"fill":{"fillType":"solid","color":{"rgb":"F9D73F"}}}},{"data":"","style":{}}]]}]}', true);
         foreach ($configColor['sheets'] as $index => $sheet) {
             $configColor['sheets'][$index] = \array_merge($sheet, ['validations' => [null, $validation]]);
         }

--- a/docs/dev/common-bundle/spreadsheet.md
+++ b/docs/dev/common-bundle/spreadsheet.md
@@ -2,15 +2,21 @@
 
 In Twig you can set the spreadsheet options by generating a JSON
 
-Two writer are supported:
+Two `writer` are supported:
 
 - `xlsx`: Generate a Microsoft Excel file
 - `csv`: Generate a CSV file
+
+The `normalized` configuration attribute, when set to true, generates a deterministic Microsoft Excel file. This is useful to avoid duplicates in storage services.
+
+The `creator` configuration attribute is used to set the creator metadata field of the Microsoft Excel file.
 
 ```twig
 {% set config = {
     "filename": "custom-filename",
     "disposition": "attachment",
+    "creator": "Creator Name",
+    "normalized": false,
     "writer": "xlsx",
     "value_binder": "string",
     "sheets": [


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | y  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

For econologic reasons, it can make sense to generate normalized xlsx files (same input ==> xsls files with same hash)