### PR TITLE
fix(admin/form-submissions): add batch size on delete (avoid out of memory)

### DIFF
--- a/EMS/core-bundle/src/Repository/FormSubmissionFileRepository.php
+++ b/EMS/core-bundle/src/Repository/FormSubmissionFileRepository.php
@@ -39,20 +39,43 @@ class FormSubmissionFileRepository extends ServiceEntityRepository
         return $qb->getQuery()->getOneOrNullResult();
     }
 
-    public function removeExpiredSubmissionAttachments(): int
+    public function removeExpiredSubmissionAttachments(int $batchSize = 1000): int
     {
         $now = new \DateTimeImmutable();
-        $qb = $this->createQueryBuilder('f')
-            ->delete()
-            ->where(\sprintf(
-                'EXISTS (
+        $totalDeleted = 0;
+
+        do {
+            $ids = $this->createQueryBuilder('f')
+                ->select('f.id')
+                ->where(\sprintf(
+                    'EXISTS (
                     SELECT 1 FROM %s s
                     WHERE s = f.formSubmission AND s.expireDate < :now
                 )',
-                FormSubmission::class
-            ))
-            ->setParameter('now', $now);
+                    FormSubmission::class
+                ))
+                ->setParameter('now', $now)
+                ->setMaxResults($batchSize)
+                ->orderBy('f.created', 'ASC')
+                ->getQuery()
+                ->getSingleColumnResult();
 
-        return $qb->getQuery()->execute();
+            if ([] === $ids) {
+                break;
+            }
+
+            $deleted = $this->createQueryBuilder('f')
+                ->delete()
+                ->where('f.id IN (:ids)')
+                ->setParameter('ids', $ids)
+                ->getQuery()
+                ->execute();
+
+            $totalDeleted += $deleted;
+
+            $this->getEntityManager()->clear();
+        } while (\count($ids) === $batchSize);
+
+        return $totalDeleted;
     }
 }

--- a/EMS/core-bundle/src/Repository/FormSubmissionRepository.php
+++ b/EMS/core-bundle/src/Repository/FormSubmissionRepository.php
@@ -85,31 +85,73 @@ class FormSubmissionRepository extends ServiceEntityRepository
         return (int) $qb->getQuery()->getSingleScalarResult();
     }
 
-    public function deleteAllExpiredSubmission(): int
+    public function deleteAllExpiredSubmission(int $batchSize = 1000): int
     {
         $now = new \DateTimeImmutable();
+        $totalDeleted = 0;
 
-        return $this->createQueryBuilder('fs')
-            ->delete()
-            ->where('fs.expireDate < :now')
-            ->setParameter('now', $now)
-            ->getQuery()
-            ->execute();
+        do {
+            $ids = $this->createQueryBuilder('fs')
+                ->select('fs.id')
+                ->where('fs.expireDate < :now')
+                ->setParameter('now', $now)
+                ->setMaxResults($batchSize)
+                ->getQuery()
+                ->getSingleColumnResult();
+
+            if ([] === $ids) {
+                break;
+            }
+
+            $deleted = $this->createQueryBuilder('fs')
+                ->delete()
+                ->where('fs.id IN (:ids)')
+                ->setParameter('ids', $ids)
+                ->getQuery()
+                ->execute();
+
+            $totalDeleted += $deleted;
+
+            $this->getEntityManager()->clear();
+        } while (\count($ids) === $batchSize);
+
+        return $totalDeleted;
     }
 
-    public function clearDataOnExpiredSubmissions(): int
+    public function clearDataOnExpiredSubmissions(int $batchSize = 1000): int
     {
         $now = new \DateTimeImmutable();
+        $totalUpdated = 0;
 
-        return $this->createQueryBuilder('fs')
-            ->update()
-            ->set('fs.data', ':nullValue')
-            ->where('fs.expireDate < :now')
-            ->andWhere('fs.data IS NOT NULL')
-            ->setParameter('now', $now)
-            ->setParameter('nullValue', null)
-            ->getQuery()
-            ->execute();
+        do {
+            $ids = $this->createQueryBuilder('fs')
+                ->select('fs.id')
+                ->where('fs.expireDate < :now')
+                ->andWhere('fs.data IS NOT NULL')
+                ->setParameter('now', $now)
+                ->setMaxResults($batchSize)
+                ->getQuery()
+                ->getSingleColumnResult();
+
+            if ([] === $ids) {
+                break;
+            }
+
+            $updated = $this->createQueryBuilder('fs')
+                ->update()
+                ->set('fs.data', ':nullValue')
+                ->where('fs.id IN (:ids)')
+                ->setParameter('now', $now)
+                ->setParameter('ids', $ids)
+                ->getQuery()
+                ->execute();
+
+            $totalUpdated += $updated;
+
+            $this->getEntityManager()->clear();
+        } while (\count($ids) === $batchSize);
+
+        return $totalUpdated;
     }
 
     /**


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   |  n |
| BC breaks?     |  n |
| Deprecations?  |  n |
| Fixed tickets? |  n |
| Documentation? | n  |

Deleting table with too many records with a single query might be memory consuming
