### PR TITLE
feat(admin/contenttype): add unwrap for html attribute transformer

### DIFF
--- a/EMS/core-bundle/src/Core/ContentType/Transformer/HtmlAttributeTransformer.php
+++ b/EMS/core-bundle/src/Core/ContentType/Transformer/HtmlAttributeTransformer.php
@@ -17,9 +17,9 @@ final class HtmlAttributeTransformer extends BaseHtmlTransformer
     }
 
     #[\Override]
-    public function supports(string $class): bool
+    public function supports(string $fieldTypeClass): bool
     {
-        return WysiwygFieldType::class === $class;
+        return WysiwygFieldType::class === $fieldTypeClass;
     }
 
     #[\Override]

--- a/EMS/core-bundle/src/Core/ContentType/Transformer/HtmlAttributeTransformer.php
+++ b/EMS/core-bundle/src/Core/ContentType/Transformer/HtmlAttributeTransformer.php
@@ -10,6 +10,15 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class HtmlAttributeTransformer extends BaseHtmlTransformer
 {
+    /** @var list<string> */
+    private const array UNWRAP_BLACKLIST = [
+        'table', 'thead', 'tbody', 'tfoot', 'tr', 'td', 'th',
+        'ul', 'ol', 'li', 'dl', 'dt', 'dd',
+        'p', 'section', 'article', 'header', 'footer', 'nav', 'aside',
+        'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+        'figure', 'figcaption', 'blockquote', 'pre',
+    ];
+
     #[\Override]
     public function getName(): string
     {
@@ -25,7 +34,7 @@ final class HtmlAttributeTransformer extends BaseHtmlTransformer
     #[\Override]
     public function transform(TransformContext $context): void
     {
-        if (null == $data = $context->getData()) {
+        if (null === $context->getData()) {
             return;
         }
 
@@ -70,6 +79,9 @@ final class HtmlAttributeTransformer extends BaseHtmlTransformer
 
         foreach ($this->crawl($crawler, $xpath) as $element) {
             $element->removeAttribute($attribute);
+            if (0 === $element->attributes->length) {
+                $this->unwrap($element);
+            }
             ++$result;
         }
 
@@ -120,6 +132,9 @@ final class HtmlAttributeTransformer extends BaseHtmlTransformer
 
             if (0 === \count($filter)) {
                 $element->removeAttribute('class');
+                if (0 === $element->attributes->length) {
+                    $this->unwrap($element);
+                }
                 continue;
             }
 
@@ -154,6 +169,9 @@ final class HtmlAttributeTransformer extends BaseHtmlTransformer
 
             if (0 === \count($filter)) {
                 $element->removeAttribute('style');
+                if (0 === $element->attributes->length) {
+                    $this->unwrap($element);
+                }
                 continue;
             }
 
@@ -162,5 +180,39 @@ final class HtmlAttributeTransformer extends BaseHtmlTransformer
         }
 
         return $result;
+    }
+
+    private function unwrap(\DOMElement $element): void
+    {
+        if (\in_array(\strtolower($element->nodeName), self::UNWRAP_BLACKLIST, true)) {
+            return;
+        }
+
+        $parent = $element->parentNode;
+        if (null === $parent) {
+            return;
+        }
+
+        $hasContent = null !== $element->firstChild;
+
+        if (!$hasContent) {
+            $prev = $element->previousSibling;
+            $next = $element->nextSibling;
+            $parent->removeChild($element);
+
+            if ($next instanceof \DOMText) {
+                $next->nodeValue = \preg_replace('/^[ \t]*\n/', '', $next->nodeValue ?? '');
+            }
+            if ($prev instanceof \DOMText) {
+                $prev->nodeValue = \rtrim($prev->nodeValue ?? '', " \t");
+            }
+
+            return;
+        }
+
+        while (null !== $element->firstChild) {
+            $parent->insertBefore($element->firstChild, $element);
+        }
+        $parent->removeChild($element);
     }
 }

--- a/EMS/core-bundle/src/Core/ContentType/Transformer/HtmlEmptyTransformer.php
+++ b/EMS/core-bundle/src/Core/ContentType/Transformer/HtmlEmptyTransformer.php
@@ -15,9 +15,9 @@ final class HtmlEmptyTransformer extends AbstractTransformer
     }
 
     #[\Override]
-    public function supports(string $class): bool
+    public function supports(string $fieldTypeClass): bool
     {
-        return WysiwygFieldType::class === $class;
+        return WysiwygFieldType::class === $fieldTypeClass;
     }
 
     #[\Override]

--- a/EMS/core-bundle/src/Core/ContentType/Transformer/HtmlRemoveNodeTransformer.php
+++ b/EMS/core-bundle/src/Core/ContentType/Transformer/HtmlRemoveNodeTransformer.php
@@ -18,9 +18,9 @@ final class HtmlRemoveNodeTransformer extends BaseHtmlTransformer
     }
 
     #[\Override]
-    public function supports(string $class): bool
+    public function supports(string $fieldTypeClass): bool
     {
-        return WysiwygFieldType::class === $class;
+        return WysiwygFieldType::class === $fieldTypeClass;
     }
 
     #[\Override]

--- a/EMS/core-bundle/tests/Unit/Core/ContentType/Transformer/HtmlAttributeTransformerTest.php
+++ b/EMS/core-bundle/tests/Unit/Core/ContentType/Transformer/HtmlAttributeTransformerTest.php
@@ -119,7 +119,6 @@ class HtmlAttributeTransformerTest extends AbstractTransformerTestCase
         $output = <<<HTML
             <div class="test">
                 <h1>Test</h1>
-                <span></span>
             </div>
             HTML;
 
@@ -201,6 +200,50 @@ class HtmlAttributeTransformerTest extends AbstractTransformerTestCase
             'attribute' => 'style',
             'element' => 'h1',
             'remove' => true,
+        ]);
+    }
+
+    public function testRemoveLastAttributeClass(): void
+    {
+        $input = '<p>Test <ins class="newWord">new word</ins></p>';
+        $output = '<p>Test new word</p>';
+
+        $this->assertEqualsInputOutPut($input, $output, [
+            'attribute' => 'class',
+            'remove_value_prefix' => 'newWord',
+        ]);
+    }
+
+    public function testRemoveLastAttributeStyle(): void
+    {
+        $input = '<p>Test <span style="color:red">new word</span></p>';
+        $output = '<p>Test new word</p>';
+
+        $this->assertEqualsInputOutPut($input, $output, [
+            'attribute' => 'style',
+            'remove_value_prefix' => 'color',
+        ]);
+    }
+
+    public function testRemoveAttributeUnwraps(): void
+    {
+        $input = '<p>Test <span data-foo="bar">new word</span></p>';
+        $output = '<p>Test new word</p>';
+
+        $this->assertEqualsInputOutPut($input, $output, [
+            'attribute' => 'data-foo',
+            'remove' => true,
+        ]);
+    }
+
+    public function testRemoveClassKeepsElementWithOtherAttributes(): void
+    {
+        $input = '<p>Test <ins class="newWord" id="x">new word</ins></p>';
+        $output = '<p>Test <ins id="x">new word</ins></p>';
+
+        $this->assertEqualsInputOutPut($input, $output, [
+            'attribute' => 'class',
+            'remove_value_prefix' => 'newWord',
         ]);
     }
 }

--- a/docs/elasticms-admin/contentType/contentType.md
+++ b/docs/elasticms-admin/contentType/contentType.md
@@ -269,64 +269,171 @@ Start a new job, the body should be the command with arguments and options.
 Similar to the export render option, but will always generate a pdf.
 
 # Transformers
-In the "Migration Options" of contenttype field you can add one or more transformers.
+
+In the "Migration Options" of a contenttype field you can add one or more transformers.
 For each transformer you need to define a JSON config.
 When running the transform command these transformers will be applied.
 
-| Name                                                          | Description                                       | Field   |
-|---------------------------------------------------------------|---------------------------------------------------|---------|
-| [Html Attribute Transformer](#html-attribute-transformer)     | Remove html attribute or remove attribute values. | wysiwyg | 
-| [Html Empty Transformer](#html-empty-transformer)             | Clean empty html content                          | wysiwyg | 
-| [Html Remove Node Transformer](#html-remove-node-transformer) | Clean empty html content                          | wysiwyg | 
+| Name                                                          | Description                                 | Field   |
+|---------------------------------------------------------------|---------------------------------------------|---------|
+| [Html Attribute Transformer](#html-attribute-transformer)     | Remove html attributes or attribute values. | wysiwyg |
+| [Html Empty Transformer](#html-empty-transformer)             | Clean empty html content.                   | wysiwyg |
+| [Html Remove Node Transformer](#html-remove-node-transformer) | Remove html nodes.                          | wysiwyg |
 
 ## Html Attribute Transformer
+
 Only available for WYSIWYG field types.
+
+Removes an attribute (or specific values inside `class` / `style`) from matching elements. When an element has no
+attributes left after the transformation, it is automatically **unwrapped**: its children are moved to the parent and
+the element itself is removed, along with the surrounding whitespace of the removed line.
+
+Unwrapping is skipped for structural elements to avoid breaking the document layout. The following tags are never
+unwrapped:
+`table`, `thead`, `tbody`, `tfoot`, `tr`, `td`, `th`, `ul`, `ol`, `li`, `dl`, `dt`, `dd`, `p`, `section`, `article`,
+`header`, `footer`, `nav`, `aside`, `h1`–`h6`, `figure`, `figcaption`, `blockquote`, `pre`.
+
 ### Config
-* **attribute** : required, which attribute you want to transform
-* **element** : default (*), which html element
-* **remove** : default (false), remove the attribute
-* **remove_value_prefix** : default (null), remove all values starting by from **class** or **style** attributes.
+
+* **attribute**: required, which attribute you want to transform.
+* **element**: default `*`, which html element to target.
+* **remove**: default `false`, remove the attribute entirely.
+* **remove_value_prefix**: default `null`, remove values starting with this prefix from `class` or `style` attributes.
 
 ### Examples
-> Remove all style attributes for all table elements
+
+> Remove all style attributes from table elements
+
 ```json
-{"attribute": "style", "element": "table", "remove": "true"}
+{
+  "attribute": "style",
+  "element": "table",
+  "remove": true
+}
 ```
-> Remove all cellpadding attributes for all table elements
+
+> Remove all cellpadding attributes from table elements
+
 ```json
-{"attribute": "cellpadding", "element": "table", "remove": "true"}
+{
+  "attribute": "cellpadding",
+  "element": "table",
+  "remove": true
+}
 ```
+
 > Remove all style values related to font-size
+
 ```json
-{"attribute": "style", "element": "*", "remove_value_prefix": "font-size"}
+{
+  "attribute": "style",
+  "element": "*",
+  "remove_value_prefix": "font-size"
+}
 ```
-> Remove all class values starting with 'font' from all divs
+
+> Remove all class values starting with `font-` from all divs
+
 ```json
-{"attribute": "class", "element": "div", "remove_value_prefix": "font-"}
+{
+  "attribute": "class",
+  "element": "div",
+  "remove_value_prefix": "font-"
+}
+```
+
+### Unwrap behavior
+
+Given the config `{"attribute": "class", "remove_value_prefix": "newWord"}`:
+
+Input:
+
+```html
+
+<p>Test
+  <ins class="newWord">new word</ins>
+</p>
+```
+
+Output:
+
+```html
+<p>Test new word</p>
+```
+
+Empty elements are removed together with the blank line they were on. Given
+`{"attribute": "style", "element": "span", "remove_value_prefix": "background"}`:
+
+Input:
+
+```html
+
+<div class="test">
+  <h1>Test</h1>
+  <span style="background: red;"></span>
+</div>
+```
+
+Output:
+
+```html
+
+<div class="test">
+  <h1>Test</h1>
+</div>
 ```
 
 ## Html Empty Transformer
-Only available for WYSIWYG field types.
-Clean content without textual content
+
+Only available for WYSIWYG field types. Cleans content without textual content.
+
 ### Config
-> No config required
 
-Example transformer to null
+> No config required.
+
+Example, transformed to `null`:
+
 ```html
-<p style="text-align: justify;"> </p> <div class="example" style="text-align: justify;"> </div> <p> </p>
-```
-```html
-<html lang="en"><body><h1>            </h1><p>&nbsp;       </p></body>        </html>
+<p style="text-align: justify;"></p>
+<div class="example" style="text-align: justify;"></div> <p></p>
 ```
 
-## Html remove node transformer
+```html
+
+<html lang="en">
+<body><h1></h1>
+<p>&nbsp; </p></body>
+</html>
+```
+
+## Html Remove Node Transformer
+
+Only available for WYSIWYG field types. Removes matching html nodes.
+
+### Config
+
+* **element**: required, which html element to remove.
+* **attribute**: optional, only remove elements that have this attribute.
+* **attribute_contains**: optional, only remove elements whose attribute value contains this string.
+
+### Examples
+
 > Remove all span elements
+
 ```json
-{"element": "span"}
+{
+  "element": "span"
+}
 ```
-> Remove all span that have a class attribute containing *delete*
+
+> Remove all spans that have a class attribute containing `delete`
+
 ```json
-{"element": "span", "attribute": "class", "attribute_contains": "delete"}
+{
+  "element": "span",
+  "attribute": "class",
+  "attribute_contains": "delete"
+}
 ```
 
 # Views


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | y  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

When the `HtmlAttributeTransformer` removes the last attribute of an element (either via `remove` or `remove_value_prefix`), the element itself is now unwrapped instead of left behind as an empty tag.

### Example
Config: `{"attribute": "class", "remove_value_prefix": "newWord"}`

Before:
```html
Test new word
→ Test new word
```

After:
```html
Test new word
→ Test new word
```

### Notes
- Structural tags (`table`, `tr`, `td`, `ul`, `li`, `p`, `h1`–`h6`, ...) are never unwrapped.
- Surrounding whitespace of removed empty elements is cleaned up so blank lines don't stay behind.
- Tests added for `class`, `style` and `remove` cases.
