### PR TITLE
feat(admin/contenttype): add html unwrap transformer

### DIFF
--- a/EMS/core-bundle/config/services.xml
+++ b/EMS/core-bundle/config/services.xml
@@ -114,6 +114,9 @@
         <service id="ems_core.core_content_type_transformer.html_remove_node_transformer" class="EMS\CoreBundle\Core\ContentType\Transformer\HtmlRemoveNodeTransformer">
             <tag name="ems_core.content_type.transformer"/>
         </service>
+        <service id="ems_core.core_content_type_transformer.html_unwrap_transformer" class="EMS\CoreBundle\Core\ContentType\Transformer\HtmlUnwrapTransformer">
+            <tag name="ems_core.content_type.transformer"/>
+        </service>
         <service id="emsco.core_mercure.mercure_service" class="EMS\CoreBundle\Core\Mercure\MercureService">
             <argument type="service" id="mercure.hub.default"/>
             <argument type="service" id="emsco.manager.user"/>

--- a/EMS/core-bundle/src/Core/ContentType/Transformer/BaseHtmlTransformer.php
+++ b/EMS/core-bundle/src/Core/ContentType/Transformer/BaseHtmlTransformer.php
@@ -8,6 +8,15 @@ use Symfony\Component\DomCrawler\Crawler;
 
 abstract class BaseHtmlTransformer extends AbstractTransformer
 {
+    /** @var list<string> */
+    private const array UNWRAP_BLACKLIST = [
+        'table', 'thead', 'tbody', 'tfoot', 'tr', 'td', 'th',
+        'ul', 'ol', 'li', 'dl', 'dt', 'dd',
+        'p', 'section', 'article', 'header', 'footer', 'nav', 'aside',
+        'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+        'figure', 'figcaption', 'blockquote', 'pre',
+    ];
+
     protected function setTransformed(TransformContext $context, Crawler $crawler): void
     {
         $data = $context->getData();
@@ -39,6 +48,84 @@ abstract class BaseHtmlTransformer extends AbstractTransformer
             if ($element instanceof \DOMElement) {
                 yield $element;
             }
+        }
+    }
+
+    protected function unwrap(\DOMElement $element): void
+    {
+        if (\in_array(\strtolower($element->nodeName), self::UNWRAP_BLACKLIST, true)) {
+            return;
+        }
+
+        $parent = $element->parentNode;
+        if (null === $parent) {
+            return;
+        }
+
+        if (null === $element->firstChild) {
+            $this->unwrapEmpty($element, $parent);
+
+            return;
+        }
+
+        $this->dedentChildren($element);
+
+        while (null !== $element->firstChild) {
+            $parent->insertBefore($element->firstChild, $element);
+        }
+        $parent->removeChild($element);
+    }
+
+    private function unwrapEmpty(\DOMElement $element, \DOMNode $parent): void
+    {
+        $prev = $element->previousSibling;
+        $next = $element->nextSibling;
+        $parent->removeChild($element);
+
+        if ($next instanceof \DOMText) {
+            $next->nodeValue = \preg_replace('/^[ \t]*\n/', '', $next->nodeValue ?? '');
+        }
+        if ($prev instanceof \DOMText) {
+            $prev->nodeValue = \rtrim($prev->nodeValue ?? '', " \t");
+        }
+    }
+
+    private function dedentChildren(\DOMElement $element): void
+    {
+        while ($element->firstChild instanceof \DOMText && '' === \trim($element->firstChild->nodeValue ?? '')) {
+            $element->removeChild($element->firstChild);
+        }
+        while ($element->lastChild instanceof \DOMText && '' === \trim($element->lastChild->nodeValue ?? '')) {
+            $element->removeChild($element->lastChild);
+        }
+
+        $document = $element->ownerDocument;
+        if (null === $document) {
+            return;
+        }
+
+        $outerIndent = '';
+        if ($element->previousSibling instanceof \DOMText
+            && \preg_match('/\n([ \t]*)$/', $element->previousSibling->nodeValue ?? '', $m)) {
+            $outerIndent = $m[1];
+        }
+
+        $textNodes = new \DOMXPath($document)->query('.//text()', $element) ?: [];
+        $innerIndent = '';
+        foreach ($textNodes as $textNode) {
+            if (\preg_match('/\n([ \t]+)/', $textNode->nodeValue ?? '', $m)) {
+                $innerIndent = $m[1];
+                break;
+            }
+        }
+
+        if (\strlen($innerIndent) <= \strlen($outerIndent) || !\str_starts_with($innerIndent, $outerIndent)) {
+            return;
+        }
+
+        $dedent = \substr($innerIndent, \strlen($outerIndent));
+        foreach ($textNodes as $textNode) {
+            $textNode->nodeValue = \str_replace("\n".$dedent, "\n", $textNode->nodeValue ?? '');
         }
     }
 }

--- a/EMS/core-bundle/src/Core/ContentType/Transformer/HtmlAttributeTransformer.php
+++ b/EMS/core-bundle/src/Core/ContentType/Transformer/HtmlAttributeTransformer.php
@@ -10,15 +10,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class HtmlAttributeTransformer extends BaseHtmlTransformer
 {
-    /** @var list<string> */
-    private const array UNWRAP_BLACKLIST = [
-        'table', 'thead', 'tbody', 'tfoot', 'tr', 'td', 'th',
-        'ul', 'ol', 'li', 'dl', 'dt', 'dd',
-        'p', 'section', 'article', 'header', 'footer', 'nav', 'aside',
-        'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
-        'figure', 'figcaption', 'blockquote', 'pre',
-    ];
-
     #[\Override]
     public function getName(): string
     {
@@ -180,39 +171,5 @@ final class HtmlAttributeTransformer extends BaseHtmlTransformer
         }
 
         return $result;
-    }
-
-    private function unwrap(\DOMElement $element): void
-    {
-        if (\in_array(\strtolower($element->nodeName), self::UNWRAP_BLACKLIST, true)) {
-            return;
-        }
-
-        $parent = $element->parentNode;
-        if (null === $parent) {
-            return;
-        }
-
-        $hasContent = null !== $element->firstChild;
-
-        if (!$hasContent) {
-            $prev = $element->previousSibling;
-            $next = $element->nextSibling;
-            $parent->removeChild($element);
-
-            if ($next instanceof \DOMText) {
-                $next->nodeValue = \preg_replace('/^[ \t]*\n/', '', $next->nodeValue ?? '');
-            }
-            if ($prev instanceof \DOMText) {
-                $prev->nodeValue = \rtrim($prev->nodeValue ?? '', " \t");
-            }
-
-            return;
-        }
-
-        while (null !== $element->firstChild) {
-            $parent->insertBefore($element->firstChild, $element);
-        }
-        $parent->removeChild($element);
     }
 }

--- a/EMS/core-bundle/src/Core/ContentType/Transformer/HtmlUnwrapTransformer.php
+++ b/EMS/core-bundle/src/Core/ContentType/Transformer/HtmlUnwrapTransformer.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\Core\ContentType\Transformer;
+
+use EMS\CoreBundle\Form\DataField\WysiwygFieldType;
+use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class HtmlUnwrapTransformer extends BaseHtmlTransformer
+{
+    #[\Override]
+    public function getName(): string
+    {
+        return 'HTML Unwrap';
+    }
+
+    #[\Override]
+    public function supports(string $fieldTypeClass): bool
+    {
+        return WysiwygFieldType::class === $fieldTypeClass;
+    }
+
+    #[\Override]
+    public function transform(TransformContext $context): void
+    {
+        if (null === $context->getData()) {
+            return;
+        }
+
+        $crawler = new Crawler();
+        $crawler->addContent($context->getData());
+        $options = $this->resolveOptions($context->getOptions());
+
+        $xpath = \implode('|', \array_map(
+            fn (string $el) => \sprintf('//%s[not(@*)]', $el),
+            $options['elements']
+        ));
+
+        $result = 0;
+        foreach ($this->crawl($crawler, $xpath) as $element) {
+            $this->unwrap($element);
+            ++$result;
+        }
+
+        if ($result > 0) {
+            $this->setTransformed($context, $crawler);
+        }
+    }
+
+    #[\Override]
+    protected function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver
+            ->setRequired(['elements'])
+            ->setAllowedTypes('elements', 'string[]')
+        ;
+    }
+}

--- a/EMS/core-bundle/tests/Unit/Core/ContentType/Transformer/HtmlUnwrapTransformerTest.php
+++ b/EMS/core-bundle/tests/Unit/Core/ContentType/Transformer/HtmlUnwrapTransformerTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\Tests\Unit\Core\ContentType\Transformer;
+
+use EMS\CoreBundle\Core\ContentType\Transformer\ContentTransformerInterface;
+use EMS\CoreBundle\Core\ContentType\Transformer\HtmlUnwrapTransformer;
+
+class HtmlUnwrapTransformerTest extends AbstractTransformerTestCase
+{
+    #[\Override]
+    protected function getTransformer(): ContentTransformerInterface
+    {
+        return new HtmlUnwrapTransformer();
+    }
+
+    public function testUnwrapDiv(): void
+    {
+        $input = '<div>Hello <strong>world</strong></div>';
+        $output = 'Hello <strong>world</strong>';
+
+        $this->assertEqualsInputOutPut($input, $output, [
+            'elements' => ['div', 'span', 'ins'],
+        ]);
+    }
+
+    public function testUnwrapSpan(): void
+    {
+        $input = '<p>Test <span>new word</span></p>';
+        $output = '<p>Test new word</p>';
+
+        $this->assertEqualsInputOutPut($input, $output, [
+            'elements' => ['div', 'span', 'ins'],
+        ]);
+    }
+
+    public function testUnwrapIns(): void
+    {
+        $input = '<p>Test <ins>new word</ins></p>';
+        $output = '<p>Test new word</p>';
+
+        $this->assertEqualsInputOutPut($input, $output, [
+            'elements' => ['div', 'span', 'ins'],
+        ]);
+    }
+
+    public function testKeepElementWithAttributes(): void
+    {
+        $input = '<p>Test <span class="highlight">word</span></p>';
+        $output = '<p>Test <span class="highlight">word</span></p>';
+
+        $this->assertEqualsInputOutPut($input, $output, [
+            'elements' => ['div', 'span', 'ins'],
+        ]);
+    }
+
+    public function testOnlyConfiguredElements(): void
+    {
+        $input = '<p>Test <span>a</span> <ins>b</ins></p>';
+        $output = '<p>Test a <ins>b</ins></p>';
+
+        $this->assertEqualsInputOutPut($input, $output, [
+            'elements' => ['span'],
+        ]);
+    }
+
+    public function testUnwrapKeepsIndentation(): void
+    {
+        $input = <<<HTML
+            <section>
+                <div>
+                    <h1>Title</h1>
+                    <div>
+                        <p>Paragraph <span>Test</span></p>
+                    </div>
+                </div>
+            </section>
+            HTML;
+        $output = <<<HTML
+            <section>
+                <h1>Title</h1>
+                <p>Paragraph Test</p>
+            </section>
+            HTML;
+
+        $this->assertEqualsInputOutPut($input, $output, [
+            'elements' => ['div', 'span'],
+        ]);
+    }
+}

--- a/docs/elasticms-admin/contentType/contentType.md
+++ b/docs/elasticms-admin/contentType/contentType.md
@@ -279,6 +279,7 @@ When running the transform command these transformers will be applied.
 | [Html Attribute Transformer](#html-attribute-transformer)     | Remove html attributes or attribute values. | wysiwyg |
 | [Html Empty Transformer](#html-empty-transformer)             | Clean empty html content.                   | wysiwyg |
 | [Html Remove Node Transformer](#html-remove-node-transformer) | Remove html nodes.                          | wysiwyg |
+| [Html Unwrap Transformer](#html-unwrap-transformer)           | Unwrap html elements without attributes.    | wysiwyg |
 
 ## Html Attribute Transformer
 
@@ -349,14 +350,12 @@ Given the config `{"attribute": "class", "remove_value_prefix": "newWord"}`:
 Input:
 
 ```html
-
 <p>Test
   <ins class="newWord">new word</ins>
 </p>
 ```
 
 Output:
-
 ```html
 <p>Test new word</p>
 ```
@@ -367,7 +366,6 @@ Empty elements are removed together with the blank line they were on. Given
 Input:
 
 ```html
-
 <div class="test">
   <h1>Test</h1>
   <span style="background: red;"></span>
@@ -377,7 +375,6 @@ Input:
 Output:
 
 ```html
-
 <div class="test">
   <h1>Test</h1>
 </div>
@@ -399,7 +396,6 @@ Example, transformed to `null`:
 ```
 
 ```html
-
 <html lang="en">
 <body><h1></h1>
 <p>&nbsp; </p></body>
@@ -434,6 +430,57 @@ Only available for WYSIWYG field types. Removes matching html nodes.
   "attribute": "class",
   "attribute_contains": "delete"
 }
+```
+
+## Html Unwrap Transformer
+
+Only available for WYSIWYG field types.
+
+Unwraps configured html elements that have **no attributes**: the element itself is removed but its children are kept in
+place. Elements with attributes are left untouched. The same unwrap logic as
+the [Html Attribute Transformer](#html-attribute-transformer) is used, so the structural blacklist applies and
+surrounding whitespace/indentation is cleaned up.
+
+### Config
+
+* **elements**: required, list of html elements to unwrap.
+
+### Examples
+
+> Unwrap empty `div`, `span` and `ins` elements
+
+```json
+{
+  "elements": [
+    "div",
+    "span",
+    "ins"
+  ]
+}
+```
+
+### Example
+
+Given the config `{"elements": ["div"]}`:
+
+Input:
+
+```html
+<section>
+  <div>
+    <h1>Title</h1>
+    <p>Paragraph</p>
+  </div>
+</section>
+```
+
+Output:
+
+```html
+<section>
+  <h1>Title</h1>
+  <p>Paragraph</p>
+</section>
 ```
 
 # Views


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  n |
| New feature?   | y  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

## Html Unwrap Transformer

New transformer that unwraps configured html elements when they have no attributes. The element itself is removed, but its children stay in place.

### Config
- **elements**: required, list of html elements to unwrap.

### Example
Config: `{"elements": ["div"]}`

Before:
```html
<section>
    <div>
        <h1>Title</h1>
        <p>Paragraph</p>
    </div>
</section>
```

After:
```html
<section>
    <h1>Title</h1>
    <p>Paragraph</p>
</section>
```

### Notes
- Shares the unwrap logic with `HtmlAttributeTransformer` (moved to `BaseHtmlTransformer`).
- Structural tags (`table`, `tr`, `td`, `ul`, `li`, `p`, `h1`–`h6`, ...) are never unwrapped.
- Surrounding whitespace and child indentation are cleaned up so the output stays readable.
- Documentation and tests added.
