### PR TITLE
fix(admin/menu): invalid test id on dashboard menu

### DIFF
--- a/EMS/core-bundle/templates/notification/menu.html.twig
+++ b/EMS/core-bundle/templates/notification/menu.html.twig
@@ -2,7 +2,7 @@
 
 {%  for dashboard in dashboardMenu.children %}
     <li class="notifications-menu">
-        <a href="{{ path(dashboard.route, dashboard.routeParameters) }}"{% if dashboard.color %} class="text-{{ dashboard.color }}"{% endif %} data-testid="notification-menu-{{ dashboard.name }}">
+        <a href="{{ path(dashboard.route, dashboard.routeParameters) }}"{% if dashboard.color %} class="text-{{ dashboard.color }}"{% endif %} data-testid="notification-menu-{{ dashboard.label|slug|lower }}">
             <i class="{{ dashboard.icon }}"></i>
         </a>
     </li>


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

It's not the dashboard but a menu entry, for now slugged the label to lower.

Neither the property "name" nor one of the methods "name()", "getname()"/"isname()"/"hasname()" or "__call()" exist and have public access in class "EMS\CoreBundle\Core\UI\MenuEntry" in @EMSCore/notification/menu.html.twig at line 5.
