### PR TITLE
feat(web/asset):  create symlink for relative or absolute EMSCH_ASSET_LOCAL_FOLDER

### DIFF
--- a/EMS/client-helper-bundle/src/Twig/AssetExtension.php
+++ b/EMS/client-helper-bundle/src/Twig/AssetExtension.php
@@ -31,11 +31,15 @@ final class AssetExtension
             return;
         }
         $filesystem = new Filesystem();
-        $folder = $this->publicDir.'/'.$localFolder;
-        if (!\str_starts_with($localFolder, '../') || !$filesystem->exists($folder)) {
+        if (!\str_starts_with($localFolder, '../') && !\str_starts_with($localFolder, '/')) {
             $this->localFolder = $localFolder;
 
             return;
+        }
+
+        $folder = $localFolder;
+        if (\str_starts_with($localFolder, '../')) {
+            $folder = $this->publicDir.'/'.$localFolder;
         }
 
         $symlink = $this->publicDir.'/bundles/emssymlink';

--- a/EMS/client-helper-bundle/src/Twig/AssetExtension.php
+++ b/EMS/client-helper-bundle/src/Twig/AssetExtension.php
@@ -9,6 +9,7 @@ use EMS\CommonBundle\Controller\FileController;
 use EMS\CommonBundle\Helper\EmsFields;
 use EMS\CommonBundle\Storage\StorageManager;
 use EMS\CommonBundle\Twig\AssetExtension as CommonAssetExtension;
+use Symfony\Component\Filesystem\Filesystem;
 use Twig\Attribute\AsTwigFunction;
 
 final class AssetExtension
@@ -26,9 +27,31 @@ final class AssetExtension
         ?string $localFolder = null
     ) {
         $this->publicDir = $projectDir.'/public';
-        if (\is_string($localFolder) && '' !== $localFolder) {
-            $this->localFolder = $localFolder;
+        if (!\is_string($localFolder) || '' === $localFolder) {
+            return;
         }
+        $filesystem = new Filesystem();
+        $folder = $this->publicDir.'/'.$localFolder;
+        if (!\str_starts_with($localFolder, '../') || !$filesystem->exists($folder)) {
+            $this->localFolder = $localFolder;
+
+            return;
+        }
+
+        $symlink = $this->publicDir.'/bundles/emssymlink';
+        if (\is_link($symlink)) {
+            $target = \readlink($symlink);
+            if ($target === $symlink) {
+                return;
+            }
+            $filesystem->remove($symlink);
+        }
+
+        if ($filesystem->exists($symlink)) {
+            throw new \RuntimeException('The /bundles/emssymlink already exists.');
+        }
+        $filesystem->symlink($folder, $symlink);
+        $this->localFolder = 'bundles/emssymlink';
     }
 
     public function applyVersion(string $path): string

--- a/EMS/client-helper-bundle/src/Twig/AssetExtension.php
+++ b/EMS/client-helper-bundle/src/Twig/AssetExtension.php
@@ -41,7 +41,9 @@ final class AssetExtension
         $symlink = $this->publicDir.'/bundles/emssymlink';
         if (\is_link($symlink)) {
             $target = \readlink($symlink);
-            if ($target === $symlink) {
+            if ($target === $folder) {
+                $this->localFolder = 'bundles/emssymlink';
+
                 return;
             }
             $filesystem->remove($symlink);


### PR DESCRIPTION

| Q              | A |
|----------------|---|
| Bug fix?       |   n|
| New feature?   |  y |
| BC breaks?     | n  |
| Deprecations?  |  n |
| Fixed tickets? |  n |
| Documentation? | n  |

In dev mode (with the mono repo and a project aside) its now possible to assign the `EMSCH_ASSET_LOCAL_FOLDER` envvar to something like `../../../my-project/dist`. The client-helper-bundle will create a `bundles/emssymlink` symlink by itself