### PR TITLE
fix(common/json-menu-nested): context may define testId

### DIFF
--- a/EMS/core-bundle/templates/components/json_menu_nested/component.html.twig
+++ b/EMS/core-bundle/templates/components/json_menu_nested/component.html.twig
@@ -3,12 +3,12 @@
 {# @var template \EMS\CoreBundle\Core\Component\JsonMenuNested\Template\JsonMenuNestedTemplate #}
 {# @var config   \EMS\CoreBundle\Core\Component\JsonMenuNested\Config\JsonMenuNestedConfig #}
 
-<div class="json-menu-nested-component" id="{{ id }}" data-hash="{{ hash }}" {% if config.activeItemId %}data-active-item-id="{{ config.activeItemId }}"{% endif %} data-testid="json-menu-nested-component-{{ context.structureTitle|ems_slug }}">
+<div class="json-menu-nested-component" id="{{ id }}" data-hash="{{ hash }}" {% if config.activeItemId %}data-active-item-id="{{ config.activeItemId }}"{% endif %} data-testid="json-menu-nested-component-{{ context.testId|default('main')|ems_slug }}">
     <div class="jmn-node-loading" data-testid="jmn-loading"><i class="fa fa-cog fa-spin fa-3x fa-fw"></i></div>
     <div class="jmn-top" data-testid="jmn-top"></div>
     <div class="jmn-wrapper" data-testid="jmn-wrapper">
         <div class="jmn-header">{{ template.block('jmn_columns', _context)|raw }}</div>
-        <div id="{{- "tree-#{id}" -}}" class="jmn-tree jmn-node jmn-sortable" data-id="{{ config.jsonMenuNested.id }}"  data-types="{{ config.nodes.types('_root')|json_encode|e('html_attr') }}" data-testid="menu-tree-{{ context.structureTitle|ems_slug }}"></div>
+        <div id="{{- "tree-#{id}" -}}" class="jmn-tree jmn-node jmn-sortable" data-id="{{ config.jsonMenuNested.id }}"  data-types="{{ config.nodes.types('_root')|json_encode|e('html_attr') }}" data-testid="menu-tree-{{ context.testId|default('main')|ems_slug }}"></div>
     </div>
     <div class="jmn-footer" data-testid="jmn-footer"></div>
 </div>

--- a/docs/dev/core-bundle/twig/json-menu-nested.md
+++ b/docs/dev/core-bundle/twig/json-menu-nested.md
@@ -22,7 +22,7 @@ Loading the page with the request parameter **item** and value a item id, will s
 - **structure** : pass a json string of a part of the structure. Silent publish will now do partial updates
 - **actions** : allow or deny actions by default everything is enabled
 - **blocks** : overwrite item actions, append item information
-- **context** : extra context for the blocks rendering
+- **context** : extra context for the blocks rendering, the context may define a `testId` attribute that will be used to specify custom `data-testid` (default value `main`)
 
 ### Simple render
 ```twig


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  |  n |
| Fixed tickets? | y  |
| Documentation? | n  |

Now a structureTitle is mandatory in json-menu-nested component's context

#1668