### PR TITLE
feat(common/property-accessor): recursive get/set and iterate

### DIFF
--- a/EMS/common-bundle/src/Common/PropertyAccess/PropertyAccessor.php
+++ b/EMS/common-bundle/src/Common/PropertyAccess/PropertyAccessor.php
@@ -36,6 +36,29 @@ class PropertyAccessor
     {
         $propertyPath = $this->getPropertyPath($propertyPath);
         $currentElement = $propertyPath->current();
+
+        if ('**' === $currentElement->getName()) {
+            if ($propertyPath->last()) {
+                return $array;
+            }
+
+            $propertyPath->next();
+            $targetId = $propertyPath->current()->getName();
+
+            $found = $this->findRecursive($array, $targetId);
+            if (null === $found) {
+                return null;
+            }
+
+            if ($propertyPath->last()) {
+                return $found;
+            }
+
+            $propertyPath->next();
+
+            return $this->getValue($found, $propertyPath);
+        }
+
         if (!isset($array[$currentElement->getName()])) {
             return null;
         }
@@ -52,6 +75,35 @@ class PropertyAccessor
     }
 
     /**
+     * @param array<mixed> $array
+     *
+     * @return ?array<mixed>
+     */
+    private function findRecursive(array $array, string $targetId): ?array
+    {
+        if (isset($array['id']) && (string) $array['id'] === $targetId) {
+            return $array;
+        }
+
+        foreach ($array as $item) {
+            if (!\is_array($item)) {
+                continue;
+            }
+
+            if (isset($item['id']) && (string) $item['id'] === $targetId) {
+                return $item;
+            }
+
+            $res = $this->findRecursive($item, $targetId);
+            if ($res) {
+                return $res;
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * @param mixed[] $array
      */
     public function setValue(array &$array, PropertyPath|string $propertyPath, mixed $value): void
@@ -63,6 +115,21 @@ class PropertyAccessor
 
             return;
         }
+
+        if ('**' === $currentElement->getName()) {
+            $propertyPath->next();
+            $targetId = $propertyPath->current()->getName();
+
+            if ($propertyPath->last()) {
+                return;
+            }
+
+            $propertyPath->next();
+            $this->setValueRecursive($array, $targetId, $propertyPath, $value);
+
+            return;
+        }
+
         if (!isset($array[$currentElement->getName()])) {
             $array[$currentElement->getName()] = [];
         } else {
@@ -74,20 +141,64 @@ class PropertyAccessor
     }
 
     /**
-     * @param mixed[]               $array
-     * @param array<string, string> $replacers
+     * @param array<mixed> $array
+     */
+    private function setValueRecursive(array &$array, string $targetId, PropertyPath $propertyPath, mixed $value): bool
+    {
+        if (isset($array['id']) && (string) $array['id'] === $targetId) {
+            $this->setValue($array, $propertyPath, $value);
+
+            return true;
+        }
+
+        foreach ($array as &$item) {
+            if (!\is_array($item)) {
+                continue;
+            }
+
+            if (isset($item['id']) && (string) $item['id'] === $targetId) {
+                $this->setValue($item, $propertyPath, $value);
+
+                return true;
+            }
+
+            if ($this->setValueRecursive($item, $targetId, $propertyPath, $value)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param mixed[]                 $array
+     * @param array<string, string>   $replacers
+     * @param array{id_as_key?: bool} $options
      *
      * @return \Generator<string, mixed>
      */
-    public function iterator(PropertyPath|string $propertyPath, array $array, array $replacers = [], string $basePath = ''): \Generator
+    public function iterator(PropertyPath|string $propertyPath, array $array, array $replacers = [], string $basePath = '', array $options = []): \Generator
     {
         $propertyPath = $this->getPropertyPath($propertyPath);
         $currentElement = $propertyPath->current();
+        $currentName = $currentElement->getName();
 
-        if ('*' === $currentElement->getName()) {
+        if (\in_array('id_key', $currentElement->getOperators())) {
+            $options['id_as_key'] = true;
+        }
+
+        if ('*' === $currentName) {
             foreach ($this->iterateOnAllChildren($propertyPath, $array, $replacers, $basePath) as $key => $value) {
                 yield $key => $value;
             }
+        } elseif ('**' === $currentName) {
+            $last = $propertyPath->last();
+            $propertyPath->next();
+            $index = $propertyPath->getIndex();
+
+            yield from $this->iterateRecursive($propertyPath, $array, $replacers, $basePath, $last, $index, $options);
+
+            return;
         }
 
         $last = $propertyPath->last();
@@ -110,7 +221,7 @@ class PropertyAccessor
                 if (!\is_array($decoded)) {
                     throw new \RuntimeException('Unexpected non decoded array');
                 }
-                foreach ($this->iterator($propertyPath, $decoded, $replacers, $path) as $key => $value) {
+                foreach ($this->iterator($propertyPath, $decoded, $replacers, $path, $options) as $key => $value) {
                     yield $key => $value;
                 }
             }
@@ -198,6 +309,43 @@ class PropertyAccessor
                     yield $path => $childValue;
                 }
             }
+        }
+    }
+
+    /**
+     * @param mixed[]                 $array
+     * @param array<string,string>    $replacers
+     * @param array{id_as_key?: bool} $options
+     *
+     * @return \Generator<string, mixed>
+     */
+    private function iterateRecursive(PropertyPath $propertyPath, array $array, array $replacers, string $basePath, bool $last, int $index, array $options = [], ?string $parentPath = null): \Generator
+    {
+        foreach ($array as $key => $item) {
+            if (!\is_array($item)) {
+                continue;
+            }
+
+            $useIdAsKey = $options['id_as_key'] ?? false;
+
+            if ($useIdAsKey && isset($item['id']) && \is_scalar($item['id'])) {
+                $currentPath = \sprintf('%s[**][%s]', $basePath, $item['id']);
+            } else {
+                $effectiveParent = $parentPath ?? $basePath;
+                $currentPath = \sprintf('%s[%s]', $effectiveParent, $key);
+            }
+
+            $propertyPath->setIndex($index);
+
+            if ($last) {
+                yield $currentPath => $item;
+            } else {
+                yield from $this->iterator($propertyPath, $item, $replacers, $currentPath, $options);
+            }
+
+            $nextParentPath = ($useIdAsKey && isset($item['id']) && \is_scalar($item['id'])) ? $currentPath : $parentPath;
+
+            yield from $this->iterateRecursive($propertyPath, $item, $replacers, $basePath, $last, $index, $options, $nextParentPath);
         }
     }
 

--- a/EMS/common-bundle/tests/Unit/Common/PropertyAccess/PropertyAccessRecursiveTest.php
+++ b/EMS/common-bundle/tests/Unit/Common/PropertyAccess/PropertyAccessRecursiveTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CommonBundle\Tests\Unit\Common\PropertyAccess;
+
+use EMS\CommonBundle\Common\PropertyAccess\PropertyAccessor;
+use EMS\Helpers\Standard\Json;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class PropertyAccessRecursiveTest extends TestCase
+{
+    public static function nestedSourceDataProvider(): array
+    {
+        $sourceData = [
+            'structure' => Json::encode([
+                [
+                    'id' => 'folder-root',
+                    'label' => 'Root',
+                    'children' => [
+                        [
+                            'id' => 'sub-folder-1',
+                            'label' => 'Sub 1',
+                            'object' => [
+                                'title_nl' => 'Gevonden!',
+                                'title_fr' => 'Trouvé !',
+                            ],
+                            'children' => [],
+                        ],
+                    ],
+                ],
+            ]),
+        ];
+
+        return [[$sourceData]];
+    }
+
+    #[DataProvider('nestedSourceDataProvider')]
+    public function testIteratorRecursiveWithBeautifulPaths(array $sourceData): void
+    {
+        $accessor = PropertyAccessor::createPropertyAccessor();
+
+        $results = [];
+        foreach ($accessor->iterator('[json:id_key:structure][**][title_%locale%]', $sourceData, ['%locale%' => 'nl']) as $path => $value) {
+            $results[$path] = $value;
+        }
+
+        $expectedPath = '[json:id_key:structure][**][sub-folder-1][object][title_%locale%]';
+        $this->assertArrayHasKey($expectedPath, $results);
+        $this->assertEquals('Gevonden!', $results[$expectedPath]);
+    }
+
+    #[DataProvider('nestedSourceDataProvider')]
+    public function testGetValueWithRecursivePath(array $sourceData): void
+    {
+        $accessor = PropertyAccessor::createPropertyAccessor();
+        $this->assertEquals('Gevonden!', $accessor->getValue($sourceData, '[json:id_key:structure][**][sub-folder-1][object][title_nl]'));
+    }
+
+    #[DataProvider('nestedSourceDataProvider')]
+    public function testGetValueWithRecursivePathNotFound(array $sourceData): void
+    {
+        $accessor = PropertyAccessor::createPropertyAccessor();
+        $this->assertNull($accessor->getValue($sourceData, '[json:id_key:structure][**][non-existing-uuid][object][title_nl]'));
+    }
+
+    #[DataProvider('nestedSourceDataProvider')]
+    public function testSetValueWithRecursivePathUpdate(array $sourceData): void
+    {
+        $accessor = PropertyAccessor::createPropertyAccessor();
+        $path = '[json:id_key:structure][**][sub-folder-1][object][title_nl]';
+
+        $accessor->setValue($sourceData, $path, 'Aangepast!');
+
+        $this->assertEquals('Aangepast!', $accessor->getValue($sourceData, $path));
+    }
+
+    #[DataProvider('nestedSourceDataProvider')]
+    public function testSetValueWithRecursivePathInsert(array $sourceData): void
+    {
+        $accessor = PropertyAccessor::createPropertyAccessor();
+        $path = '[json:id_key:structure][**][sub-folder-1][object][title_de]';
+
+        $accessor->setValue($sourceData, $path, 'Gefunden!');
+
+        $this->assertEquals('Gefunden!', $accessor->getValue($sourceData, $path));
+    }
+
+    #[DataProvider('nestedSourceDataProvider')]
+    public function testSetValueWithRecursivePathPreservesOtherFields(array $sourceData): void
+    {
+        $accessor = PropertyAccessor::createPropertyAccessor();
+
+        $accessor->setValue($sourceData, '[json:id_key:structure][**][sub-folder-1][object][title_nl]', 'Aangepast!');
+
+        $structure = Json::decode($sourceData['structure']);
+        $this->assertEquals('Trouvé !', $structure[0]['children'][0]['object']['title_fr']);
+        $this->assertEquals('Aangepast!', $structure[0]['children'][0]['object']['title_nl']);
+    }
+}

--- a/docs/dev/common-bundle/property-accessor.md
+++ b/docs/dev/common-bundle/property-accessor.md
@@ -1,0 +1,104 @@
+# PropertyAccessor
+
+The `PropertyAccessor` is a singleton utility for reading, writing, and iterating over deeply nested array structures
+using a bracket-notation path syntax. It supports encoding/decoding operators, wildcard iteration, and recursive
+traversal by ID.
+
+## Path Syntax
+
+Paths use bracket notation to navigate nested arrays:
+
+```
+[field1][field2][field3]
+```
+
+Each bracket segment maps to a key in the array. For example, `[settings][theme][color]` accesses
+`$array['settings']['theme']['color']`.
+
+### Operators
+
+Operators are prefixed to the field name, separated by colons. Multiple operators can be chained and are applied in
+order during decoding and in reverse order during encoding.
+
+| Operator | Description                                                |
+|----------|------------------------------------------------------------|
+| `json`   | JSON encodes/decodes the value                             |
+| `base64` | Base64 encodes/decodes the value                           |
+| `id_key` | Re-indexes an array using each item's `id` property as key |
+
+Example: `[json:id_key:structure]` first JSON-decodes the `structure` field, then re-indexes the resulting array by
+`id`.
+
+### Wildcards
+
+| Wildcard | Description                         |
+|----------|-------------------------------------|
+| `*`      | Iterates over all direct children   |
+| `**`     | Recursively traverses nested arrays |
+
+### Recursive Traversal (`**`)
+
+The `**` wildcard performs a depth-first search through all nested arrays. When combined with the `id_key` operator, it
+generates "beautiful paths" that include the matched item's `id` instead of numeric indices.
+
+#### In `getValue` and `setValue`
+
+When used in `getValue` or `setValue`, the segment immediately after `**` is treated as a target ID. The accessor
+searches the tree for an item whose `id` property matches, then continues resolving the remaining path from that item.
+
+```php
+$accessor = PropertyAccessor::createPropertyAccessor();
+
+$data = [
+    'structure' => Json::encode([
+        ['id' => 'root', 'children' => [
+            ['id' => 'node-1', 'config' => ['enabled' => true]]
+        ]]
+    ])
+];
+
+// Read a deeply nested value by ID
+$value = $accessor->getValue($data, '[json:id_key:structure][**][node-1][config][enabled]');
+// Returns: true
+
+// Write a deeply nested value by ID
+$accessor->setValue($data, '[json:id_key:structure][**][node-1][config][enabled]', false);
+```
+
+If no item with the given ID is found, `getValue` returns `null` and `setValue` is a no-op.
+
+#### In `iterator`
+
+When iterating with `**`, all nested arrays are yielded. Combined with `id_key`, the generated paths use the item's `id`
+instead of numeric keys, producing stable, human-readable paths.
+
+```php
+$fieldPath = '[json:id_key:structure][**][title_%locale%]';
+$replacers = ['%locale%' => 'nl'];
+
+foreach ($accessor->iterator($fieldPath, $data, $replacers) as $path => $value) {
+    // $path: [json:id_key:structure][**][node-1][content][title_%locale%]
+    // $value: the matched value
+}
+```
+
+### Replacers
+
+The `iterator` method accepts a `$replacers` array that performs string substitution on field names. This is useful for
+locale-aware paths:
+
+```php
+$replacers = ['%locale%' => 'fr'];
+// Path [title_%locale%] resolves to field title_fr in the data
+// but the yielded key retains the placeholder [title_%locale%]
+```
+
+### Pipe-separated Fields
+
+A single path segment can match multiple fields using the pipe character:
+
+```
+[title_nl|title_fr|title_de]
+```
+
+This iterates over all matching fields in a single pass.


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  n |
| New feature?   | y  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | y  |

## Summary

Extends the `PropertyAccessor` with support for the `**` (double wildcard) operator in `getValue` and `setValue`, enabling read and write access to deeply nested structures by ID — matching the paths already generated by the `iterator` method.

## Motivation

The `iterator` method already supports `**` to recursively traverse nested arrays and generate "beautiful paths" using item IDs (e.g. `[json:id_key:structure][**][sub-folder-1][object][title_nl]`). However, `getValue` and `setValue` could not consume these paths, making it impossible to round-trip: iterate to discover paths, then use those same paths to read or update values.

## Changes

### `getValue` — recursive ID lookup

When `getValue` encounters a `**` segment, it treats the next segment as a target ID and performs a depth-first search via a new `findRecursive` helper. Once the matching item is found, resolution continues normally for the remaining path segments. Returns `null` if no item matches.

### `setValue` — recursive ID lookup by reference

A new `setValueRecursive` method walks the tree by reference (`&$item`) to locate the item with the matching ID, then delegates to the standard `setValue` for the remaining path. This ensures modifications propagate back through the array, including proper re-encoding (e.g. JSON) on the way out.

### `iterateRecursive` — stable path generation with `id_key`

Fixed path generation for non-ID intermediary nodes. Previously, children of an ID-bearing item would lose the `[**][id]` context in their path. A new `$parentPath` parameter tracks the nearest ID-bearing ancestor so that intermediate keys (like `[object]`) are appended to the correct base.

## Tests

Added `PropertyAccessRecursiveTest` with the following cases:

- **testIteratorRecursiveWithBeautifulPaths** — verifies the iterator generates `[**][id]` paths
- **testGetValueWithRecursivePath** — reads a value through `**` + ID
- **testGetValueWithRecursivePathNotFound** — returns `null` for non-existing IDs
- **testSetValueWithRecursivePathUpdate** — updates an existing value through `**` + ID
- **testSetValueWithRecursivePathInsert** — adds a new field through `**` + ID
- **testSetValueWithRecursivePathPreservesOtherFields** — confirms sibling fields and JSON encoding remain intact after a write
