### PR TITLE
fix(admin/tiptap): remove format only style and indent correct

### DIFF
--- a/EMS/admin-ui-bundle/assets/css/core/components/_wysiwyg_tiptap_iframe.scss
+++ b/EMS/admin-ui-bundle/assets/css/core/components/_wysiwyg_tiptap_iframe.scss
@@ -16,4 +16,12 @@ body {
     box-sizing: border-box;
     padding: 5px;
     min-height: 100%;
+
+    li p {
+        margin: 0;
+    }
+
+    li p + p {
+        margin-top: 0.5em;
+    }
 }

--- a/EMS/admin-ui-bundle/assets/src/core/components/tiptap/action/cleanup.ts
+++ b/EMS/admin-ui-bundle/assets/src/core/components/tiptap/action/cleanup.ts
@@ -7,7 +7,7 @@ export const cleanupActions: ToolbarAction[] = [
         group: 'cleanup',
         icon: IconClear,
         tooltip: 'Remove Format',
-        command: (e) => e.tiptap.chain().focus().unsetAllMarks().clearNodes().run(),
+        command: (e) => e.tiptap.chain().focus().unsetAllMarks().run(),
         isActive: () => false
     }
 ]

--- a/EMS/admin-ui-bundle/assets/src/core/components/tiptap/action/indent.ts
+++ b/EMS/admin-ui-bundle/assets/src/core/components/tiptap/action/indent.ts
@@ -3,7 +3,7 @@ import IconIndent from '@tabler/icons/outline/indent-increase.svg?raw'
 import IconOutdent from '@tabler/icons/outline/indent-decrease.svg?raw'
 import { ToolbarAction } from '../types.ts'
 
-const INDENTABLE = ['paragraph', 'heading', 'bulletList', 'orderedList']
+const INDENTABLE = ['paragraph', 'heading']
 
 const IndentExtension = Extension.create({
     name: 'indent',
@@ -27,9 +27,26 @@ const IndentExtension = Extension.create({
     }
 })
 
+function isInList(state: any): boolean {
+    const { $from } = state.selection
+    for (let d = $from.depth; d > 0; d--) {
+        if ($from.node(d).type.name === 'listItem') return true
+    }
+    return false
+}
+
 function changeIndent(delta: number) {
     return (e: { tiptap: any }) => {
-        e.tiptap
+        const editor = e.tiptap
+        if (isInList(editor.state)) {
+            if (delta > 0) {
+                editor.chain().focus().sinkListItem('listItem').run()
+            } else {
+                editor.chain().focus().liftListItem('listItem').run()
+            }
+            return
+        }
+        editor
             .chain()
             .focus()
             .command(({ tr, state }: { tr: any; state: any }) => {
@@ -37,11 +54,6 @@ function changeIndent(delta: number) {
                 for (let d = $from.depth; d > 0; d--) {
                     const node = $from.node(d)
                     if (!INDENTABLE.includes(node.type.name)) continue
-                    if (
-                        (node.type.name === 'paragraph' || node.type.name === 'heading') &&
-                        $from.node(d - 1)?.type.name === 'listItem'
-                    )
-                        continue
                     const pos = $from.before(d)
                     const indent = node.attrs.indent || 0
                     const next = indent + delta

--- a/EMS/admin-ui-bundle/assets/src/core/components/tiptap/action/indent.ts
+++ b/EMS/admin-ui-bundle/assets/src/core/components/tiptap/action/indent.ts
@@ -3,12 +3,14 @@ import IconIndent from '@tabler/icons/outline/indent-increase.svg?raw'
 import IconOutdent from '@tabler/icons/outline/indent-decrease.svg?raw'
 import { ToolbarAction } from '../types.ts'
 
+const INDENTABLE = ['paragraph', 'heading', 'bulletList', 'orderedList']
+
 const IndentExtension = Extension.create({
     name: 'indent',
     addGlobalAttributes() {
         return [
             {
-                types: ['paragraph', 'heading'],
+                types: INDENTABLE,
                 attributes: {
                     indent: {
                         default: 0,
@@ -25,6 +27,38 @@ const IndentExtension = Extension.create({
     }
 })
 
+function changeIndent(delta: number) {
+    return (e: { tiptap: any }) => {
+        e.tiptap
+            .chain()
+            .focus()
+            .command(({ tr, state }: { tr: any; state: any }) => {
+                const { $from } = state.selection
+                for (let d = $from.depth; d > 0; d--) {
+                    const node = $from.node(d)
+                    if (!INDENTABLE.includes(node.type.name)) continue
+                    if (
+                        (node.type.name === 'paragraph' || node.type.name === 'heading') &&
+                        $from.node(d - 1)?.type.name === 'listItem'
+                    )
+                        continue
+                    const pos = $from.before(d)
+                    const indent = node.attrs.indent || 0
+                    const next = indent + delta
+                    if (next >= 0) {
+                        tr.setNodeMarkup(pos, undefined, {
+                            ...node.attrs,
+                            indent: next
+                        })
+                    }
+                    break
+                }
+                return true
+            })
+            .run()
+    }
+}
+
 export const indentActions: ToolbarAction[] = [
     {
         name: 'Outdent',
@@ -32,30 +66,7 @@ export const indentActions: ToolbarAction[] = [
         icon: IconOutdent,
         tooltip: 'Decrease Indent',
         extensions: [IndentExtension],
-        command: (e) => {
-            e.tiptap
-                .chain()
-                .focus()
-                .command(({ tr, state }) => {
-                    state.doc.nodesBetween(
-                        state.selection.from,
-                        state.selection.to,
-                        (node, pos) => {
-                            if (node.type.name === 'paragraph' || node.type.name === 'heading') {
-                                const indent = node.attrs.indent || 0
-                                if (indent > 0) {
-                                    tr.setNodeMarkup(pos, undefined, {
-                                        ...node.attrs,
-                                        indent: indent - 1
-                                    })
-                                }
-                            }
-                        }
-                    )
-                    return true
-                })
-                .run()
-        },
+        command: changeIndent(-1),
         isActive: () => false
     },
     {
@@ -64,28 +75,7 @@ export const indentActions: ToolbarAction[] = [
         icon: IconIndent,
         tooltip: 'Increase Indent',
         extensions: [IndentExtension],
-        command: (e) => {
-            e.tiptap
-                .chain()
-                .focus()
-                .command(({ tr, state }) => {
-                    state.doc.nodesBetween(
-                        state.selection.from,
-                        state.selection.to,
-                        (node, pos) => {
-                            if (node.type.name === 'paragraph' || node.type.name === 'heading') {
-                                const indent = node.attrs.indent || 0
-                                tr.setNodeMarkup(pos, undefined, {
-                                    ...node.attrs,
-                                    indent: indent + 1
-                                })
-                            }
-                        }
-                    )
-                    return true
-                })
-                .run()
-        },
+        command: changeIndent(1),
         isActive: () => false
     }
 ]


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

- Remove format should only clean the styles and not remove elements.
- Indentation was not working correctly
- When click indent increase or decrease on a list item it should create a sub list or remove the sublist
- Tiptap / ProseMirror  creates paragraph in list items, which is still valid html. But added a css fix for no margins
