### PR TITLE
fix(admin/cli): username option not defined and rebuild failing

### DIFF
--- a/EMS/core-bundle/src/Command/AbstractCoreCommand.php
+++ b/EMS/core-bundle/src/Command/AbstractCoreCommand.php
@@ -46,7 +46,10 @@ abstract class AbstractCoreCommand extends AbstractCommand
     {
         $this->initialized = true;
         parent::initialize($input, $output);
-        $this->username = $this->getOptionStringNull(self::OPTION_USERNAME);
+
+        if ($input->hasOption(self::OPTION_USERNAME)) {
+            $this->username = $this->getOptionStringNull(self::OPTION_USERNAME);
+        }
     }
 
     public function getUsername(): string

--- a/EMS/core-bundle/src/Command/Environment/AbstractEnvironmentCommand.php
+++ b/EMS/core-bundle/src/Command/Environment/AbstractEnvironmentCommand.php
@@ -44,7 +44,7 @@ abstract class AbstractEnvironmentCommand extends AbstractCoreCommand
         $this->addUsernameOption($this->defaultUsernameOption);
     }
 
-    protected function configureRevisionSearcher(): void
+    protected function configureRevisionSearcher(string $defaultUser): void
     {
         $this
             ->addOption(self::OPTION_SCROLL_SIZE, null, InputOption::VALUE_REQUIRED, 'Size of the elasticsearch scroll request')
@@ -53,7 +53,7 @@ abstract class AbstractEnvironmentCommand extends AbstractCoreCommand
             ->addOption(self::OPTION_DRY_RUN, '', InputOption::VALUE_NONE, 'Dry run')
         ;
 
-        $this->addDeprecatedUsernameOption(self::OPTION_USER, null, $this->getUsername());
+        $this->addDeprecatedUsernameOption(self::OPTION_USER, null, $defaultUser);
     }
 
     #[\Override]

--- a/EMS/core-bundle/src/Command/Environment/AlignCommand.php
+++ b/EMS/core-bundle/src/Command/Environment/AlignCommand.php
@@ -68,7 +68,7 @@ class AlignCommand extends AbstractEnvironmentCommand
         ;
 
         $this->configureForceProtection();
-        $this->configureRevisionSearcher();
+        $this->configureRevisionSearcher(self::LOCK_USER);
     }
 
     #[\Override]

--- a/EMS/core-bundle/src/Command/Environment/UnpublishCommand.php
+++ b/EMS/core-bundle/src/Command/Environment/UnpublishCommand.php
@@ -47,7 +47,7 @@ final class UnpublishCommand extends AbstractEnvironmentCommand
         ;
 
         $this->configureForceProtection();
-        $this->configureRevisionSearcher();
+        $this->configureRevisionSearcher(self::LOCK_USER);
     }
 
     #[\Override]

--- a/EMS/core-bundle/src/Command/ReindexCommand.php
+++ b/EMS/core-bundle/src/Command/ReindexCommand.php
@@ -149,8 +149,8 @@ class ReindexCommand extends AbstractCoreCommand
             $this->bulker->setSize($bulkSize);
             $paginator = $revRepo->getRevisionsPaginatorPerEnvironmentAndContentType($environment, $contentType, $page, $bulkSize);
 
-            $this->io->newLine();
-            $this->io->text('Start reindex '.$contentType->getName());
+            $output->writeln('');
+            $output->writeln('Start reindex '.$contentType->getName());
             $progress = new ProgressBar($output, $paginator->count());
             $progress->start();
             do {
@@ -191,12 +191,11 @@ class ReindexCommand extends AbstractCoreCommand
             $this->bulker->send(true);
 
             $progress->finish();
-            $this->io->newLine();
-
-            $this->io->text(' '.$this->count.' objects are re-indexed in '.$index.' ('.$this->deleted.' not indexed as deleted, '.$this->error.' with indexing error)');
+            $output->writeln('');
+            $output->writeln(' '.$this->count.' objects are re-indexed in '.$index.' ('.$this->deleted.' not indexed as deleted, '.$this->error.' with indexing error)');
 
             if ($this->reloaded > 0) {
-                $this->io->text(\sprintf('%d documents are reloaded', $this->reloaded));
+                $output->writeln(\sprintf('%d documents are reloaded', $this->reloaded));
             }
 
             $this->logger->notice('command.reindex.end', [
@@ -214,7 +213,7 @@ class ReindexCommand extends AbstractCoreCommand
                 EmsFields::LOG_ENVIRONMENT_FIELD => $name,
             ]);
 
-            $this->io->warning('Environment named '.$name.' not found');
+            $output->writeln('WARNING: Environment named '.$name.' not found');
         }
     }
 }


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Regression bugs of https://github.com/ems-project/elasticms/pull/1670

## Problem 1

Runing `emsco:job:run` or `emco:user:create` throws an error: The "username" option does not exist.  

We can only ask for the username option if it's configured, and it can return null if not defined. But we cannot ask for the option if the command does not have the option.

## Problem 2

Rebuild is calling the reindex function of the reindex command. In this case $io is not defined and we should just use $output argument.

Typed property EMS\CommonBundle\Common\Command\AbstractCommand::$io must not be accessed before initialization

## Problem 3

Align command & unpublish command not working, because we are calling getUsername during configuration of the commands.
