### PR TITLE
fix(admin/security): API authorization bypass via access_control rule ordering

### DIFF
--- a/elasticms-admin/config/packages/security.yaml
+++ b/elasticms-admin/config/packages/security.yaml
@@ -83,8 +83,8 @@ security:
         - { path: ^/bundles, role: PUBLIC_ACCESS }
         - { path: ^/action, roles: ROLE_USER }
         - { path: ^/api/user-profile, roles: IS_AUTHENTICATED_FULLY }
-        - { path: ^/api, roles: ROLE_API }
         - { path: ^/api/admin, roles: ROLE_ADMIN }
+        - { path: ^/api, roles: ROLE_API }
         - { path: ^/admin, roles: ROLE_ADMIN }
         - { path: ^/channel-admin, roles: ROLE_ADMIN }
         - { path: ^/user, roles: ROLE_USER_MANAGEMENT }


### PR DESCRIPTION

| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | y  |
| Deprecations?  | n  |
| Fixed tickets? |  y |
| Documentation? | n  |

A default authorization flaw in ElasticMS allows any authenticated user with ROLE_API to access /api/admin/* endpoints that were intended to require ROLE_ADMIN.

The issue is caused by the shipped Symfony access_control rule order in elasticms-admin/config/packages/security.yaml. Because Symfony uses first-match-wins semantics, the generic ^/api rule is evaluated before the more specific ^/api/admin rule, so admin API routes are granted based on ROLE_API before the ROLE_ADMIN restriction is reached.

This results in vertical privilege escalation from ROLE_API to effective admin-level access on the API surface.
