### PR TITLE
fix(admin/security): open redirect via unvalidated redirect

### DIFF
--- a/EMS/core-bundle/src/EventListener/RequestListener.php
+++ b/EMS/core-bundle/src/EventListener/RequestListener.php
@@ -40,11 +40,35 @@ class RequestListener
     public function onKernelResponse(ResponseEvent $event): void
     {
         $response = $event->getResponse();
-        $redirectUrl = $event->getRequest()->query->get('redirectToUrl');
+        $redirectUrl = $this->getSafeRedirectTarget($event->getRequest()->query->get('redirectToUrl'));
 
-        if ($response instanceof RedirectResponse && \is_string($redirectUrl)) {
+        if ($response instanceof RedirectResponse && null !== $redirectUrl) {
             $response->setTargetUrl($redirectUrl);
         }
+    }
+
+    private function getSafeRedirectTarget(mixed $redirectUrl): ?string
+    {
+        if (!\is_string($redirectUrl) || '' === $redirectUrl) {
+            return null;
+        }
+
+        if (1 !== \preg_match('/^\/(?!\/)/', $redirectUrl) || \str_contains($redirectUrl, '\\') || 1 === \preg_match('/[\x00-\x1F\x7F]/', $redirectUrl)) {
+            return null;
+        }
+
+        $parts = \parse_url($redirectUrl);
+        if (false === $parts) {
+            return null;
+        }
+
+        foreach (['scheme', 'host', 'port', 'user', 'pass'] as $component) {
+            if (isset($parts[$component])) {
+                return null;
+            }
+        }
+
+        return $redirectUrl;
     }
 
     public function onKernelException(ExceptionEvent $event): void

--- a/EMS/core-bundle/tests/Unit/EventListener/RequestListenerTest.php
+++ b/EMS/core-bundle/tests/Unit/EventListener/RequestListenerTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EMS\CoreBundle\Tests\Unit\EventListener;
+
+use EMS\CoreBundle\EventListener\RequestListener;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+final class RequestListenerTest extends TestCase
+{
+    public function testItAllowsInternalRedirectTargets(): void
+    {
+        $listener = $this->createListener();
+        $request = Request::create('/login', 'GET', ['redirectToUrl' => '/dashboard?tab=welcome#intro']);
+        $response = new RedirectResponse('/default');
+        $event = new ResponseEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST, $response);
+
+        $listener->onKernelResponse($event);
+
+        self::assertSame('/dashboard?tab=welcome#intro', $response->getTargetUrl());
+    }
+
+    public function testItRejectsUnsafeRedirectTargets(): void
+    {
+        $listener = $this->createListener();
+
+        foreach ([
+            'https://evil.example.com',
+            '//evil.example.com',
+            '/\\evil.example.com',
+            "/safe\r\nLocation:https://evil.example.com",
+            'dashboard',
+        ] as $redirectToUrl) {
+            $request = Request::create('/login', 'GET', ['redirectToUrl' => $redirectToUrl]);
+            $response = new RedirectResponse('/default');
+            $event = new ResponseEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST, $response);
+
+            $listener->onKernelResponse($event);
+
+            self::assertSame('/default', $response->getTargetUrl(), \sprintf('Failed for redirect target "%s"', $redirectToUrl));
+        }
+    }
+
+    public function testItDoesNotChangeNonRedirectResponses(): void
+    {
+        $listener = $this->createListener();
+        $request = Request::create('/login', 'GET', ['redirectToUrl' => '/dashboard']);
+        $response = new Response();
+        $event = new ResponseEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST, $response);
+
+        $listener->onKernelResponse($event);
+
+        self::assertSame($response, $event->getResponse());
+    }
+
+    private function createListener(): RequestListener
+    {
+        return new \ReflectionClass(RequestListener::class)->newInstanceWithoutConstructor();
+    }
+}

--- a/EMS/core-bundle/tests/Unit/EventListener/RequestListenerTest.php
+++ b/EMS/core-bundle/tests/Unit/EventListener/RequestListenerTest.php
@@ -14,12 +14,19 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 final class RequestListenerTest extends TestCase
 {
+    private HttpKernelInterface $kernel;
+
+    protected function setUp(): void
+    {
+        $this->kernel = $this->createStub(HttpKernelInterface::class);
+    }
+
     public function testItAllowsInternalRedirectTargets(): void
     {
         $listener = $this->createListener();
         $request = Request::create('/login', 'GET', ['redirectToUrl' => '/dashboard?tab=welcome#intro']);
         $response = new RedirectResponse('/default');
-        $event = new ResponseEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST, $response);
+        $event = new ResponseEvent($this->kernel, $request, HttpKernelInterface::MAIN_REQUEST, $response);
 
         $listener->onKernelResponse($event);
 
@@ -39,7 +46,7 @@ final class RequestListenerTest extends TestCase
         ] as $redirectToUrl) {
             $request = Request::create('/login', 'GET', ['redirectToUrl' => $redirectToUrl]);
             $response = new RedirectResponse('/default');
-            $event = new ResponseEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST, $response);
+            $event = new ResponseEvent($this->kernel, $request, HttpKernelInterface::MAIN_REQUEST, $response);
 
             $listener->onKernelResponse($event);
 
@@ -52,7 +59,7 @@ final class RequestListenerTest extends TestCase
         $listener = $this->createListener();
         $request = Request::create('/login', 'GET', ['redirectToUrl' => '/dashboard']);
         $response = new Response();
-        $event = new ResponseEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST, $response);
+        $event = new ResponseEvent($this->kernel, $request, HttpKernelInterface::MAIN_REQUEST, $response);
 
         $listener->onKernelResponse($event);
 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  n |
| New feature?   | n  |
| BC breaks?     |  n |
| Deprecations?  | n  |
| Fixed tickets? | y  |
| Documentation? | n  |

ElasticMS contains a global open redirect vulnerability in EMS/core-bundle/src/EventListener/RequestListener.php.

The redirectToUrl query parameter is copied directly into RedirectResponse::setTargetUrl() without validation. An attacker can supply an external URL and cause the application to redirect users there after login or after any other flow that returns a redirect response.

This can be used for phishing and trust abuse by using a legitimate ElasticMS URL as the initial entry point.
