### PR TITLE
fix(admin/revision): isPublish not deleted envs

### DIFF
--- a/EMS/core-bundle/src/Entity/Revision.php
+++ b/EMS/core-bundle/src/Entity/Revision.php
@@ -595,8 +595,8 @@ class Revision implements EntityInterface, \Stringable
 
     public function isPublished(string $environmentName): bool
     {
-        foreach ($this->environmentRevisions as $environmentRevision) {
-            if ($environmentRevision->getEnvironment()->getName() === $environmentName) {
+        foreach ($this->getEnvironments() as $environment) {
+            if ($environment->getName() === $environmentName) {
                 return true;
             }
         }


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   |  n |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

The isPublished command is also checking deleted revisions, fixed by using the getEnvironments() which excludes deleted environments.
