### PR TITLE
fix(api): coreApi->getBaseUrl() always ends with a slash (/)

### DIFF
--- a/EMS/client-helper-bundle/src/Command/Local/PushCommand.php
+++ b/EMS/client-helper-bundle/src/Command/Local/PushCommand.php
@@ -90,7 +90,7 @@ final class PushCommand extends AbstractLocalCommand
 
     private function writeItem(string $type, Item $item, string $id): void
     {
-        $url = \vsprintf('%s - %s/data/revisions/%s:%s', [
+        $url = \vsprintf('%s - %sdata/revisions/%s:%s', [
             $item->getKey(),
             $this->coreApi->getBaseUrl(),
             $item->getContentType(),

--- a/elasticms-cli/src/Command/Web/DeadLinksCommand.php
+++ b/elasticms-cli/src/Command/Web/DeadLinksCommand.php
@@ -118,7 +118,7 @@ class DeadLinksCommand extends AbstractCommand
         $coreApi = $this->adminHelper->getCoreApi();
         if ($coreApi->isAuthenticated()) {
             $hash = $coreApi->file()->uploadFile($tempFile->path, 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', $filename);
-            $this->io->success(\sprintf('%s/data/file/%s?type=%s&name=%s', $coreApi->getBaseUrl(), $hash, 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', \urlencode($filename)));
+            $this->io->success(\sprintf('%sdata/file/%s?type=%s&name=%s', $coreApi->getBaseUrl(), $hash, 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', \urlencode($filename)));
         } else {
             File::putContents($filename, $tempFile->getContents());
             $this->io->success(\sprintf('The file %s has been saved in the current working directory', $filename));


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

