### PR TITLE
fix(clientHelper): avoid double slash in the displayed url

### DIFF
--- a/EMS/client-helper-bundle/src/Command/Local/PushCommand.php
+++ b/EMS/client-helper-bundle/src/Command/Local/PushCommand.php
@@ -90,7 +90,7 @@ final class PushCommand extends AbstractLocalCommand
 
     private function writeItem(string $type, Item $item, string $id): void
     {
-        $url = \vsprintf('%s - %s/data/revisions/%s:%s', [
+        $url = \vsprintf('%s - %sdata/revisions/%s:%s', [
             $item->getKey(),
             $this->coreApi->getBaseUrl(),
             $item->getContentType(),


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   |  n |
| BC breaks?     | n  |
| Deprecations?  |  n |
| Fixed tickets? | n  |
| Documentation? | n  |
