### PR TITLE
fix(common/core-api): avoid search attribute to be double json encoded in API calls

### DIFF
--- a/EMS/common-bundle/src/Common/CoreApi/Endpoint/Search/Search.php
+++ b/EMS/common-bundle/src/Common/CoreApi/Endpoint/Search/Search.php
@@ -24,13 +24,13 @@ class Search implements SearchInterface
     #[\Override]
     public function search(SearchObject $search): ResponseInterface
     {
-        return Response::fromArray($this->client->post('/api/search/search', ['search' => $search->serialize()])->getData());
+        return Response::fromArray($this->client->post('/api/search/search', ['search' => $search->toPayload()])->getData());
     }
 
     #[\Override]
     public function count(SearchObject $search): int
     {
-        $count = $this->client->post('/api/search/count', ['search' => $search->serialize()])->getData()['count'] ?? null;
+        $count = $this->client->post('/api/search/count', ['search' => $search->toPayload()])->getData()['count'] ?? null;
         if (!\is_int($count)) {
             throw new \RuntimeException('Unexpected: count must be a string');
         }

--- a/EMS/common-bundle/src/Common/CoreApi/Endpoint/Search/Search.php
+++ b/EMS/common-bundle/src/Common/CoreApi/Endpoint/Search/Search.php
@@ -32,7 +32,7 @@ class Search implements SearchInterface
     {
         $count = $this->client->post('/api/search/count', ['search' => $search->toPayload()])->getData()['count'] ?? null;
         if (!\is_int($count)) {
-            throw new \RuntimeException('Unexpected: count must be a string');
+            throw new \RuntimeException('Unexpected: count must be an integer');
         }
 
         return $count;

--- a/EMS/common-bundle/src/Common/CoreApi/Search/Scroll.php
+++ b/EMS/common-bundle/src/Common/CoreApi/Search/Scroll.php
@@ -83,7 +83,7 @@ class Scroll implements \Iterator
     private function initScroll(): void
     {
         $this->currentResponse = Response::fromArray($this->client->post('/api/search/init-scroll', [
-            'search' => $this->search->serialize(),
+            'search' => $this->search->toPayload(),
             'expire-time' => $this->expireTime,
         ])->getData());
         $this->currentPage = 0;

--- a/EMS/common-bundle/src/Search/Search.php
+++ b/EMS/common-bundle/src/Search/Search.php
@@ -11,6 +11,7 @@ use Elastica\Search as ElasticaSearch;
 use Elastica\Suggest;
 use EMS\CommonBundle\Elasticsearch\Aggregation\ElasticaAggregation;
 use EMS\CommonBundle\Elasticsearch\Document\EMSSource;
+use EMS\Helpers\Standard\Type;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Encoder\XmlEncoder;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;

--- a/EMS/common-bundle/src/Search/Search.php
+++ b/EMS/common-bundle/src/Search/Search.php
@@ -71,12 +71,7 @@ class Search
      */
     public function toPayload(): array
     {
-        $data = self::getSerializer()->normalize($this, null, self::SERIALIZER_CONTEXT);
-        if (!\is_array($data)) {
-            throw new \RuntimeException('Unexpected normalized search data');
-        }
-
-        return $data;
+        return Type::array(self::getSerializer()->normalize($this, null, self::SERIALIZER_CONTEXT));
     }
 
     /**

--- a/EMS/common-bundle/src/Search/Search.php
+++ b/EMS/common-bundle/src/Search/Search.php
@@ -19,6 +19,10 @@ use Symfony\Component\Serializer\Serializer;
 
 class Search
 {
+    private const SERIALIZER_CONTEXT = [
+        AbstractNormalizer::IGNORED_ATTRIBUTES => ['query', 'aggregations', 'suggest'],
+    ];
+
     /** @var string[] */
     private array $sourceIncludes = [];
     /** @var string[] */
@@ -49,12 +53,12 @@ class Search
 
     public function serialize(string $format = 'json'): string
     {
-        return self::getSerializer()->serialize($this, $format, [AbstractNormalizer::IGNORED_ATTRIBUTES => ['query', 'aggregations', 'suggest']]);
+        return self::getSerializer()->serialize($this, $format, self::SERIALIZER_CONTEXT);
     }
 
     public static function deserialize(string $data, string $format = 'json'): Search
     {
-        $data = self::getSerializer()->deserialize($data, Search::class, $format);
+        $data = self::getSerializer()->deserialize($data, self::class, $format, self::SERIALIZER_CONTEXT);
         if (!$data instanceof Search) {
             throw new \RuntimeException('Unexpected search object');
         }

--- a/EMS/common-bundle/src/Search/Search.php
+++ b/EMS/common-bundle/src/Search/Search.php
@@ -66,6 +66,32 @@ class Search
         return $data;
     }
 
+    /**
+     * @return mixed[]
+     */
+    public function toPayload(): array
+    {
+        $data = self::getSerializer()->normalize($this, null, self::SERIALIZER_CONTEXT);
+        if (!\is_array($data)) {
+            throw new \RuntimeException('Unexpected normalized search data');
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param mixed[] $data
+     */
+    public static function fromPayload(array $data): self
+    {
+        $search = self::getSerializer()->denormalize($data, self::class, null, self::SERIALIZER_CONTEXT);
+        if (!$search instanceof Search) {
+            throw new \RuntimeException('Unexpected search object');
+        }
+
+        return $search;
+    }
+
     public function hasSources(): bool
     {
         return \count($this->sourceIncludes) > 0 || \count($this->sourceExcludes) > 0;

--- a/EMS/common-bundle/tests/Unit/Common/CoreApi/Endpoint/Search/SearchAiTest.php
+++ b/EMS/common-bundle/tests/Unit/Common/CoreApi/Endpoint/Search/SearchAiTest.php
@@ -33,7 +33,7 @@ class SearchAiTest extends TestCase
 
         $this->client->expects($this->once())
             ->method('post')
-            ->with('/api/search/search', ['search' => $searchObject->serialize()])
+            ->with('/api/search/search', ['search' => $searchObject->toPayload()])
             ->willReturn($this->createMockResult(['data' => 'test']));
 
         $response = $this->search->search($searchObject);
@@ -47,7 +47,7 @@ class SearchAiTest extends TestCase
 
         $this->client->expects($this->once())
             ->method('post')
-            ->with('/api/search/count', ['search' => $searchObject->serialize()])
+            ->with('/api/search/count', ['search' => $searchObject->toPayload()])
             ->willReturn($this->createMockResult(['count' => 5]));
 
         $count = $this->search->count($searchObject);

--- a/EMS/common-bundle/tests/Unit/Common/CoreApi/Search/ScrollAiTest.php
+++ b/EMS/common-bundle/tests/Unit/Common/CoreApi/Search/ScrollAiTest.php
@@ -59,14 +59,14 @@ class ScrollAiTest extends TestCase
             ->expects($this->once())
             ->method('post')
             ->with('/api/search/init-scroll', [
-                'search' => '{}',
+                'search' => [],
                 'expire-time' => '3m',
             ])
             ->willReturn($this->createConfiguredMock(Result::class, ['getData' => []]));
 
         $this->search
-            ->method('serialize')
-            ->willReturn('{}');
+            ->method('toPayload')
+            ->willReturn([]);
 
         $scroll = new Scroll($this->client, $this->search);
         $scroll->rewind();

--- a/EMS/common-bundle/tests/Unit/Search/SearchAiTest.php
+++ b/EMS/common-bundle/tests/Unit/Search/SearchAiTest.php
@@ -25,6 +25,24 @@ class SearchAiTest extends TestCase
         $this->assertEquals($search->getIndices(), $deserialized->getIndices());
     }
 
+    public function testToPayloadAndFromPayload(): void
+    {
+        $search = new Search(['index1'], ['match_all' => new \stdClass()]);
+        $search->setSources(['field1']);
+        $search->setContentTypes(['type1']);
+        $search->setSize(15);
+        $search->setFrom(5);
+        $search->setSort(['field1' => 'asc']);
+        $search->addTermsAggregation('test_aggregation', 'field1', 10);
+        $search->setHighlight(['fields' => ['field1' => new \stdClass()]]);
+        $search->setRegex('test_regex');
+
+        $data = $search->toPayload();
+        $fromArray = Search::fromPayload($data);
+
+        $this->assertEquals($data, $fromArray->toPayload());
+    }
+
     public function testHasSources(): void
     {
         $search = new Search(['index1']);

--- a/EMS/core-bundle/src/Controller/Api/Search/SearchController.php
+++ b/EMS/core-bundle/src/Controller/Api/Search/SearchController.php
@@ -213,11 +213,12 @@ class SearchController
     private function getSearch(array $json): Search
     {
         $data = $json['search'] ?? null;
-        if (!\is_string($data)) {
-            throw new \RuntimeException('Unexpected: search must be a string');
+        if (\is_array($data)) {
+            return Search::fromPayload($data);
         }
-        $search = Search::deserialize($data);
-
-        return $search;
+        if (\is_string($data)) {
+            return Search::deserialize($data);
+        }
+        throw new \RuntimeException('Unexpected: search must be an array or a string');
     }
 }


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? |  n |
| Documentation? | n  |

FYI, Search::serialized is now only references by unit tests. 