### PR TITLE
fix(common/storage): heads when multiple storages

### DIFF
--- a/EMS/common-bundle/src/Storage/StorageManager.php
+++ b/EMS/common-bundle/src/Storage/StorageManager.php
@@ -101,10 +101,15 @@ class StorageManager implements FileManagerInterface
         $pagedHashes = \array_chunk($uniqueFileHashes, $this->headChunkSize, true);
 
         foreach ($pagedHashes as $hashes) {
+            $keepMissing = $hashes;
             foreach ($this->adapters as $adapter) {
-                yield from $adapter->heads(...$hashes);
-                break;
+                $keepMissing = \array_map(
+                    fn ($v1, $v2) => (\is_string($v1) && $v1 === $v2) ? $v1 : true,
+                    $keepMissing,
+                    $adapter->heads(...$hashes)
+                );
             }
+            yield $keepMissing;
         }
     }
 

--- a/EMS/common-bundle/src/Storage/StorageManager.php
+++ b/EMS/common-bundle/src/Storage/StorageManager.php
@@ -108,6 +108,10 @@ class StorageManager implements FileManagerInterface
                     $keepMissing,
                     $adapter->heads(...$hashes)
                 );
+                $hashes = \array_filter($keepMissing, fn ($v) => \is_string($v));
+                if ([] === $hashes) {
+                    break;
+                }
             }
             yield from \array_values($keepMissing);
         }

--- a/EMS/common-bundle/src/Storage/StorageManager.php
+++ b/EMS/common-bundle/src/Storage/StorageManager.php
@@ -109,7 +109,7 @@ class StorageManager implements FileManagerInterface
                     $adapter->heads(...$hashes)
                 );
             }
-            yield $keepMissing;
+            yield from \array_values($keepMissing);
         }
     }
 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? |  n |
| Documentation? | n  |

In case of multiple storages defined, only the first storage was answering to `heads` calls.
