### PR TITLE
fix(admin/twig): missing double quotes in media library template

### DIFF
--- a/EMS/admin-ui-bundle/templates/bootstrap5/components/media_library/template.twig
+++ b/EMS/admin-ui-bundle/templates/bootstrap5/components/media_library/template.twig
@@ -59,7 +59,7 @@
 {%- endblock media_lib_file_row -%}
 
 {% block media_lib_file %}
-    <div><a href="{{- mediaFile.urlView -}}" download="{{- mediaFile.name -}}" data-ems-id="{{- mediaFile.emsId -}}" data-json="{{ mediaFile.getDataJson()|e('html_attr') }}>{{- mediaFile.name -}}</a></div>
+    <div><a href="{{- mediaFile.urlView -}}" download="{{- mediaFile.name -}}" data-ems-id="{{- mediaFile.emsId -}}" data-json="{{ mediaFile.getDataJson()|e('html_attr') }}">{{- mediaFile.name -}}</a></div>
     <div>{{- mediaFile.file.mimetype|trans({}, 'emsco-mimetypes') -}}</div>
     <div class="text-right">{{- mediaFile.file.filesize|ems_format_bytes -}}</div>
 {% endblock media_lib_file %}

--- a/EMS/core-bundle/templates/components/media_library/template.twig
+++ b/EMS/core-bundle/templates/components/media_library/template.twig
@@ -59,7 +59,7 @@
 {%- endblock media_lib_file_row -%}
 
 {% block media_lib_file %}
-    <div><a href="{{- mediaFile.urlView -}}" download="{{- mediaFile.name -}}" data-ems-id="{{- mediaFile.emsId -}}" data-json="{{ mediaFile.getDataJson()|e('html_attr') }}>{{- mediaFile.name -}}</a></div>
+    <div><a href="{{- mediaFile.urlView -}}" download="{{- mediaFile.name -}}" data-ems-id="{{- mediaFile.emsId -}}" data-json="{{ mediaFile.getDataJson()|e('html_attr') }}">{{- mediaFile.name -}}</a></div>
     <div>{{- mediaFile.file.mimetype|trans({}, 'emsco-mimetypes') -}}</div>
     <div class="text-right">{{- mediaFile.file.filesize|ems_format_bytes -}}</div>
 {% endblock media_lib_file %}


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  |n  |
| Fixed tickets? | n  |
| Documentation? | n  |

