### PR TITLE
refactor(admin/form): remove defaultValue from DataLinkFieldType

### DIFF
--- a/EMS/core-bundle/src/Form/DataField/DataLinkFieldType.php
+++ b/EMS/core-bundle/src/Form/DataField/DataLinkFieldType.php
@@ -177,7 +177,6 @@ class DataLinkFieldType extends DataFieldType
         $resolver->setDefault('type', null);
         $resolver->setDefault('searchId', null);
         $resolver->setDefault('environment', null);
-        $resolver->setDefault('defaultValue', null);
         $resolver->setDefault('required', false);
         $resolver->setDefault('sortable', false);
         $resolver->setDefault('dynamicLoading', true);
@@ -240,8 +239,6 @@ class DataLinkFieldType extends DataFieldType
         ])->add('type', TextType::class, [
             'required' => false,
         ])->add('searchId', TextType::class, [
-            'required' => false,
-        ])->add('defaultValue', TextType::class, [
             'required' => false,
         ]);
 


### PR DESCRIPTION
… 

| Q              | A |
|----------------|---|
| Bug fix?       |   |
| New feature?   |   |
| BC breaks?     |   |
| Deprecations?  |   |
| Fixed tickets? |   |
| Documentation? |   |

he DataLinkFieldType's defaultValue field has neve worked the right way to specify a default value is in the ContentType's defaultValue

fix: #124 
