### PR TITLE
fix(admin/translation): channel not set user locale

### DIFF
--- a/EMS/core-bundle/src/EventListener/UserLocaleListener.php
+++ b/EMS/core-bundle/src/EventListener/UserLocaleListener.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace EMS\CoreBundle\EventListener;
 
 use EMS\CoreBundle\Entity\User;
+use EMS\CoreBundle\Service\Channel\ChannelRegistrar;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -31,6 +32,10 @@ final readonly class UserLocaleListener implements EventSubscriberInterface
     public function onKernelRequest(RequestEvent $event): void
     {
         if (!$event->isMainRequest()) {
+            return;
+        }
+
+        if (\preg_match(ChannelRegistrar::EMSCO_CHANNEL_PATH_REGEX, $event->getRequest()->getPathInfo())) {
             return;
         }
 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Bug from: https://github.com/ems-project/elasticms/pull/1718
We can not set the user locale, if we are inside a channel
