### PR TITLE
fix(admin/inline-editor): add translation keys

### DIFF
--- a/EMS/admin-ui-bundle/templates/inline-editor/editor.html.twig
+++ b/EMS/admin-ui-bundle/templates/inline-editor/editor.html.twig
@@ -1,4 +1,5 @@
 {% use "@EMSAdminUI/inline-editor/render.html.twig" %}
+{%- trans_default_domain 'ems-adminui-twigs' -%}
 <!doctype html>
 <html lang="en">
     <head>

--- a/EMS/admin-ui-bundle/templates/inline-editor/render.html.twig
+++ b/EMS/admin-ui-bundle/templates/inline-editor/render.html.twig
@@ -1,3 +1,5 @@
+{%- trans_default_domain 'ems-adminui-twigs' -%}
+
 {%- block actions -%}
     <button type="button" class="btn btn-sm btn-outline-secondary" data-editor-action="discard">
         {{ 'inline_editor.action.discard'|trans }}

--- a/EMS/admin-ui-bundle/translations/ems-adminui-twigs+intl-icu.en.yml
+++ b/EMS/admin-ui-bundle/translations/ems-adminui-twigs+intl-icu.en.yml
@@ -112,6 +112,16 @@ field_type:
         edit: Edit
         move_item: Move
         paste: Paste
+inline_editor:
+    action:
+        discard: Discard
+        exit: Exit
+        publish: Publish
+        save: Save
+    elements: Elements
+    status:
+        draft_by: 'In draft by "{user}"'
+    title: 'Inline Editor'
 job:
     command: Command
     completed: Completed

--- a/EMS/admin-ui-bundle/translations/ems-adminui-twigs+intl-icu.fr.yml
+++ b/EMS/admin-ui-bundle/translations/ems-adminui-twigs+intl-icu.fr.yml
@@ -112,6 +112,16 @@ field_type:
         edit: Modifier
         move_item: Déplacer
         paste: Coller
+inline_editor:
+    action:
+        discard: Abandonner
+        exit: Quitter
+        publish: Publier
+        save: Enregistrer
+    elements: Éléments
+    status:
+        draft_by: 'En brouillon par "{user}"'
+    title: 'Éditeur en ligne'
 job:
     command: Commande
     completed: Terminé

--- a/EMS/admin-ui-bundle/translations/ems-adminui-twigs+intl-icu.nl.yml
+++ b/EMS/admin-ui-bundle/translations/ems-adminui-twigs+intl-icu.nl.yml
@@ -112,6 +112,16 @@ field_type:
         edit: Bewerken
         move_item: Verplaatsen
         paste: Plakken
+inline_editor:
+    action:
+        discard: Annuleren
+        exit: Afsluiten
+        publish: Publiceren
+        save: Opslaan
+    elements: Elementen
+    status:
+        draft_by: 'In concept door "{user}"'
+    title: Inline-editor
 job:
     command: Commando
     completed: Voltooid


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   |  n |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Add missing translations keys.
Keys were added in https://github.com/ems-project/elasticms/pull/1718, but no translations
