### PR TITLE
fix(common/storage): preserve input order in S3 adapter heads()

### DIFF
--- a/EMS/common-bundle/src/Storage/Service/S3Storage.php
+++ b/EMS/common-bundle/src/Storage/Service/S3Storage.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace EMS\CommonBundle\Storage\Service;
 
 use Aws\CommandPool;
-use Aws\Exception\AwsException;
 use Aws\S3\Exception\S3Exception;
 use Aws\S3\S3Client;
 use EMS\CommonBundle\Common\Cache\Cache;

--- a/EMS/common-bundle/src/Storage/Service/S3Storage.php
+++ b/EMS/common-bundle/src/Storage/Service/S3Storage.php
@@ -409,25 +409,27 @@ class S3Storage extends AbstractUrlStorage implements \Stringable
     public function heads(string ...$hashes): array
     {
         $client = $this->getS3Client();
-        $notFound = [];
+        $notFound = \array_fill(0, \count($hashes), true);
 
         $promiseGenerator = function () use ($hashes, $client, &$notFound) {
-            foreach ($hashes as $hash) {
+            foreach ($hashes as $index => $hash) {
                 yield $client->headObjectAsync([
                     'Bucket' => $this->bucket,
                     'Key' => \implode('/', [\substr($hash, 0, 3), $hash]),
-                ])->then(onFulfilled: function () use (&$notFound) {
-                    $notFound[] = true;
-                }, onRejected: function (AwsException $exception) use (&$notFound, $hash) {
-                    if ('NotFound' === $exception->getAwsErrorCode()) {
-                        $notFound[] = $hash;
+                ])->then(
+                    onFulfilled: function () use (&$notFound, $index) {
+                        $notFound[$index] = true;
+                    },
+                    onRejected: function (AwsException $exception) use (&$notFound, $hash, $index) {
+                        if ('NotFound' === $exception->getAwsErrorCode()) {
+                            $notFound[$index] = $hash;
+                        }
                     }
-                });
+                );
             }
         };
 
-        $promise = Each::ofLimit(iterable: $promiseGenerator(), concurrency: 500);
-        $promise->wait();
+        Each::ofLimit(iterable: $promiseGenerator(), concurrency: 500)->wait();
 
         return $notFound;
     }

--- a/EMS/common-bundle/src/Storage/Service/S3Storage.php
+++ b/EMS/common-bundle/src/Storage/Service/S3Storage.php
@@ -420,11 +420,9 @@ class S3Storage extends AbstractUrlStorage implements \Stringable
                     onFulfilled: function () use (&$notFound, $index) {
                         $notFound[$index] = true;
                     },
-                    onRejected: function (AwsException $exception) use (&$notFound, $hash, $index) {
-                        if ('NotFound' === $exception->getAwsErrorCode()) {
-                            $notFound[$index] = $hash;
-                        }
-                    }
+                    onRejected: function () use (&$notFound, $hash, $index) {
+                        $notFound[$index] = $hash;
+                    },
                 );
             }
         };


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   |  n |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Regression of https://github.com/ems-project/elasticms/pull/1703

## Problem
The S3 storage adapter's heads() method returned results in promise completion order instead of input order. Due to the concurrent execution (Each::ofLimit with concurrency 500), S3 does not necessarily respond in the order requests were sent.

## Impact
The caller in StorageManager::heads() uses array_map to align results positionally with the input hashes. Because of the out-of-order responses, existing files were sometimes matched to hashes not yet present in S3, causing false negatives: files were marked as "already exists" and skipped during upload.
The issue manifested intermittently, depending on S3 response timing.

## Solution
The $notFound array is now pre-filled with true based on the input count, and the promise callbacks write to a specific index instead of appending. This keeps the output order aligned with the input order, as expected by the array<int, string|true> contract of StorageAdapterInterface::heads().
