### PR TITLE
fix(core/api): search payload query not working

### DIFF
--- a/EMS/common-bundle/src/Search/Search.php
+++ b/EMS/common-bundle/src/Search/Search.php
@@ -84,6 +84,9 @@ class Search
         if (!$search instanceof Search) {
             throw new \RuntimeException('Unexpected search object');
         }
+        if (isset($data['query'])) {
+            $search->setQueryArray($data['query']);
+        }
 
         return $search;
     }


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Regresssion of #1699 

the /api/search/search endpoint is not using the query from the post data. This because the query is in the ignored attributes.
