### PR TITLE
fix(common/api): api search fromPayload issue

### DIFF
--- a/EMS/common-bundle/src/Search/Search.php
+++ b/EMS/common-bundle/src/Search/Search.php
@@ -75,22 +75,6 @@ class Search
         return Type::array(self::getSerializer()->normalize($this, null, self::SERIALIZER_CONTEXT));
     }
 
-    /**
-     * @param mixed[] $data
-     */
-    public static function fromPayload(array $data): self
-    {
-        $search = self::getSerializer()->denormalize($data, self::class, null, self::SERIALIZER_CONTEXT);
-        if (!$search instanceof Search) {
-            throw new \RuntimeException('Unexpected search object');
-        }
-        if (isset($data['query'])) {
-            $search->setQueryArray($data['query']);
-        }
-
-        return $search;
-    }
-
     public function hasSources(): bool
     {
         return \count($this->sourceIncludes) > 0 || \count($this->sourceExcludes) > 0;

--- a/EMS/common-bundle/tests/Unit/Search/SearchAiTest.php
+++ b/EMS/common-bundle/tests/Unit/Search/SearchAiTest.php
@@ -9,6 +9,7 @@ use Elastica\Query\MatchAll;
 use Elastica\Suggest;
 use Elastica\Suggest\Term;
 use EMS\CommonBundle\Search\Search;
+use EMS\Helpers\Standard\Json;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Serializer;
 
@@ -38,7 +39,7 @@ class SearchAiTest extends TestCase
         $search->setRegex('test_regex');
 
         $data = $search->toPayload();
-        $fromArray = Search::fromPayload($data);
+        $fromArray = Search::deserialize(Json::encode($data));
 
         $this->assertEquals($data, $fromArray->toPayload());
     }

--- a/EMS/core-bundle/src/Controller/Api/Search/SearchController.php
+++ b/EMS/core-bundle/src/Controller/Api/Search/SearchController.php
@@ -214,7 +214,7 @@ class SearchController
     {
         $data = $json['search'] ?? null;
         if (\is_array($data)) {
-            return Search::fromPayload($data);
+            $data = Json::encode($data);
         }
         if (\is_string($data)) {
             return Search::deserialize($data);

--- a/EMS/core-bundle/src/Controller/ContentManagement/FileController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/FileController.php
@@ -117,12 +117,12 @@ class FileController extends AbstractController
         $name = $params['name'] ?? 'upload.bin';
         $type = $params['type'] ?? 'application/bin';
         $hash = $params['hash'] ?? $sha1;
-        $size = $params['size'] ?? $size;
+        $size = (int) ($params['size'] ?? $size);
         $algo = $params['algo'] ?? 'sha1';
 
         $user = $this->getUsername();
 
-        if (empty($hash) || empty($algo) || (empty($size) && 0 !== $size)) {
+        if (empty($hash) || empty($algo) || 0 === $size) {
             throw new BadRequestHttpException('Bad Request, invalid json parameters');
         }
 

--- a/EMS/core-bundle/src/Controller/ContentManagement/FileController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/FileController.php
@@ -102,7 +102,6 @@ class FileController extends AbstractController
     /**
      * @param int $size
      */
-    #[\Deprecated]
     public function initUploadFile(?string $sha1, $size, bool $apiRoute, Request $request): Response
     {
         if ($sha1 || $size) {

--- a/EMS/core-bundle/src/Controller/ContentManagement/FileController.php
+++ b/EMS/core-bundle/src/Controller/ContentManagement/FileController.php
@@ -122,7 +122,7 @@ class FileController extends AbstractController
 
         $user = $this->getUsername();
 
-        if (empty($hash) || empty($algo) || 0 === $size) {
+        if (empty($hash) || empty($algo) || $size < 0) {
             throw new BadRequestHttpException('Bad Request, invalid json parameters');
         }
 


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   |  n |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? |  n |
| Documentation? | n  |

a json like {"query":{"match_all":{}}} mlust not be converted into {"query":{"match_all":[]}}
