### PR TITLE
fix(admin/querySearch): load dataLinks from query search environments

### DIFF
--- a/EMS/core-bundle/src/Form/Field/ObjectChoiceList.php
+++ b/EMS/core-bundle/src/Form/Field/ObjectChoiceList.php
@@ -77,7 +77,7 @@ class ObjectChoiceList implements ChoiceListInterface
     #[\Override]
     public function getChoicesForValues(array $choices): array
     {
-        $this->choices = $this->objectChoiceCacheService->load($choices, $this->circleOnly, $this->withWarning);
+        $this->choices = $this->objectChoiceCacheService->load($choices, $this->querySearchName, $this->circleOnly, $this->withWarning);
 
         return \array_keys($this->choices);
     }
@@ -90,7 +90,7 @@ class ObjectChoiceList implements ChoiceListInterface
     #[\Override]
     public function getValuesForChoices(array $choices): array
     {
-        $this->choices = $this->objectChoiceCacheService->load($choices, $this->circleOnly, $this->withWarning);
+        $this->choices = $this->objectChoiceCacheService->load($choices, $this->querySearchName, $this->circleOnly, $this->withWarning);
 
         return \array_keys($this->choices);
     }
@@ -116,7 +116,7 @@ class ObjectChoiceList implements ChoiceListInterface
      */
     public function loadChoices(array $choices): array
     {
-        $this->choices = $this->objectChoiceCacheService->load($choices, $this->circleOnly, $this->withWarning);
+        $this->choices = $this->objectChoiceCacheService->load($choices, $this->querySearchName, $this->circleOnly, $this->withWarning);
 
         return $this->choices;
     }

--- a/EMS/core-bundle/src/Service/ObjectChoiceCacheService.php
+++ b/EMS/core-bundle/src/Service/ObjectChoiceCacheService.php
@@ -12,6 +12,8 @@ use EMS\CommonBundle\Search\Search;
 use EMS\CommonBundle\Service\ElasticaService;
 use EMS\CoreBundle\Core\ContentType\Version\VersionFields;
 use EMS\CoreBundle\Entity\ContentType;
+use EMS\CoreBundle\Entity\Environment;
+use EMS\CoreBundle\Entity\QuerySearch;
 use EMS\CoreBundle\Entity\UserInterface;
 use EMS\CoreBundle\Form\Field\ObjectChoiceListItem;
 use EMS\CoreBundle\Service\Revision\RevisionService;
@@ -132,7 +134,7 @@ class ObjectChoiceCacheService
      *
      * @return ObjectChoiceListItem[]
      */
-    public function load(array $objectIds, bool $circleOnly = false, bool $withWarning = true): array
+    public function load(array $objectIds, ?string $querySearchName, bool $circleOnly = false, bool $withWarning = true): array
     {
         $choices = [];
         $missingOuuidsPerIndexAndType = [];
@@ -149,7 +151,7 @@ class ObjectChoiceCacheService
                     if (!isset($this->fullyLoaded[$objectType])) {
                         $contentType = $this->contentTypeService->getByName($objectType);
                         if ($contentType) {
-                            $index = $this->contentTypeService->getIndex($contentType);
+                            $index = $querySearchName ?? $this->contentTypeService->getIndex($contentType);
                             if ($index) {
                                 $missingOuuidsPerIndexAndType[$index][$objectType][] = $objectOuuid;
                             } elseif ($withWarning) {
@@ -200,7 +202,16 @@ class ObjectChoiceCacheService
             }
             $boolQuery->setMinimumShouldMatch(1);
 
-            $search = new Search([$indexName], $boolQuery);
+            if (null !== $querySearchName) {
+                $querySearch = $this->querySearchName->getByItemName($querySearchName);
+                if (!$querySearch instanceof QuerySearch) {
+                    throw new \RuntimeException('Unexpected query search object');
+                }
+                $searchAliases = \array_map(fn (Environment $env) => $env->getAlias(), $querySearch->getEnvironments());
+                $search = new Search($searchAliases, $boolQuery);
+            } else {
+                $search = new Search([$indexName], $boolQuery);
+            }
             $search->setSources($sourceField);
 
             $scroll = $this->elasticaService->scroll($search);


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? |  n |
| Documentation? | n  |

If a datalink is loaded from a QuerySearch, the loader must relies on the QuerySearch's environments (e.g. archives or synonyms in external environments)
