### PR TITLE
fix(admin/xliff): new translation must option

### DIFF
--- a/EMS/core-bundle/src/Command/Xliff/ExtractCommand.php
+++ b/EMS/core-bundle/src/Command/Xliff/ExtractCommand.php
@@ -66,6 +66,7 @@ final class ExtractCommand extends AbstractCommand
     public const string OPTION_MAIL_TO = 'mail-to';
     public const string OPTION_MAIL_CC = 'mail-cc';
     public const string OPTION_MAIL_REPLY_TO = 'mail-reply-to';
+    public const string OPTION_TRANSLATION_MUST = 'translation-must';
     private const string MAIL_TEMPLATE = '@EMSCore/email/xliff/extract.email.html.twig';
     private string $xliffBasename;
     private ?string $baseUrl = null;
@@ -114,6 +115,7 @@ final class ExtractCommand extends AbstractCommand
             ->addOption(self::OPTION_MAIL_TO, null, InputOption::VALUE_OPTIONAL, 'A comma seperated list of emails where to send the XLIFF')
             ->addOption(self::OPTION_MAIL_CC, null, InputOption::VALUE_OPTIONAL, 'A comma seperated list of emails where to send, in carbon copy, the XLIFF')
             ->addOption(self::OPTION_MAIL_REPLY_TO, null, InputOption::VALUE_OPTIONAL, 'A comma seperated list of emails where to reply')
+            ->addOption(self::OPTION_TRANSLATION_MUST, null, InputOption::VALUE_OPTIONAL, 'Add must in query for searching translations', null)
         ;
     }
 
@@ -145,6 +147,11 @@ final class ExtractCommand extends AbstractCommand
 
         if (null === $this->translationField && $this->translationField !== $this->localeField) {
             throw new \RuntimeException(\sprintf('Both %s and %s options must be defined or not defined at all (fields defined with %%locale%% placeholder)', self::OPTION_TRANSLATION_FIELD, self::OPTION_LOCALE_FIELD));
+        }
+
+        $translationMust = $this->getOptionStringNull(self::OPTION_TRANSLATION_MUST);
+        if (null !== $translationMust) {
+            $this->xliffService->setTranslationMust($translationMust);
         }
     }
 

--- a/EMS/core-bundle/src/Command/Xliff/UpdateCommand.php
+++ b/EMS/core-bundle/src/Command/Xliff/UpdateCommand.php
@@ -43,6 +43,7 @@ final class UpdateCommand extends AbstractCommand
     public const string OPTION_DRY_RUN = 'dry-run';
     public const string OPTION_CURRENT_REVISION_ONLY = 'current-revision-only';
     public const string OPTION_BASE_URL = 'base-url';
+    public const string OPTION_TRANSLATION_MUST = 'translation-must';
 
     private string $xliffFilename;
     private ?Environment $publishTo = null;
@@ -75,7 +76,9 @@ final class UpdateCommand extends AbstractCommand
             ->addOption(self::OPTION_TRANSLATION_FIELD, null, InputOption::VALUE_OPTIONAL, 'Field containing the translation field', null)
             ->addOption(self::OPTION_DRY_RUN, null, InputOption::VALUE_NONE, 'If set nothing is saved in the database')
             ->addOption(self::OPTION_CURRENT_REVISION_ONLY, null, InputOption::VALUE_NONE, 'Translations will be updated only is the source revision is still a current revision')
-            ->addOption(self::OPTION_BASE_URL, null, InputOption::VALUE_OPTIONAL, 'Base url, in order to generate a download link to the error report');
+            ->addOption(self::OPTION_BASE_URL, null, InputOption::VALUE_OPTIONAL, 'Base url, in order to generate a download link to the error report')
+            ->addOption(self::OPTION_TRANSLATION_MUST, null, InputOption::VALUE_OPTIONAL, 'Add must in query for searching translations', null)
+        ;
     }
 
     #[\Override]
@@ -101,6 +104,11 @@ final class UpdateCommand extends AbstractCommand
 
         if (null === $this->translationField && $this->translationField !== $this->localeField) {
             throw new \RuntimeException(\sprintf('Both %s and %s options must be defined or not defined at all (fields defined with %%locale%% placeholder)', self::OPTION_TRANSLATION_FIELD, self::OPTION_LOCALE_FIELD));
+        }
+
+        $translationMust = $this->getOptionStringNull(self::OPTION_TRANSLATION_MUST);
+        if (null !== $translationMust) {
+            $this->xliffService->setTranslationMust($translationMust);
         }
     }
 

--- a/EMS/core-bundle/src/Service/Internationalization/XliffService.php
+++ b/EMS/core-bundle/src/Service/Internationalization/XliffService.php
@@ -16,6 +16,7 @@ use EMS\CoreBundle\Entity\Revision;
 use EMS\CoreBundle\Exception\XliffException;
 use EMS\CoreBundle\Service\Revision\RevisionService;
 use EMS\Helpers\Html\HtmlHelper;
+use EMS\Helpers\Standard\Json;
 use EMS\Xliff\Xliff\Entity\InsertReport;
 use EMS\Xliff\Xliff\Extractor;
 use EMS\Xliff\Xliff\InsertionRevision;
@@ -23,6 +24,9 @@ use Psr\Log\LoggerInterface;
 
 class XliffService
 {
+    /** @var array<mixed>|null */
+    private ?array $translationMust = null;
+
     public function __construct(private readonly LoggerInterface $logger, private readonly RevisionService $revisionService, private readonly ElasticaService $elasticaService)
     {
     }
@@ -126,6 +130,11 @@ class XliffService
         return $this->revisionService->updateRawData($currentRevision, $data, $username);
     }
 
+    public function setTranslationMust(string $translationMust): void
+    {
+        $this->translationMust = Json::decode($translationMust);
+    }
+
     public function testInsert(InsertReport $insertReport, InsertionRevision $insertionRevision, ?string $localeField): void
     {
         $propertyAccessor = PropertyAccessor::createPropertyAccessor();
@@ -169,6 +178,11 @@ class XliffService
         $boolQuery = $this->elasticaService->getBoolQuery();
         $boolQuery->addMust($this->elasticaService->getTermsQuery($translationField, [$translationId]));
         $boolQuery->addMust($this->elasticaService->getTermsQuery($localeField, [$targetLocale]));
+
+        if (null !== $this->translationMust) {
+            $boolQuery->addMust($this->translationMust);
+        }
+
         $search = new Search([$targetEnvironment->getAlias()], $boolQuery);
         try {
             return $this->elasticaService->singleSearch($search);


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  y |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | n  |
| Documentation? | n  |

Add a new 'translation-must' option on the extract/update translation command. For duplicate translation ids
