### PR TITLE
feat(admin/tiptap): improve inline editor support

### DIFF
--- a/EMS/admin-ui-bundle/assets/css/core/components/_inline_editor.scss
+++ b/EMS/admin-ui-bundle/assets/css/core/components/_inline_editor.scss
@@ -1,7 +1,8 @@
 @import "bootstrap/scss/bootstrap";
 @import "./dialog";
 @import "./tiptap/toolbar";
-@import "./tiptap/_context_menu";
+@import "./tiptap/context_menu";
+@import "./tiptap/dialog";
 
 html, body {
   margin: 0;

--- a/EMS/admin-ui-bundle/assets/css/core/components/_inline_editor_iframe.scss
+++ b/EMS/admin-ui-bundle/assets/css/core/components/_inline_editor_iframe.scss
@@ -12,18 +12,20 @@
     --go2editor-z: 1050;
 }
 
-[contenteditable] {
-    outline: none;
-    display: inline-block;
-}
+.ProseMirror {
+    &[contenteditable] {
+        outline: none;
+        display: inline-block;
+    }
 
-[contenteditable]:focus {
-    background-color: rgba(0, 150, 255, 0.1);
-    border-radius: 4px;
-}
+    &[contenteditable]:focus {
+        background-color: rgba(0, 150, 255, 0.1);
+        border-radius: 4px;
+    }
 
-[contenteditable]::selection {
-    background: rgba(0, 150, 255, 0.3);
+    &[contenteditable]::selection {
+        background: rgba(0, 150, 255, 0.3);
+    }
 }
 
 #go2editor {

--- a/EMS/admin-ui-bundle/assets/css/core/components/_wysiwyg_tiptap.scss
+++ b/EMS/admin-ui-bundle/assets/css/core/components/_wysiwyg_tiptap.scss
@@ -109,13 +109,3 @@ body.wysiwyg-resizing {
         }
     }
 }
-
-.wysiwyg-source-container {
-    display: none;
-}
-.is-source-mode .wysiwyg-source-container {
-    display: block;
-}
-.is-source-mode .wysiwyg-iframe {
-    display: none;
-}

--- a/EMS/admin-ui-bundle/assets/css/core/components/tiptap/_dialog.scss
+++ b/EMS/admin-ui-bundle/assets/css/core/components/tiptap/_dialog.scss
@@ -17,8 +17,10 @@ dialog.ems-dialog .tiptap-dialog-color {
     cursor: pointer;
     box-sizing: border-box;
     border: 1px solid transparent;
+    outline: none;
 
-    &:hover {
+    &:hover,
+    &:focus-visible {
       border-color: #000;
       outline: 1px solid #fff;
       outline-offset: -2px;

--- a/EMS/admin-ui-bundle/assets/src/core/components/dialog.ts
+++ b/EMS/admin-ui-bundle/assets/src/core/components/dialog.ts
@@ -10,6 +10,7 @@ interface DialogOptions {
     draggable?: boolean
     closeLabel: string
     bodyClass?: string
+    doc?: Document
 }
 
 export class Dialog {
@@ -17,12 +18,14 @@ export class Dialog {
     body: HTMLElement
     footer: HTMLElement
     private options: DialogOptions
+    private readonly doc: Document
 
     private onCloseCallback?: () => void
 
     constructor(title: string, options: DialogOptions) {
         this.options = options
-        this.element = document.createElement('dialog')
+        this.doc = options.doc ?? document
+        this.element = this.doc.createElement('dialog')
         this.element.className = 'ems-dialog'
 
         this.element.innerHTML = `
@@ -47,7 +50,7 @@ export class Dialog {
         this.element.querySelector('.dialog-close')!.addEventListener('click', () => this.close())
 
         this.element.addEventListener('close', () => {
-            document.body.classList.remove('dialog-open')
+            this.doc.body.classList.remove('dialog-open')
             this.element.remove()
             this.onCloseCallback?.()
         })
@@ -61,13 +64,12 @@ export class Dialog {
             this.makeDraggable()
         }
 
-        const doc = window.top?.document || document
-        doc.body.appendChild(this.element)
+        this.doc.body.appendChild(this.element)
     }
 
     private makeDraggable(): void {
         const header = this.element.querySelector('.dialog-header') as HTMLElement
-        const doc = window.top?.document || document
+        const doc = this.doc
         header.classList.add('draggable')
         let offsetX = 0
         let offsetY = 0
@@ -107,7 +109,7 @@ export class Dialog {
     }
 
     addButton({ label, variant = 'default', onClick }: DialogButton): this {
-        const btn = document.createElement('button')
+        const btn = this.doc.createElement('button')
         btn.innerText = label
         btn.type = 'button'
         btn.dataset.variant = variant
@@ -120,7 +122,7 @@ export class Dialog {
     }
 
     open(): void {
-        document.body.classList.add('dialog-open')
+        this.doc.body.classList.add('dialog-open')
         this.element.showModal()
         const firstInput = this.element.querySelector<HTMLElement>('input, select, textarea')
         if (firstInput) {

--- a/EMS/admin-ui-bundle/assets/src/core/components/tiptap/editor.ts
+++ b/EMS/admin-ui-bundle/assets/src/core/components/tiptap/editor.ts
@@ -37,6 +37,8 @@ export class TiptapEditor {
         this.docParent = this.options.parent ?? document
         this.profile = options.wysiwygProfile ?? new WysiwygProfile()
 
+        options.element.classList = 'wysiwyg-content';
+
         const lang = this.options.wysiwygOptions?.lang ?? 'en'
         this.locale = isTransLocale(lang) ? lang : 'en'
 

--- a/EMS/admin-ui-bundle/assets/src/core/components/tiptap/editor.ts
+++ b/EMS/admin-ui-bundle/assets/src/core/components/tiptap/editor.ts
@@ -109,9 +109,9 @@ export class TiptapEditor {
     }
 
     destroy() {
-        this.tiptap.destroy()
-        this.toolbar.destroy()
         this.menu.destroy()
+        this.toolbar.destroy()
+        this.tiptap.destroy()
         this.options.element.innerHTML = ''
     }
 

--- a/EMS/admin-ui-bundle/assets/src/core/components/tiptap/editor.ts
+++ b/EMS/admin-ui-bundle/assets/src/core/components/tiptap/editor.ts
@@ -37,7 +37,7 @@ export class TiptapEditor {
         this.docParent = this.options.parent ?? document
         this.profile = options.wysiwygProfile ?? new WysiwygProfile()
 
-        options.element.classList = 'wysiwyg-content';
+        options.element.classList = 'wysiwyg-content'
 
         const lang = this.options.wysiwygOptions?.lang ?? 'en'
         this.locale = isTransLocale(lang) ? lang : 'en'
@@ -74,7 +74,8 @@ export class TiptapEditor {
         return new Dialog(this.trans(title), {
             draggable: true,
             closeLabel: this.trans('modal_close'),
-            bodyClass
+            bodyClass,
+            doc: this.docParent
         })
     }
 

--- a/EMS/admin-ui-bundle/assets/src/core/components/tiptap/module/color.ts
+++ b/EMS/admin-ui-bundle/assets/src/core/components/tiptap/module/color.ts
@@ -192,7 +192,7 @@ function buildBody(editor: TiptapEditor): string {
             <div class="tiptap-color-predefined-section"></div>
             <div class="tiptap-color-divider"></div>
             <div class="tiptap-color-active-section"></div>
-            <button type="button" class="tiptap-color-row-btn tiptap-color-more-btn">${editor.trans('color_more')}</button>
+            <button type="button" class="tiptap-color-row-btn tiptap-color-more-btn" data-name="more">${editor.trans('color_more')}</button>
         </div>
     `
 }
@@ -237,34 +237,22 @@ function createColorDropdown(
         icon,
         buildBody: () => buildBody(editor),
         onItemClick(name) {
+            if (name === 'more') {
+                new DialogColor({
+                    editor: editor,
+                    initial: activeColor,
+                    onSelect: (color) => {
+                        applyColor(editor, type, color)
+                    }
+                }).open()
+                return
+            }
             const color = name === 'auto' ? null : name
             applyColor(editor, type, color)
         },
         onOpen(root) {
             activeColor = getActiveColor(editor, type)
             refreshDynamicSections(root, editor, type)
-
-            const autoBtn = root.querySelector<HTMLButtonElement>('[data-name="auto"]')
-            if (autoBtn) {
-                autoBtn.onclick = () => {
-                    dropdown.hide()
-                    applyColor(editor, type, null)
-                }
-            }
-
-            const moreBtn = root.querySelector<HTMLButtonElement>('.tiptap-color-more-btn')
-            if (moreBtn) {
-                moreBtn.onclick = () => {
-                    dropdown.hide()
-                    new DialogColor({
-                        editor: editor,
-                        initial: activeColor,
-                        onSelect: (color) => {
-                            applyColor(editor, type, color)
-                        }
-                    }).open()
-                }
-            }
         }
     })
 

--- a/EMS/admin-ui-bundle/assets/src/core/components/tiptap/ui/contextMenu.ts
+++ b/EMS/admin-ui-bundle/assets/src/core/components/tiptap/ui/contextMenu.ts
@@ -227,11 +227,8 @@ export class ContextMenu {
     }
 
     private getFrameOffset(): { x: number; y: number } {
-        const doc = this.editor.docEditor
-        if (doc === document) return { x: 0, y: 0 }
-        const frame = [...this.editor.docParent.querySelectorAll('iframe')].find(
-            (f) => f.contentDocument === doc
-        )
+        const win = this.editor.docEditor.defaultView
+        const frame = win?.frameElement as HTMLIFrameElement | null
         if (!frame) return { x: 0, y: 0 }
         const rect = frame.getBoundingClientRect()
         return { x: rect.left, y: rect.top }

--- a/EMS/admin-ui-bundle/assets/src/core/components/tiptap/ui/dropdown.ts
+++ b/EMS/admin-ui-bundle/assets/src/core/components/tiptap/ui/dropdown.ts
@@ -71,10 +71,10 @@ export function createDropdown(editor: TiptapEditor, config: DropdownConfig): Dr
     const bindItemEvents = (root: HTMLElement) => {
         root.addEventListener('mousedown', (e) => {
             const target = e.target as HTMLElement
-            const li = target.closest('li')
-            if (!li?.dataset.name) return
+            const item = target.closest<HTMLElement>('[data-name]')
+            if (!item?.dataset.name) return
             e.preventDefault()
-            config.onItemClick(li.dataset.name)
+            config.onItemClick(item.dataset.name)
             hide()
         })
     }
@@ -134,8 +134,9 @@ export function createDropdown(editor: TiptapEditor, config: DropdownConfig): Dr
 
     const handleOutsideClick = (e: MouseEvent) => {
         const target = e.target as HTMLElement
-        if (target.closest('[data-keep-open-on-blur]')) return
-        if (panel && !panel.contains(target) && !button.contains(target)) hide()
+        if (!panel || panel.hidden) return
+        if (panel.contains(target) || button.contains(target)) return
+        hide()
     }
 
     const onBlur = () => {

--- a/EMS/admin-ui-bundle/assets/src/core/components/tiptap/ui/dropdown.ts
+++ b/EMS/admin-ui-bundle/assets/src/core/components/tiptap/ui/dropdown.ts
@@ -149,6 +149,7 @@ export function createDropdown(editor: TiptapEditor, config: DropdownConfig): Dr
     }
 
     doc.addEventListener('mousedown', handleOutsideClick)
+    editor.docEditor.addEventListener('mousedown', handleOutsideClick)
     doc.addEventListener('keydown', onEscape)
     window.addEventListener('blur', onBlur)
     window.addEventListener('resize', hide)
@@ -188,6 +189,7 @@ export function createDropdown(editor: TiptapEditor, config: DropdownConfig): Dr
         destroy() {
             panel?.remove()
             doc.removeEventListener('mousedown', handleOutsideClick)
+            editor.docEditor.removeEventListener('mousedown', handleOutsideClick)
             doc.removeEventListener('keydown', onEscape)
             window.removeEventListener('resize', hide)
             window.removeEventListener('scroll', hide, true)

--- a/EMS/admin-ui-bundle/assets/src/core/components/tiptap/ui/toolbar.ts
+++ b/EMS/admin-ui-bundle/assets/src/core/components/tiptap/ui/toolbar.ts
@@ -36,7 +36,7 @@ export class Toolbar {
     }
 
     mount(target: HTMLElement) {
-        this.build()
+        if (!this.container.children.length) this.build()
         target.appendChild(this.container)
         this.update()
     }

--- a/EMS/admin-ui-bundle/templates/bootstrap5/wysiwyg_styles_set/iframe.html.twig
+++ b/EMS/admin-ui-bundle/templates/bootstrap5/wysiwyg_styles_set/iframe.html.twig
@@ -11,7 +11,7 @@
         <link rel="stylesheet" href="{{ asset(styleSet.contentCss, 'emsch') }}">
     {% endif %}
 </head>
-<body class="wysiwyg-preview"
+<body class="wysiwyg-preview wysiwyg-content"
       data-field="{{ field }}"
       data-field-path="{{ fieldPath|e('html_attr') }}"
       {% if emsLink %}data-document-url="{{ path('emsco_interface_document_get', {interface: 'json', name: emsLink.contentType, ouuid: emsLink.ouuid}) }}"{% endif %} >

--- a/EMS/core-bundle/templates/wysiwyg_styles_set/iframe.html.twig
+++ b/EMS/core-bundle/templates/wysiwyg_styles_set/iframe.html.twig
@@ -11,7 +11,7 @@
         <link rel="stylesheet" href="{{ asset(styleSet.contentCss, 'emsch') }}">
     {% endif %}
 </head>
-<body class="wysiwyg-preview"
+<body class="wysiwyg-preview wysiwyg-content"
       data-field="{{ field }}"
       data-field-path="{{ fieldPath|e('html_attr') }}"
       {% if emsLink %}data-document-url="{{ path('emsco_interface_document_get', { interface: 'json', name: emsLink.contentType, ouuid: emsLink.ouuid }) }}"{% endif %} >

--- a/demo/src/css/components/_list.scss
+++ b/demo/src/css/components/_list.scss
@@ -1,7 +1,15 @@
-main {
+main, .wysiwyg-content {
   ul:not(.list-unstyled) {
     padding-left: 1.5rem;
     list-style-type: none;
+
+    li p {
+      margin: 0;
+    }
+
+    li p + p {
+      margin-top: 0.5em;
+    }
 
     li {
       position: relative;

--- a/docs/src/elasticms-admin/wysiwyg/tiptap.md
+++ b/docs/src/elasticms-admin/wysiwyg/tiptap.md
@@ -297,6 +297,8 @@ The editor adapts to different use cases through a `WysiwygProfile`. The profile
 - **Translation overrides** — via `translations`, overrides specific UI translation keys per locale
   (e.g. `{ nl: { button_apply: 'Toepassen' } }`). Unknown keys are silently ignored; falls back to
   the built-in translation when no override is set.
+- **Custom CSS** — content styling is applied by targeting the `.wysiwyg-content` class. This works
+  consistently across the preview, the Tiptap iframe editor, and the Tiptap inline editor.
 
 Modules can implement an `isEnabled` check that reads the profile to decide whether they should be
 loaded at all.


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       | y  |
| New feature?   | n  |
| BC breaks?     | n  |
| Deprecations?  | n  |
| Fixed tickets? | #1704, #1750  |
| Documentation? | y  |

- Fixed colors -> more not working
- Opening dropdown create multiple divs
- Position context menu not correct
- Bug on discard & save (tiptap was destroy to fast)
- Add new `.wysiwyg-content` class for correct styling preview, tiptap admin & tiptap inline


