### PR TITLE
fix: give access to the host from the sandbox: e.g. http://host.docke…

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -282,6 +282,8 @@ services:
     sandbox:
         profiles: [ "all","sandbox" ]
         image: docker.io/smalswebtech/base-php:8.5-cli-dev
+        extra_hosts:
+            - "host.docker.internal:host-gateway"
         user: ${DOCKER_USER-1000}
         env_file:
             -   ./sandbox.env


### PR DESCRIPTION
| Q              | A |
|----------------|---|
| Bug fix?       |  n |
| New feature?   | y  |
| BC breaks?     |  n |
| Deprecations?  |  n |
| Fixed tickets? |  n |
| Documentation? |n   |

Give access to the host from the sandbox e.g. http://host.docker.internal:8881